### PR TITLE
First part of a cleanup pass

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,5 +7,5 @@ Version 8.7
 -----------
 .Additions and changes
 - Initial public source version
-.Bug fixes
+- Bug fixes
 - Numerous changes in formatting for asciidoc conversion.

--- a/COPYING.adoc
+++ b/COPYING.adoc
@@ -5,11 +5,11 @@ image:https://i.creativecommons.org/l/by-sa/4.0/88x31.png[CC BY-SA] Synacor, Inc
 This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
 International License unless another license agreement between you and
 Synacor, Inc. provides otherwise. To view a copy of this license, visit
-http://creativecommons.org/licenses/by-sa/4.0 or send a letter to Creative
+https://creativecommons.org/licenses/by-sa/4.0 or send a letter to Creative
 Commons, PO Box 1866, Mountain View, CA 94042, USA.
 
 Synacor, Inc., 2016 +
 40 La Riviere Drive, Suite 300 +
 Buffalo, New York 14202
 
-http://www.synacor.com
+https://www.synacor.com

--- a/adminconsole.adoc
+++ b/adminconsole.adoc
@@ -34,7 +34,7 @@ the following URL pattern.
 [cols=",",options="header",]
 |====================================================
 |Parameter |Description
-|server,domain |The Zimbra server name or IP address.
+|server.domain.com |The Zimbra server name or IP address.
 |7071 |The default HTTP listen port.
 |====================================================
 
@@ -85,13 +85,13 @@ authenticated, or if authentication has expired:
 Global:
 [source,bash]
 ----
-zmprov mcf zimbraAdminConsoleLoginURL <https:/example.com>
+zmprov mcf zimbraAdminConsoleLoginURL <https://example.com>
 ----
 
 Domain:
 [source,bash]
 ----
-zmprov md <domain> zimbraAdminConsoleLoginURL<https:// example.com
+zmprov md <domain> zimbraAdminConsoleLoginURL <https://example.com>
 ----
 ****
 
@@ -102,13 +102,13 @@ To specify a URL to redirect administrators, for logging out:
 Global:
 [source,bash]
 ----
-zmprov mcf zimbraAdminConsoleLogoutURL <https:/example.com>
+zmprov mcf zimbraAdminConsoleLogoutURL <https://example.com>
 ----
 
 Domain:
 [source,bash]
 ----
-zmprov md <domain> zimbraAdminConsoleLogoutURL<https:// example.com
+zmprov md <domain> zimbraAdminConsoleLogoutURL <https://example.com>
 ----
 ****
 
@@ -996,7 +996,7 @@ marks at the beginning and end of the message to be displayed.
 Creating a global message or domain-specific message.
 [source,bash]
 ----
-zmprov md domainexample.com zimbraAdminConsoleLoginMessage "message to display"
+zmprov md <domain> zimbraAdminConsoleLoginMessage "message to display"
 ----
 ****
 
@@ -1005,7 +1005,7 @@ zmprov md domainexample.com zimbraAdminConsoleLoginMessage "message to display"
 Creating a multiple-message display:
 [source,bash]
 ----
-zmprov md domainexample.com +zimbraAdminConsoleLoginMessage "second message to display"
+zmprov md <domain> +zimbraAdminConsoleLoginMessage "second message to display"
 ----
 ****
 
@@ -1030,7 +1030,7 @@ the beginning and end of an individual message to be deleted.
 Removing a specific message:
 [source,bash]
 ----
-zmprov md domainexample.com -zimbraAdminConsoleLoginMessage "message to display"
+zmprov md <domain> -zimbraAdminConsoleLoginMessage "message to display"
 ----
 ****
 
@@ -1039,7 +1039,7 @@ zmprov md domainexample.com -zimbraAdminConsoleLoginMessage "message to display"
 Removing all messages:
 [source,bash]
 ----
-zmprov md domainexample.com zimbraAdminConsoleLoginMessage '
+zmprov md <domain> zimbraAdminConsoleLoginMessage ''
 ----
 ****
 

--- a/backuprestore.adoc
+++ b/backuprestore.adoc
@@ -376,7 +376,7 @@ old backups deleted at 12:00 a.m. every day.
 +
 [source, bash]
 ----
-zmschedulebackup -R f “0 1 * * 7” i “0 1 * * 1-6” d 1m “0 0 * * *”
+zmschedulebackup -R f "0 1 * * 7" i "0 1 * * 1-6" d 1m "0 0 * * *"
 ----
 
 * Add an additional full backup time to your current schedule. This
@@ -384,7 +384,7 @@ example adds a full backup on Thursday at 1 a.m.
 +
 [source, bash]
 ----
-zmschedulebackup -A f “0 1 * * 4”
+zmschedulebackup -A f "0 1 * * 4"
 ----
 * Review your backup schedule. The schedule is displayed.
 +
@@ -587,7 +587,7 @@ zmbackupquery -lb full-20070712.155951.123
 * To find a full backup sessions since a specific date:
 [source,bash]
 ----
-zmbackupquery --type full --from “2007/01/01 12:45:45”
+zmbackupquery --type full --from "2007/01/01 12:45:45"
 ----
 * To find all full backup sessions in the backup directory:
 [source,bash]
@@ -598,7 +598,7 @@ zmbackupquery --type full
 time window
 [source,bash]
 ----
-zmbackupquery -a user1@example.com --type full --from “2007/ 07/05 12:01:15” --to “2007/07/12 17:01:45”
+zmbackupquery -a user1@example.com --type full --from "2007/07/05 12:01:15" --to "2007/07/12 17:01:45"
 ----
 ****
 
@@ -754,7 +754,7 @@ The mysqldump is a backup of your MySQL database at a specific time.
 Data changes that occur later than the dump file are written to the
 binary log.To recover to a specific point in time, binary logging must
 be enabled. See the Zimbra wiki article, MySQL Backup and Restore at
-http://wiki.zimbra.com/wiki/ MySQL_Backup_and_Restore.
+https://wiki.zimbra.com/wiki/MySQL_Backup_and_Restore.
 
 The MySQL dump files are gzipped and placed in the backup target
 directory, or to +/opt/zimbra/backup+, if no directory is specified.
@@ -766,7 +766,7 @@ mySQL database backup file that is saved.
 * Enable mysqldump to run automatically with your backups, type
 [source, bash]
 ----
-zmlocalconfig edit mysql_backup_retention=<N>.
+zmlocalconfig edit mysql_backup_retention=<N>
 ----
 *N* is the number of copies of the mySQL database backups that
 areretained.
@@ -815,7 +815,7 @@ zmprov mcf zimbraBackupMinFreeSpace <value>
 * By server:
 [source, bash]
 ----
-zmprov ms <server hostname> zimbraBackupMinFreeSpace <value>
+zmprov ms <zmhostname> zimbraBackupMinFreeSpace <value>
 ----
 
 Backup sessions run if the free disk space is at least the value you
@@ -924,7 +924,7 @@ zmrestore -a account@company.com-restoreToTime <arg>
 ----
 Two common ways to write the <timearg> are
 
-* +“YYYY/MM/DD hh:mm:ss”+
+* +"YYYY/MM/DD hh:mm:ss"+
 * +YYYYMMDD.hhmmss+
 ====
 
@@ -1090,7 +1090,7 @@ Otherwise, the emails would be overwritten during the restore process.
 +
 [source,bash]
 ----
-zmrestore -a (account@abc.com account@abc.com)
+zmrestore -a account@abc.com
 ----
 
 .  For each account that was restored, put the account back into active mode
@@ -1114,7 +1114,7 @@ mailbox willhave to be reindexed after the restore.
 +
 [source,bash]
 ----
-zmrestore <all or account> --exclude-search-index
+zmrestore -a <all|account> --exclude-search-index
 ----
 
 * *Blobs*. This is a useful option when all blobs for the mailbox being
@@ -1354,7 +1354,7 @@ zmlocalconfig -f -e zimbra_ldap_password=<password>
 +
 [source,bash]
 ----
-zmrestoreoffline -sys -a all -c -br.
+zmrestoreoffline -sys -a all -c -br
 ----
 +
 You might run a command such as nohup here also. To watch the progress,
@@ -1562,7 +1562,7 @@ You can now run the +zmplayredo+ command to replay changes from 8:00:00.
 
 [source,bash]
 ----
-zmplayredo --fromTime ‘2008/10/17 08:00:00:000*’*
+zmplayredo --fromTime "2008/10/17 08:00:00:000"
 ----
 
 All data is brought forward to the current time and the standby site is

--- a/cmdlineutils.adoc
+++ b/cmdlineutils.adoc
@@ -6,9 +6,9 @@
 Command Line Interface (CLI) can be used to create, modify and delete
 certain features and functions of the {product-name}.  The Administration
 Console is the main tool for maintaining the {product-name}, but some
-functions can only be changed from the CLI utility.
+functions can only be changed from CLI utilities.
 
-The CLI utility can be used for the following purposes:
+The CLI utilities can be used for the following purposes:
 
 * Provisioning accounts
 * Backup and Restore
@@ -29,16 +29,16 @@ command-line conventions.  Use the following general guidelines with the
 CLI:
 
 * CLI commands are run as the zimbra user: +
-`su - zimbrA`
+`su - zimbra`
 
 * The CLI commands are case-sensitive.  You must type them in lower case.
 
 * Press *ENTER* after you type a command.
 
 * To display usage information about a command, type the CLI command with
-  `- h`.
+  `-h`.
 +
-Example: `zmprov - h` lists all the options available for the `zmprov`
+Example: `zmprov -h` lists all the options available for the `zmprov`
 utility.
 
 * Each operation is invoked through command-line options.  Many have a
@@ -85,13 +85,13 @@ The table below lists the CLI commands in `/opt/zimbra/bin`.
 |CLI |Description
 
 |`antispam-mysqladmin` |
-Send admin commands to anti=spam MySQL server
+anti-spam SQL server admin utility
 
 |`antispam-mysql` |
-Enters interactive command-line MySQL session with the mailbox mysql
+anti-spam SQL client
 
 |`antispam-mysql.server` |
-Start, stop the SQL instance for the mailbox package
+Start, stop the anti-spam SQL instance
 
 |`ldap` |
 Start, stop, or find the status of Zimbra LDAP
@@ -100,16 +100,16 @@ Start, stop, or find the status of Zimbra LDAP
 Perform a search on an LDAP server
 
 |`logmysqladmin` |
-Send myslqadmin commands to the logger mysql
+Send mysqladmin commands to the logger SQL instance
 
 |`mysql` |
-Enters interactive command-line MySQL session with the mailbox mysql
+Enters interactive command-line for the mailbox SQL instance
 
 |`mysql.server` |
-Start, stop the SQL instance for the mailbox package
+Start, stop the mailbox SQL instance
 
 |`mysqladmin` |
-Send admin commands to MySQL
+Send admin commands to the mailbox SQL instance
 
 |`postconf` |
 
@@ -134,7 +134,7 @@ Start, stop, reload, status for anti-spam service
 Start, stop, reload, status for the anti-virus service
 
 |`zmantispamdbpasswd` |
-Changes anti-spam MySQL database password
+Changes anti-spam SQL database password
 
 |`zmapachectl` |
 Start, stop, reload, or check status of Apache service (for spell check)
@@ -178,10 +178,10 @@ Manage self-signed and commercial certificates
 |`zmclamdctl` |
 Start, stop, or find the status of Clam AV
 
-|`zmcleaniplanetics` | Clean iPlanet ICS calendar files
+|`zmcleaniplanetics` |
+Clean iPlanet ICS calendar files
 
-
-|`zmcontrol (Start/Stop/Restart Service) |
+|`zmcontrol` |
 Start, stop, restart, status of the Zimbra servers.  Also can use to find
 the Zimbra version installed
 
@@ -200,7 +200,7 @@ specifying individual servers.
 General information about the server environment is displayed
 
 |`zmgsautil` |
-Global Address Book (GAL) synchronization command line utility.
+Global Address Book (GAL) synchronization utility.
 Create, delete the GAL sync account and initiate manual syncs.
 
 |`zmhostname` |
@@ -247,8 +247,9 @@ Performs mailbox management tasks
 Start, stop, reload, or find the status of the mailbox components
 (zmmailboxd, MySQL, convert)
 
-|`zmmboxsearch` (Cross Mailbox Search) |
-Search across mailboxes to find messages and attachments
+|`zmmboxsearch` |
+(Cross Mailbox Search) Search across mailboxes to find messages and
+attachments
 
 |`zmmboxmove` |
 7.1.3 and later.  Used to move selected mailboxes from one Zimbra server to
@@ -264,10 +265,10 @@ another.
 Start, stop, and restart
 
 |`zmmetadump` |
-Support tool that dumps an item’s metadata in a human-readable form
+Support tool that dumps an item's metadata in a human-readable form
 
 |`zmmilterctl` |
-Start, stop, and restart the zimbra milter server if enabled
+Start, stop, and restart the Zimbra milter server if enabled
 
 |`zmmtaconfigdctl` |
 Beginning in {product-abbrev} 7.0, this command is not used.  Use `zmconfigdctl`.
@@ -276,23 +277,23 @@ Beginning in {product-abbrev} 7.0, this command is not used.  Use `zmconfigdctl`
 Start, stop, or find the status of the MTA
 
 |`zmmypasswd` |
-Change MySQL passwords
+Change SQL passwords
 
 |`zmmysqlstatus` |
 Status of mailbox SQL instance
 
 |`zmnginxconf` |
-Command line utility to output the reverse proxy configuration
+Output the reverse proxy configuration
 
 |`zmnginxctl` |
-Start, stop, and restart the zimbra reverse proxy
+Start, stop, and restart the Zimbra reverse proxy
 
 |`zmplayredo` |
 Performs data restore using backed up snapshots taken periodically.  Users
 who use snapshots to backup and restore their information from a standby
 site use this command.
 
-|`zmprov` (Provisioning) |
+|`zmprov` |
 Performs all provisioning tasks in Zimbra LDAP, including creating
 accounts, domains, distribution lists and aliases
 
@@ -308,7 +309,7 @@ Purges POP/IMAP routing information from one or more memcached servers
 
 |`zmpython` |
 Ability to write Python scripts that access Zimbra Java libraries.  It sets
-the {product-abbrev} class path and starts the Jython interpreter.
+the Zimbra class path and starts the Jython interpreter.
 
 |`zmredodump` |
 Support tool for dumping contents of a redolog file for debugging purposes
@@ -319,9 +320,9 @@ Performs full restores and incremental restores for a designated mail host
 |`zmrestoreldap` |
 Restore accounts from the LDAP backup
 
-|`zmrestoreoffline` (Offline Restore) |
-Performs full restore when the Zimbra server (i.e., the mailboxd process)
-is down
+|`zmrestoreoffline` |
+(Offline Restore) Performs full restore when the Zimbra server (i.e.,
+the mailboxd process) is down
 
 |`zmsaslauthdctl`  |
 Start, stop, or find the status of saslauthd (authentication)
@@ -333,7 +334,7 @@ Schedule backups and add the command to your cron table
 Used for other zm scripts, do not use
 
 |`zmskindeploy` |
-Deploy skins for accounts from the command line
+Deploy skins
 
 |`zmsoap` |
 Print mail, account, and admin information in the SOAP format
@@ -342,8 +343,7 @@ Print mail, account, and admin information in the SOAP format
 Start, stop, or find the status of the spell check server
 
 |`zmsshkeygen` |
-Generate Zimbra’s SSH encryption keys
-
+Generate Zimbra's SSH encryption keys
 
 |`zmstat-chart` |
 Generate charts from zmstat data collected in a directory
@@ -378,7 +378,7 @@ HTTP, HTTPS or mixed
 Used to train the anti-spam filter to recognize what is spam or ham
 
 |`zmtzupdate` |
-Provides mechanism to process time zone changes from the command line
+Provides mechanism to process time zone changes
 
 |`zmupdateauthkeys` |
 Used to fetch the ssh encryption keys created by `zmsshkeygen`
@@ -441,20 +441,20 @@ type `zmprov -h`.  The task area divided into the following sections:
 |`--file` (`-f`) |use file as input stream
 |`--server` (`-s`) |{host}[:{port}] server hostname and optional port
 |`--ldap` (`-l`) |provision via LDAP instead of SOAP
-|`--log property file` (`-L`) |log 4j property file, valid only with `-l`
+|`--logpropertyfile` (`-L`) |log4j property file, valid only with `-l`
 |`--account {name}` (`-a`) |account name to auth as
 |`--password {pass}` (`-p`) |password for account
 |`--passfile {file}` (`-P`) |read password from file
 |`--zadmin` (`-z`) |
 use Zimbra admin name/password from localconfig for admin/password
-|`--authtoken (authtoken)` (`-y`) |
+|`--authtoken {authtoken}` (`-y`) |
 use auth token string (has to be in JSON format) from command line
-|`--authtoken (authtoken file)` (`-Y`) |
-use auth token string (has to be in JSON format) from command line
+|`--authtokenfile {authtoken-file}` (`-Y`) |
+use auth token string (has to be in JSON format) from a file
 |`--verbose` (`-v`) |
 verbose mode (dumps full exception stack trace)
-|`--debug` (`-d/`) |debug mode (dumps SOAP messages)
-|`--master` (`m`) |use LDAP master.  This only valid with `-l`
+|`--debug` (`-d`) |debug mode (dumps SOAP messages)
+|`--master` (`-m`) |use LDAP master.  This only valid with `-l`
 |`--replace` (`-r`)|
 allow replacement of safe-guarded multi-value attribute configured in
 localconfig key `zmprov_saveguarded_attrs`
@@ -522,20 +522,20 @@ zmprov cps joe@domain.com test123
 This command does not check the password age or history.
 
 |`createAccount (ca)` |
-{name@domain} {password} [attribute1 value1 etc] |
+{name@domain} {password} [attr1 value1]... |
 [source,bash]
 ----
 zmprov ca joe@domain.com test123 displayName JSmith
 ----
 
 |`createDataSource (cds)` |
-{name@domain} {ds-type} {ds-name} zimbraDataSourceEnabled {TRUE \| FALSE} zimbraDataSourceFolderId {folder-id} [attr1 value1 [attr2 value2...]] |
+{name@domain} {ds-type} {ds-name} zimbraDataSourceEnabled {TRUE \| FALSE} zimbraDataSourceFolderId {folder-id} [attr1 value1 [attr2 value2]...] |
 
 |`createIdentity (cid)` |
-{name@domain} {identity-name} [attr1 value1 [attr2 value2...]] |
+{name@domain} {identity-name} [attr1 value1 [attr2 value2]...] |
 
-|`createSignature (csig)`|
-{name@domain} {signature-name} [attr1 value1 [attr2 value2...]] |
+|`createSignature (csig)` |
+{name@domain} {signature-name} [attr1 value1 [attr2 value2]...] |
 
 |`deleteAccount (da)` |
 {name@domain \| id \| adminName} |
@@ -563,7 +563,7 @@ zmprov ga joe@domain.com
 {name@domain \| id} |
 
 |`getAllAccounts (gaa)` |
-[-v] [{domain}] |
+[-v] [domain] |
 Must include `-l`/`--ldap`
 
 [source,bash]
@@ -581,29 +581,29 @@ zmprov gaaa
 ----
 
 |`getDataSources (gds)` |
-{name@domain \| id} [arg 1 [arg 2...]] |
+{name@domain \| id} [arg1 [arg2]...] |
 
 |`getIdentities (gid)` |
-{name@domain \| id} [arg 1 [arg 2...]] |
+{name@domain \| id} [arg1 [arg2]...] |
 
 |`getSignatures (gsig)` |
-{name@domain \| id} [arg 1 [arg 2...]] |
+{name@domain \| id} [arg1 [arg2]...] |
 
 |`modifyAccount (ma)` |
-{name@domain \| id \| adminName} [attribute1 value1 etc] |
+{name@domain \| id \| adminName} [attr1 value1]... |
 [source,bash]
 ----
 zmprov ma joe@domain.com zimbraAccountStatus maintenance
 ----
 
 |`modifyDataSource (mds)` |
-{name@domain \| id} {ds-name \| ds-id} [attr 1 value 1 [attr2 value 2...]] |
+{name@domain \| id} {ds-name \| ds-id} [attr1 value1 [attr2 value2]...] |
 
 |`modifyIdentity (mid)` |
-{name@domain \| id} {identity-name} [attr 1 value 1 [attr2 value 2...]] |
+{name@domain \| id} {identity-name} [attr1 value1 [attr2 value 2]...] |
 
-|`modifySignature (msig)`|
-{name@domain \| id} {signature-name \| signature-id} [attr 1 value 1 [attr 2 value 2...]] |
+|`modifySignature (msig)` |
+{name@domain \| id} {signature-name \| signature-id} [attr1 value1 [attr2 value2]...] |
 
 |`removeAccountAlias (raa)` |
 {name@domain \| id \| adminName} {alias@domain} |
@@ -624,7 +624,7 @@ After you rename an account, you should run a full backup for that account.
 
 [source,bash]
 ----
-zmbackup -f -<servername.com> -a <newaccountname@servername.com>
+zmbackup -f -s <servername.com> -a <newaccountname@servername.com>
 ----
 
 |`setAccountCOS (sac)` |
@@ -656,20 +656,20 @@ accented characters that cannot be used: ã, é, í, ú, ü, ñ.
 |Commnad |Syntax
 
 |`createCalendarResource (ccr)` |
-{name@domain} [attr1 value1 [attr2 value2...]]
+{name@domain} [attr1 value1 [attr2 value2]...]
 
 |`deleteCalendarResource (dcr)` |
 {name@domain \| id}
 
 |`getAllCalendarResources (gacr)` |
-[-v] [{domain}]
+[-v] [domain]
 
 
 |`getCalendarResource (gcr)` |
 {name@domain \| id}
 
 |`modifyCalendarResource (mcr)` |
-{name@domain \| id} [attr1 value1 {attr2 value2...]]
+{name@domain \| id} [attr1 value1 {attr2 value2]...]
 
 |`purgeAccountCalendarCache (pacc)` |
 {name@domain} [...]
@@ -712,10 +712,10 @@ This lists each COS, the COS ID and the number of accounts assigned to each
 COS
 
 |`createAliasDomain (cad)` |
-{alias-domain-name} {local-domain-name \| id} [attr1 value1 [attr2 value2...]] |
+{alias-domain-name} {local-domain-name \| id} [attr1 value1 [attr2 value2]...] |
 
 |`createDomain (cd)` |
-{domain} [attribute1 value1 etc] |
+{domain} [attr1 value1]... |
 [source,bash]
 ----
 zmprov cd mktng.domain.com zimbraAuthMech zimbra
@@ -736,13 +736,13 @@ zmprov gd mktng.domain.com
 ----
 
 |`getDomainInfo (gdi)` |
-name \| id \| virtualHostname {value} [attr1 [attr2...]] |
+name \| id \| virtualHostname {value} [attr1 [attr2]...] |
 
 |`getAllDomains (gad)` |
 [-v] |
 
 |`modifyDomain (md)` |
-{domain \| id} [attribute1 value1 etc] |
+{domain \| id} [attr1 value1]... |
 [source,bash]
 ----
 zmprov md domain.com zimbraGalMaxResults 500
@@ -770,7 +770,7 @@ updated when a domain is renamed.
 {src-cos-name \| id} {dest-cos-name} |
 
 |`createCos (cc)` |
-{name} [attribute1 value1 etc] |
+{name} [attr1 value1]... |
 [source,bash]
 ----
 zmprov cc Executive zimbraAttachmentsBlocked FALSE zimbraAuthTokenLifetime 60m zimbraMailQuota 100M zimbraMailMessageLifetime 0
@@ -798,7 +798,7 @@ zmprov gac -v
 ----
 
 |`modifyCos (mc)` |
-{name \| id} [attribute1 value1 etc] |
+{name \| id} [attr1 value1]... |
 [source,bash]
 ----
 zmprov mc Executive zimbraAttachmentsBlocked TRUE
@@ -822,7 +822,7 @@ zmprov rc Executive Business
 |Commnad |Syntax |Example/Notes
 
 |`createServer (cs)` |
-{name} [attribute1 value1 etc] |
+{name} [attr1 value1]... |
 
 |`deleteServer (ds)` |
 {name \| id} |
@@ -846,7 +846,7 @@ zmprov gas
 ----
 
 |`modifyServer (ms)` |
-{name \| id} [attribute1 value1 etc] |
+{name \| id} [attr1 value1]... |
 [source,bash]
 ----
 zmprov ms domain.com zimbraVirusDefinitionsUpdateFrequency 2h
@@ -881,16 +881,16 @@ attr1 value1 |
 Modifies the LDAP settings.
 
 |`createXMPPComponent (csc)` |
-{short-name} {domain} {server} {classname} {category} {type} [attr value1 [attr2 value2...]] |
+{short-name} {domain} {server} {classname} {category} {type} [attr1 value1 [attr2 value2]...] |
 
 |`deleteXMPPComponent (dxc)` |
 {xmpp-component-name} |
 
 |`getXMPPComponent (gxc)` |
-{name@domain} [attr1 [attr2 value2]] |
+{name@domain} [attr1 [attr2]...] |
 
 |`modifyXMPPComponent (mxc)` |
-{name@domain} [attr1 [attr2 value2]] |
+{name@domain} [attr1 value1 [attr2 value2]...] |
 
 |=======================================================================
 
@@ -940,7 +940,7 @@ zmprov gdl list@domain.com
 ----
 
 |`modifyDistributionList (mdl)` |
-{list@domain \| id} attr1 value1 {attr2 value2...} |
+{list@domain \| id} attr1 value1 [attr2 value2]... |
 [source,bash]
 ----
 zmprov md list@domain.com
@@ -968,16 +968,13 @@ zmprov md list@domain.com
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`getMailboxInfo--- (gmi)` |
+|`getMailboxInfo (gmi)` |
 {account} |
 
-|`getQuotaUsage--- (gqu)` |
+|`getQuotaUsage (gqu)` |
 {server} |
 
-|`reIndexMailbox (rim)` |
-{name@domain \| id} {start \| status \| cancel} [{reindex-by} {value1} [value2...]] |
-
-|RecalculateMailbox Counts (rmc) |
+|`recalculateMailboxCounts (rmc)` |
 {name@domain \| id} |
 
 When unread message count and quota usage are out of sync with the data
@@ -991,7 +988,7 @@ run in off peak hours and used on one mailbox
 at a time.
 
 |`reIndexMailbox (rim)` |
-{start \| status \| cancel} [{types \| ids} {type or id} [type or id...]] |
+{name@domain \| id} {start \| status \| cancel} [type \| id]... |
 
 |`compactIndexMailbox (cim)` |
 {name@domain \| id} {start \| status} |
@@ -1004,6 +1001,11 @@ at a time.
 
 |`selectMailbox (sm)` |
 {account-name} [{zmmailbox commands}] |
+
+|`unlockMailbox (ulm)` |
+{name@domain \| id} [hostname] |
+
+Only specify the hostname parameter when unlocking a mailbox after a failed move attempt.
 
 |=======================================================================
 
@@ -1027,7 +1029,7 @@ at a time.
 Prints all attribute names (account, domain, COS, servers, etc.).
 
 |`flushCache (fc)` |
-[-a] {acl \| locale \| skin \| uistrings \| license \| all \| account \| config \| glo \| balgrant \| cos \| domain \| galgroup \| group \| mime \| server \| zimlet \| <extension-cache-type>} [name1 \| id1 [name2 \| i d2...]] |
+[-a] {acl \| locale \| skin \| uistrings \| license \| all \| account \| config \| glo \| balgrant \| cos \| domain \| galgroup \| group \| mime \| server \| zimlet \| <extension-cache-type>} [name1 \| id1 [name2 \| i d2]...] |
 
 Flush cached LDAP entries for a type.  See <<zimbra_ldap_service,Zimbra LDAP Service>>.
 
@@ -1057,7 +1059,7 @@ Generates preAuth values for comparison.
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`addAccount Logger (aal)` |
+|`addAccountLogger (aal)` |
 {name@domain \| id} {logging-category} {debug \| info \| warn \| error} |
 Creates custom logging for a single account.
 
@@ -1102,14 +1104,14 @@ logging categories.
 [-v] {ldap-query} [limit] [offset] [sortBy {attribute}] [sortAscending 0 \| 1] [domain {domain}] |
 
 |`searchCalendarResources (scr)` |
-[-v] domain attr op value {attr op value...] |
+[-v] domain {attr op value} [attr op value]... |
 
 |=======================================================================
 
 [[share_provisioning_cmds]]
 ==== Share Provisioning Commands
 
-*zmprov—Share Provisioning Commands*
+.`zmprov` -- Share Provisioning Commands
 
 [cols=",,a",options="header",]
 |=======================================================================
@@ -1128,7 +1130,7 @@ logging categories.
 |Commnad |Syntax |Example/Notes
 
 |`createUCService (cucs)` |
-{name} [attr1 value1 [attr2 value2...]] |
+{name} [attr1 value1 [attr2 value2]...] |
 
 |`deleteUCService (ducs)` |
 {name \| id} |
@@ -1137,10 +1139,10 @@ logging categories.
 [-v] |
 
 |`getUCService (gucs)` |
-[-e] {name \| id} [attr1 [attr2...]] |
+[-e] {name \| id} [attr1 [attr2]...] |
 
 |`modifyUCService (mucs)` |
-{name \| id} [attr1 value1 [attr2 value2...]] |
+{name \| id} [attr1 value1 [attr2 value2]...] |
 
 |`renameUCService (rucs)` |
 {name \| id} {newName} |
@@ -1175,7 +1177,7 @@ certificates for.
 
 |=======================================================================
 
-==== Examples—using zmprov
+==== Examples -- using zmprov
 
 .Creating an account with a password that is assigned to the default COS
 ====
@@ -1214,7 +1216,7 @@ procedure.
 
 .Bulk provisioning
 ====
-See the Zimbra wiki page http://wiki.zimbra.com/wiki/Bulk_Provisioning[Bulk_Provisioning].
+See the Zimbra wiki page https://wiki.zimbra.com/wiki/Bulk_Provisioning[Bulk_Provisioning].
 ====
 
 .Adding an alias to an account
@@ -1245,7 +1247,7 @@ zmprov adlm listname@domain.com member@domain.com
 You can add multiple members to a list from the Administration Console.
 ====
 
-.Changing the administrator’s password
+.Changing the administrator's password
 ====
 
 Use this command to change any password.  Enter the address of the password
@@ -1257,7 +1259,7 @@ zmprov sp admin@domain.com password
 ----
 ====
 
-.Creating a domain that authenticates against zimbra OpenLDAP
+.Creating a domain that authenticates against Zimbra OpenLDAP
 ====
 [source,bash]
 ----
@@ -1524,7 +1526,7 @@ same function being carried out.
 
 [source,bash]
 ----
-zmarchiveconfig [args] [cmd] [cmd-args...]
+zmarchiveconfig [args] [cmd] [cmd-args]...
 ----
 
 ==== Description
@@ -1752,7 +1754,7 @@ zmbackup -i -a all -s server1.domain.com
 ----
 ====
 
-.Perform full backup of only *user1*’s mailbox on *server1*.
+.Perform full backup of only *user1*'s mailbox on *server1*.
 ====
 [source,bash]
 ----
@@ -1762,7 +1764,7 @@ zmbackup -f -a user1@domain.com -s server1
 Hostname does not need full domain if account is used.
 ====
 
-.Perform incremental backup of *user1*’s mailbox on *server1*
+.Perform incremental backup of *user1*'s mailbox on *server1*
 ====
 [source,bash]
 ----
@@ -1830,7 +1832,7 @@ calendar and sends an email notification regarding inconsistencies.  For
 example, it checks if all attendees and organizers of an event on the
 calendar agree on start/stop times and occurrences of a meeting.
 
-See the output of *zmmailbox help appointmen*t for details on
+See the output of `zmmailbox help appointment` for details on
 time-specs.
 
 ==== Syntax
@@ -1873,11 +1875,11 @@ The default schedule is as follows:
 Each crontab entry is a single line composed of five fields separated by a
 blank space.  Specify the fields as follows:
 
-* minute — 0 through 59
-* hour — 0 through 23
-* day of month — 1 through 31
-* month — 1 through 12
-* day of week — 0 through 7 (0 or 7 is Sunday, or use names)
+* minute -- 0 through 59
+* hour -- 0 through 23
+* day of month -- 1 through 31
+* month -- 1 through 12
+* day of week -- 0 through 7 (0 or 7 is Sunday, or use names)
 
 Type an asterisk (`*`) in the fields you are not using.
 
@@ -1942,7 +1944,7 @@ location is added for incremental scheduled backups, it is ignored.
 |`account` |`-a` |
 Account specific.  The default is all accounts.
 
-|`--mail-report`| |
+|`--mail-report` | |
 Send an email report to the admin user.
 
 |`--server` | |
@@ -2309,8 +2311,8 @@ zmrestore -a user1@domain.com -ca -pre new_
 
 === zmrestoreoffline (Offline Restore)
 
-Run `zmresotreoffline` when the Zimbra server (i.e., the mailbox process)
-is down.  The MySQL database for the server and the OpenLDAP directory
+Run `zmrestoreoffline` when the Zimbra server (i.e., the mailbox process)
+is down.  The SQL database for the server and the OpenLDAP directory
 server must be running before you start the `zmrestoreoffline` command.
 
 ==== Syntax
@@ -2631,7 +2633,7 @@ zmpurgeoldmbox -a <account email> [-s <server to purge>]
 |`--account` |`-a` |
 `<arg>` Email address of account to purge.
 
-|`--help` |`-h`|
+|`--help` |`-h` |
 Displays the usage options for this command
 
 |`--server` |`-s` |
@@ -2733,7 +2735,7 @@ same as the password on the LDAP master server.
 ==== Syntax
 [source,bash]
 ----
-opt/zimbra/bin/zmldappasswd [-h] [-r] [-p] [-l] new password
+/opt/zimbra/bin/zmldappasswd [-h] [-r] [-p] [-l] new-password
 ----
 
 ==== Description
@@ -2775,7 +2777,7 @@ included, the `zimbra_ldap_password` is changed.*
 
 === zmlocalconfig
 
-Use `zmlocalconfig` to set or get the local configuration for a zimbra
+Use `zmlocalconfig` to set or get the local configuration for a Zimbra
 server.  Use `zmlocalconfig -i` to see a list of supported properties that
 can be configured by an administrator.
 
@@ -2821,8 +2823,7 @@ Shows the values for only those keys listed in the `[args]` that have been
 changed from their defaults.
 
 |`--path` |`-p` |
-Shows which configuration file will be
-used.
+Shows which configuration file will be used.
 
 |`--quiet` |`-q` |
 Suppress logging.
@@ -2865,7 +2866,7 @@ tags, or saved searches at the same time.
 ==== Syntax
 [source,bash]
 ----
-zmmailbox [args] [cmd] [cmd-args ...]
+zmmailbox [args] [cmd] [cmd-args]...
 ----
 
 ==== Description
@@ -2890,11 +2891,11 @@ Account name to auth as `{name}`.
 |`-z` |`--zadmin` |
 Use zimbra admin name/password from localconfig for admin/password.
 
-|`-y` |`--authtoken (authtoken)` |
+|`-y` |`--authtoken {authtoken}` |
 Use authtoken string (has to be in JSON format) from command line.
 
-|`-Y` |`--authtoken (authtoken file)` |
-Use authtoken string (has to be in JSON format) from command line.
+|`-Y` |`--authtoken {authtoken-file}` |
+Use authtoken string (has to be in JSON format) from a file.
 
 |`-m` |`--mailbox {name}` |
 Mailbox to open.  Can be used as both authenticated and targeted unless
@@ -3018,7 +3019,8 @@ zmmailbox -z --admin-priv -m foo@example.com emptyDumpster
 ====
 [source,bash]
 ----
-zmmailbox -z mbox> sm --admin-priv foo@domain.com
+zmmailbox -z
+mbox> sm --admin-priv foo@domain.com
 ----
 ====
 
@@ -3040,7 +3042,7 @@ $ zmmailbox --auth bar@example.com -p password -m foo@example.com
 ====
 [source,bash]
 ----
-zmmailbox -z-m user@example.com gms
+zmmailbox -z -m user@example.com gms
 ----
 ====
 
@@ -3071,7 +3073,7 @@ data.  Type as:
 
 [source,bash]
 ----
-zmmailbox -z-m user@example.com gru "?fmt=zip&meta=1" > /<filename.zip>
+zmmailbox -z -m user@example.com gru "?fmt=zip&meta=1" > <filename.zip>
 ----
 ====
 
@@ -3082,17 +3084,17 @@ protocol options: HTTP, HTTPS, Mixed, Both and Redirect.  The default
 setting is HTTPS.
 
 [IMPORTANT]
-The `zmtlsctl` setting also impacts the ZCO’s *Use Secure Connection*
+The `zmtlsctl` setting also impacts the ZCO's *Use Secure Connection*
 setting.  ZCO users in a self-signed environment will encounter warnings
 about connection security unless the root CA certificate is added to Window
 Certificate Store.  See the Zimbra Wiki article
-http://wiki.zimbra.com/wiki/ZCO_Connection_Security[ZCO Connection
+https://wiki.zimbra.com/wiki/ZCO_Connection_Security[ZCO Connection
 Security] for more information.
 
 * *HTTP*.  HTTP only, the user would browse to http://zimbra.domain.com.
 
 * *HTTPS.* HTTPS only (default), the user would browse to
-https:/zimbra.domain.com.  http:// is denied.
+https://zimbra.domain.com.  http:// is denied.
 
 * *Mixed* If the user goes to http:// it will switch to https:// for the
 login only,then will revert to http:// for normal session traffic.  If the
@@ -3104,7 +3106,7 @@ the entire session.
 * *Redirect* Like mixed if the user goes to http:// it will switch to
 https:// but they will stay https:// for their entire session.
 
-All modes use SSL encryption for back-end administrative traffic.
+All modes use TLS encryption for back-end administrative traffic.
 
 [IMPORTANT]
 Only `zimbraMailMode` *HTTPS* can ensure that no listener will be available
@@ -3119,7 +3121,7 @@ during {product-abbrev} installation in /opt/zimbra/ssl/zimbra/server/server.crt
 ZCO users, secure ZCO profiles will display Certificate Trust dialogs
 unless the root CA certificate is deployed to the server.  For more
 information about ZCO certificates, see the Zimbra Wiki page
-http://wiki.zimbra.com/wiki/ZCO_Connection_Security[ZCO Connection
+https://wiki.zimbra.com/wiki/ZCO_Connection_Security[ZCO Connection
 Security].
 
 ==== Syntax
@@ -3215,10 +3217,8 @@ Check to see if a valid license is installed.
 |`--help` |`-h` |
 Shows the help for the usage options for this tool.
 
-|`--install` |`--i` |
+|`--install` |`-i` |
 `<arg>` Installs the specified license file.
-
-`[arg]` -- This is the Zimbra license file that you received.
 
 |`--ldap` |`-l` |
 Install on LDAP only.
@@ -3231,7 +3231,7 @@ Displays the license information.
 === zmmetadump
 
 The `zmmetadump` command is a support tool that dumps the contents of an
-item’s metadata in a human readable form.
+item's metadata in a human readable form.
 
 ==== Syntax
 [source,bash]
@@ -3317,8 +3317,8 @@ Stops the replay on occurrence of any error.
 
 Time is specified in the local time zone.  The year, month, date, hour,
 minute, second, and optionally millisecond should be specified.
-Month/date/hour/ minute/second are 0 -padded to 2 digits, millisecond to
-3 digits.  The hour must be specified in a 24- hour format.
+Month/date/hour/ minute/second are 0-padded to 2 digits, millisecond to
+3 digits.  The hour must be specified in a 24-hour format.
 
 
 === zmproxyconfgen
@@ -3369,7 +3369,7 @@ be written.
 
 |`--server` |`-s` |
 `<arg>` Specifies a valid server object.  Configuration is generated based
-on the specified server’s attributes.  The default is to generate
+on the specified server's attributes.  The default is to generate
 configuration based on global configuration values.
 
 |`--templatedir` |`-t` |
@@ -3395,7 +3395,7 @@ server port.
 ==== Syntax
 [source,bash]
 ----
-ProxyPurgeUtil [-v] [-i] -a account [-L accountlist] [cache1] [cache2...]]
+ProxyPurgeUtil [-v] [-i] -a account [-L accountlist] [cache1] [cache2]...]
 ----
 
 ==== Description
@@ -3472,7 +3472,7 @@ Activates the quiet mode.  Used to only print the log filename and errors,
 if any.  Useful for verifying integrity of redologs with minimal output.
 
 |`--show-blob` | |
-Shows blob content.  The specified item’s blob is printed with `<START OF
+Shows blob content.  The specified item's blob is printed with `<START OF
 BLOB>` and `<END OF BLOB>` marking the start and end of the blob.
 
 |=======================================================================
@@ -3485,7 +3485,7 @@ ZWC deployment, and restarts the web server so that it recognizes the new
 skin.
 
 For more information about this tool, see
-http://wiki.zimbra.com/index.php?title=About_Creating_{product-abbrev}_Themes.
+https://wiki.zimbra.com/index.php?title=About_Creating_{product-abbrev}_Themes.
 
 ==== Syntax
 [source,bash]
@@ -3501,7 +3501,7 @@ format.
 ==== Syntax
 [source,bash]
 ----
-zmsoap [options] <path1 [<path2>...]
+zmsoap [options] {path1} [path2]...
 ----
 
 ==== Description
@@ -3549,7 +3549,7 @@ or `admin`.
 Prints the SOAP request and other status information.
 
 |`path` | |
-`<[path...]>` Displays the element or attribute path and value.  Roughly
+`<[path]...>` Displays the element or attribute path and value.  Roughly
 follows the XPath syntax as: `[/]element1[/element2][/@attr][=value]`.
 
 |=======================================================================
@@ -3563,7 +3563,7 @@ are saved to `/opt/zimbra/zmstat/`.
 
 You must enable zmstat to collect the performance charts data:
 
-. Enter `zmprov ms {hostname} zimbraServerEnable : stats`.
+. Enter `zmprov ms {hostname} zimbraServerEnable stats`.
 . Restart the server, Enter:
 +
 [source,bash]
@@ -3687,7 +3687,7 @@ unresponsive.  The default value is 30 seconds.
 Use `zmtrainsa` to train the anti-spam filter.  This command is run
 automatically every night to train the SpamAssasin filter from messages
 users mark as "junk" / "not junk" from their mailbox.  See
-<<spamassassin_sa_update_tool,SpamAssassin’s sa-update tool>>, which is
+<<spamassassin_sa_update_tool,SpamAssassin's sa-update tool>>, which is
 included with SpamAssassin.  This tool updates SpamAssassin rules from the
 SA organization.  The tool is installed into `/opt/zimbra/common/bin`.
 
@@ -3699,7 +3699,7 @@ folder is Junk.  For ham, the default folder is Inbox.
 ==== Syntax
 [source,bash]
 ----
-zmtrainsa <user> spam|ham [folder]
+zmtrainsa <user> <spam|ham> [folder]
 ----
 
 === zmtzupdate
@@ -3817,12 +3817,12 @@ Turns off the current secondary message volume.
 
 Use `zmzimletctl` to manage Zimlets and to list all zimlets on the server.
 Additional information is provided in <<zimlets,Zimlets>>.  Most Zimlet
-deployment can be completed from the zimbra Administration Console.
+deployment can be completed from the Zimbra Administration Console.
 
 ==== Syntax
 [source,bash]
 ----
-zmzimletctl {-l} {command} <zimlet.zip|config.xml|zimlet>
+zmzimletctl [-l] {command} [<zimlet.zip>|<config.xml>|<zimlet>]
 ----
 
 ==== Description
@@ -3837,7 +3837,7 @@ zimlet files on the Server, grants, access to the members of the default
 COS, and turns on the Zimlet.
 
 |`undeploy` | |
-`<zimlet>` Uninstall a zimlet from the zimbra server.
+`<zimlet>` Uninstall a zimlet from the Zimbra server.
 
 |`install` | |
 `<zimlet.zip>` Installs the Zimlet files on the host.

--- a/colorandlogo.adoc
+++ b/colorandlogo.adoc
@@ -1,7 +1,7 @@
+[[color_and_logo_management]]
 = Color and Logo Management
 :toc:
 
-[[color_and_logo_management]
 You can change the logo and base colors of the Zimbra Web Client themes
 without having to customize individual {product-name} themes.  This
 can be done from the administration console or the CLI.
@@ -40,13 +40,12 @@ preferences selection.
 The following base colors in Zimbra Web Client themes can be changed:
 
 * The primary background color displayed in the client.
-
++
 This color is the background of the page. Variants of the color are used
 for buttons, background color of the Content and panes, tabs, and
 selection highlight. In the following image, the background color
 displays with the logo, the variant of the background color displays in
 the login area.
-
 * The secondary color is the color used for the toolbar.
 * The selection color is the color displayed for a selected item such as
 a message or an item in the Overview pane.
@@ -57,14 +56,13 @@ color is black. The text color usually does not need to be changed.
 
 You can replace the log with your company’s logo globally or per domain.
 
-*_Note:_* *_License Policy for Logo Replacement_*
-
+[NOTE]
+*_License Policy for Logo Replacement_* +
 _The Zimbra Public License does not allow removing the Zimbra logo in
 the Zimbra Web Client. Only Network Edition customers can replace Zimbra
 logos that display in the Zimbra Web Client. Therefore, only customers
 of the Network Edition should use these instructions. Additional
-information about the license usage can be found at http:/
-www.zimbra.com/license/index.html._
+information about the license usage can be found at https://www.zimbra.com/license/._
 
 ==== Graphics to Replace
 
@@ -98,7 +96,7 @@ console pages.
 ==== Changing Base Theme Colors
 
 You can either select colors from popup view of predefined colors, or
-enter the six -digit hexadecimal color value for an exact color match to
+enter the six-digit hexadecimal color value for an exact color match to
 set theme colors for the following categories:
 
 * Foreground, which is the text color.
@@ -118,38 +116,38 @@ menu.
 Use the *Customize the theme colors* container to set colors for your
 theme categories:
 
-*Admin Console: Home*> *Configure*> *Global Settings*> *Themes* or
-
-*Home*> *Configure*> *Domains*> <account.domain> > *Themes*
+Admin Console: ::
+*Home > Configure > Global Settings > Themes* or +
+*Home > Configure > Domains > _domain_ > Themes*
 
 1.  Click on the field alongside the theme category to be modified, then
 use the popup color selector to define the color for your selection.
-
++
 You can either click directly on a color, or use the entry field to
 write the hexadecimal value of the color. In either case, your selection
 will be displayed in the field.
-
++
 If you opt out of your color selections, click *reset all theme colors*
 to discard your settings.
 
-1.  Navigating away from this page results in query for save of the
-settings. Click *Yes* (to save) or *No* (to discard your settings).
+2.  Navigating away from this page results in query for save of the
+settings.
++
+Click *Yes* (to save) or *No* (to discard your settings).
 
 ==== Adding Your Logo
 
 You can replace the {product-name} logo with your company’s logo
 globally or per domain from the appropriate Themes page. Your logos must
-be the same size as specified in the
-
-Graphics to Replace
-
+be the same size as specified in the *Graphics to Replace*
 section or the images might not display correctly. The graphic files are
 saved on another server or in a directory that is not overwritten when
 {product-name} is upgraded.
 
-*_Note:_ *_When you configure the_*Customize the logo of the
-themes*_section in_****_the Global Settings > Theme page, all fields in
-this section must be completed to display the graphics correctly._
+[NOTE]
+When you configure the *Customize the logo of the
+themes* section in the *Global Settings > Theme* page, all fields in
+this section must be completed to display the graphics correctly.
 
 The Zimlet icon that displays in the Advanced search toolbar and the
 favicon.ico that displays in the URL browser address field are not
@@ -158,72 +156,61 @@ changed.
 Use the *Customize the logo of the themes* container to a logo to
 accompany the theme:
 
-*Admin Console: Home*> *Configure*> *Global Settings*> *Themes* or
+Admin Console ::
+*Home > Configure > Global Settings > Themes* or +
+*Home > Configure > Domains > _domain_ > Themes*
 
-*Home*> *Configure*> *Domains* <account.domain> > *Themes*
+.Logo Settings
 
-*Logo Settings*
+[cols=",",options="header",]
+|====================================================================
+|Option | Description
 
-*Option* *Description*
+| Logo URL of the themes |
+The company web address to be linked from the logo.
 
-Logo URL of the themes The company web address to be linked
-
-from the logo.
-
-Application logo banner URL of the themes
-
+| Application logo banner URL of the themes |
 The company logo that displays on the login and splash screens for the
 Zimbra Web Client and admin console. the dimension of the graphic must
 be exactly 450x100.
 
-Application logo banner preview (200x35)
-
-Login logo banner URL of the themes
-
-Login logo banner preview (440x60)
-
+| Application logo banner preview (200x35) |
 The company logo in the upper-left of the Zimbra Web Client application
 and the administration console. the dimension of the graphics must be
 exactly 120x35.
 
+| Login logo banner URL of the themes |
+
+| Login logo banner preview (440x60) |
+
+|====================================================================
+
 === Using the CLI to Change Theme Colors and Logo
 
 To change the Zimbra Web Client theme base colors and logos, use the
-following zmprov command.
+zmprov command.  The following attributes are configured either as a
+global config setting or as a domain settings.  Color values are
+entered as a six-digit hexadecimal codes.
 
-*CLI:* zmprov change Theme Colors
-
-The color code is entered as a six-digit hexadecimal code.
-
-*Color Attributes*
-
-The following attributes are configured either as a global config
-setting or as a domain setting:
-
+.Color Attributes
 [cols=",",options="header",]
 |====================================================================
-|*Color Attributes* |*Description*
-|zimbraSkinBackground |The hex color value for the primary background
-|Color |color displayed in the client.
+|Attribute |Description
+
+|zimbraSkinBackgroundColor |
+The hex color value for the primary background color displayed in the client.
+
+|zimbraSkinSecondaryColor |
+The hex color value for the toolbar and selected tabs.
+
+|zimbraSkinSelectionColor |
+The hex color value for the color of the selected item.
+
+|zimbraSkinForegroundColor |
+The hex color value for the text. This usually does not need to be
+changed as the default is black.
+
 |====================================================================
-
-*{product-name}* *Network Edition* *305*
-
-*Administrator Guide*
-
-*Color Attributes* *Description*
-
-[cols=",",options="header",]
-|======================================================================
-|zimbraSkinSecondary |The hex color value for the toolbar and
-|Color |selected tabs
-|zimbraSkinSelection |The hex color value for the color of the selected
-|Color |item.
-|zimbraSkinForeground |The hex color value for the text. This usually
-|Color. |does not need to be changed as the default is
-|[multiblock cell omitted] |black.
-|[multiblock cell omitted] |[multiblock cell omitted]
-|======================================================================
 
 *Changing base colors for themes*
 
@@ -232,79 +219,69 @@ for the various elements you are changing. You will be using these in
 your command entries.
 
 *CLI:* Global Setting:
-
+[source,bash]
+----
 zmprov modifyConfig <attribute-name> [“#HEX_6digit_colorcode”]
+----
 
 *CLI:* Domain Setting:
-
+[source,bash]
+----
 zmprov modifyDomain <domain> <attribute-name> [“#HEX_6digit_colorcode”]
+----
 
 *Modifying a domain*
 
-The examplein this section demonstrates how to change to the following
+The example in this section demonstrates how to change to the following
 base colors:
 
-* Background color = Coral, #ff7F50
+* Background color = Coral, #FF7F50
 * Secondary color = turquoise, #ADEAEA
-* Selection color = yellow, #FFFF00.
+* Selection color = yellow, #FFFF00
 
-1.  Specify the skin colors:
-
+1. Specify the skin colors:
 *CLI:* Log in as a Zimbra user and use parameters to modify the domain:
-
-zmprov modifyDomain domainexample.com zimbraSkinBackgroundColor
-“#FF7F50” zimbraSkinSecondaryColor “#ADEAEA” zimbraSkinSelectionColor
-“#FFFF00”
-
-The quote marks, “”, are required so the use of the # sign does not
++
+  zmprov modifyDomain domainexample.com zimbraSkinBackgroundColor "#FF7F50" zimbraSkinSecondaryColor "#ADEAEA" zimbraSkinSelectionColor "#FFFF00"
++
+The quote marks, "", are required so the use of the # sign does not
 comment out the text that follows.
-
-1.  Use parameters provided in the zmmailboxdctl commands to apply the
-changes:
-
-{product-name} themes for that domain now display these colors.
-
-*306* *Network Edition* *{product-name}*
-
-*Color and Logo Management*
++
+2. Use the zmmailboxdctl command to apply the changes by restarting
+the mailbox server process:
++
+  zmmailboxdctl restart
++
+Reload the web client and {product-name} themes for that domain should
+now display these colors.
 
 *Adding Your Logos*
 
 You add the company logo information and URL by modifying these the
 following attributes for logos:
 
+.Logo Settings
 [cols=",",options="header",]
 |=======================================================================
-|*Logo Settings* |[multiblock cell omitted]
-|*Attribute* |*Description*
+|Attribute |Description
 
-|*zimbraSkinLogoURL* |the company Web address that you want
+|zimbraSkinLogoURL |
+The company Web address that you want linked from the logo.
 
-|[multiblock cell omitted] |linked from the logo
+|zimbraSkinLogoLoginBanner |
+The company logo file name that is displayed on the login and splash
+screens for the ZWC and the {product-name} administration console.
 
-|*zimbraSkinLogoLogin* |The company logo file name that is displayed
+|zimbraSkinLogoAppBanner |
+The logo graphic file name for the graphic in the upper-left of the
+ZWC application and the administration console.
 
-|*Banner.* |on the login and splash screens for the ZWC
-
-|[multiblock cell omitted] |and the {product-name} administration
-
-|[multiblock cell omitted] |console
-
-|*zimbraSkinLogoAppBanner* |The logo graphic file name for the graphic
-in
-
-|[multiblock cell omitted] |the upper-left of the ZWC application and
-the
-
-|[multiblock cell omitted] |administration console.
-
-|[multiblock cell omitted] |[multiblock cell omitted]
 |=======================================================================
 
 *To add logos for a domain*
 
 If logo files are saved in the {product-name} server, they must be
-in a subdirectory of /opt/zimbra/jetty/webapps/zimbra.
+in a subdirectory of `/opt/zimbra/jetty/webapps/zimbra`.
 
 If the logos are hosted on another machine, enter the full URL when
 identifying the logo.
@@ -313,28 +290,22 @@ identifying the logo.
 domain:
 
 1.  Change the URL link:
-
-su - zimbra
-
-zmprov modifyDomain [http://_urlexample.com_]
-
-1.  Modify the logo display:
-
++
+ zmprov modifyDomain zimbraSkinLogoURL https://url.example.com/
++
+2.  Modify the logo display:
++
 To change the logo displayed in the login and splash screens:
-
-zmprov modifyDomain [/zimbra/loginlogo_name.png]
-
++
+ zmprov modifyDomain zimbraSkinLogoLoginBanner /zimbra/loginlogo.png
++
 To change the logo displayed on the Zimbra Web Client main page:
-
-zmprov modifyDomain [/zimbra/_loginlogo_name.png_]
-
-1.  Stop/start the server:
-
-zmcontrol stop zmcontrol start
-
-*{product-name}* *Network Edition* *307*
-
-*Administrator Guide*
++
+ zmprov modifyDomain zimbraSkinLogoAppBanner /zimbra/applogo.png
++
+3.  Stop/start the server:
++
+ zmcontrol restart
 
 *Changing the Logo on the Touch Client*
 
@@ -342,7 +313,8 @@ Use information in this section to find out how to prepare and place
 your logo image file(s) for replacement of the default Zimbra images in
 the user interfaces.
 
-*_Note:_* _Not currently supported:_ Logo modification for the Zimbra
+[NOTE]
+_Not currently supported:_ Logo modification for the Zimbra
 Web Client.
 
 You can globally replace the {product-name} logo with your
@@ -353,9 +325,10 @@ described in the following topics:
 * Watermark for Bottom-right Display in Email Message.
 * Bookmark Image for Springboard.
 
-*_Note:_ *_These image files will not survive an upgrade. Therefore, be
-sure to_****_keep a backup and repeat the replacement process after an
-upgrade_
+[NOTE]
+_These image files will not survive an upgrade. Therefore, be
+sure to keep a backup and repeat the replacement process after an
+upgrade._
 
 *Company log for {product-abbrev} Touch Client Login and Splash Screens*
 
@@ -363,62 +336,46 @@ The image displays on white background.
 
 [cols=",,",options="header",]
 |=======================================================================
-|[multiblock cell omitted] |*For Low DPI Devices* |*For High DPI
-Devices*
+| |*For Low DPI Devices* |*For High DPI Devices*
+
 |Size Requirement: |300 x 65 |600 x 130
 
-|File location: |/skins/_base/logos/ | /skins/_base/logos/
+|File location: |
+/skins/_base/logos/TouchLonginBanner.png |
+/skins/_base/logos/TouchLonginBanner@2x.png
 
-|[multiblock cell omitted] |TouchLonginBanner.png
-|TouchLonginBanner@2x.png
-
-|[multiblock cell omitted] |[multiblock cell omitted]
-|[multiblock cell omitted]
 |=======================================================================
 
 *Watermark for Bottom-right Display in Email Message*
 
 [cols=",,",options="header",]
 |=======================================================================
-|[multiblock cell omitted] |*For Low DPI Devices* |*For High DPI
-Devices*
+| |*For Low DPI Devices* |*For High DPI Devices*
+
 |Size Requirement: |200 x 45 |400 x 90
 
-|File location: |/skins/_base/logos/ | /skins/_base/logos/
+|File location: |
+/skins/_base/logos/TouchWatermarkBanner.png |
+/skins/_base/logos/TouchWatermarkBanner@2x.png
 
-|[multiblock cell omitted] |TouchWatermarkBanner.pn
-|TouchWatermarkBanner@2x.
-
-|[multiblock cell omitted] |g |pn
-
-|[multiblock cell omitted] |[multiblock cell omitted]
-|[multiblock cell omitted]
 |=======================================================================
 
 *Bookmark Image for Springboard*
 
 [cols=",,",options="header",]
 |=======================================================================
-|[multiblock cell omitted] |*For Low DPI Devices*
-|[multiblock cell omitted]
-|Size Requirement: |Mobile phone: 57 x 57 |[multiblock cell omitted]
+| |*For Low DPI Devices* |*For High DPI Devices*
 
-|File Location: |/img/logo/Icon.png with your |[multiblock cell omitted]
+|Size Requirement: |Mobile phone: 57 x 57 |Mobile phone: 114 x 114
 
-|Size Requirement: |company logo |[multiblock cell omitted]
-
-|[multiblock cell omitted] |Tablet: 72 x 72 |[multiblock cell omitted]
-
-|File Location: |[multiblock cell omitted] |[multiblock cell omitted]
-
-|[multiblock cell omitted] |/img/logo/Icon~ipad.png
-|[multiblock cell omitted]
-|=======================================================================
-
-*For High DPI Devices*
-
-Mobile phone: 114 x 114
-
+|File Location: |
+/img/logo/Icon.png |
 /img/logo/Icon@2x.png
 
-Tablet: 144 x 144 /img/logo/Icon~iPad@2x.png
+|Size Requirement: |Tablet: 72 x 72 |Tablet: 144 x 144
+
+|File Location: |
+/img/logo/Icon~ipad.png |
+/img/logo/Icon~iPad@2x.png
+
+|=======================================================================

--- a/configuration.adoc
+++ b/configuration.adoc
@@ -7,7 +7,7 @@ software. After the installation, you can manage the following components
 from either the Administration Console or using the CLI utility.
 
 *Help* is available from the Administration Console about how to perform
-tasksfrom the Administration Console. If the task is only available from
+tasks from the Administration Console. If the task is only available from
 the CLI, see <<cli_commands, Zimbra CLI Commands>> for a description of how
 to use the CLI utility.
 
@@ -22,17 +22,14 @@ for the following objects: server, account, COS, and domain. If these
 attributes are set in the server, the server settings override the
 global settings.
 
-.Admin Console
-****
-To configure global settings:
-
-*Configure > Global Settings* page.
-****
+Admin Console: ::
+To configure global settings, navigate to: +
+*Configure > Global Settings*
 
 Configured global settings are:
 
 * Default domain
-* Maximum number of results returned for GAL searches. Default =100.
+* Maximum number of results returned for GAL searches. Default = 100.
 * User views of email attachments and attachment types not permitted.
 * Configuration for authentication process, Relay MTA for external
 delivery, DNS lookup, and protocol checks.
@@ -51,12 +48,11 @@ the number of accounts created.
 [[general_information_configuration]]
 == General Information Configuration
 
-.Admin Console
-****
-Use the *General Information* screen to view and set global parameters
-forservers that have been installed and enabled.
-
+Admin Console: ::
 *Home > Configure > Global Settings*
+
+Use the *General Information* screen to view and set global parameters
+for servers that have been installed and enabled.
 
 [NOTE]
 Settings defined at the server(s) override those configured in the General
@@ -66,7 +62,6 @@ image:images/administration_console_general_information_configuration.png[Genera
 
 . Modify parameters, as appropriate for your requirements.
 . From the *Gear* icon, select *Save* to use your settings.
-****
 
 .General Information Parameters
 [cols=",a",options="header",]
@@ -75,42 +70,38 @@ image:images/administration_console_general_information_configuration.png[Genera
 
 |Most results returned by GAL search |
 The maximum number of GAL results returned from a user search. This value
-can be set by domain: the domain setting overrides the global setting.
-
+can be set by domain: the domain setting overrides the global setting. +
 Default = 100.
 
 |Default domain |
-Domain that users’ logins are authenticated against.
+Domain that users' logins are authenticated against.
 
 
 |Number of scheduled tasks that can run simultaneously|
 Number of threads used to fetch content from remote data
 sources.
 * If set too low, users do not get their mail from external sources pulled down often enough.
-* If set too high, the server may be consumed with downloading this mail and not servicing “main” user requests.
-
+* If set too high, the server may be consumed with downloading this mail and not servicing "main" user requests. +
 Default = 20
 
 |Sleep time between subsequent mailbox purges |
 
-The duration of time that the server should “rest” between purging
+The duration of time that the server should "rest" between purging
 mailboxes.  If the message purge schedule is set to 0, messages are not
-purged, even if the mail, trash and spam message life time is set.
-
+purged, even if the mail, trash and spam message life time is set. +
 Default = message purge is scheduled to run every 1 minute.
 
-|Maximum size of an uploaded file for Briefcase files (kb)|
+|Maximum size of an uploaded file for Briefcase files (KB)|
 The maximum size of a file that can be uploaded into Briefcase.
 
 [NOTE]
 The maximum message size for an email message and attachments that can be
-sent is configured in the Global Settings MTA page, Messages section.
+sent is configured in the *Global Settings > MTA* page, *Messages* section.
 
-|Admin Help URL .2+|To use the {product-name} Help, you can designate
-the URL that is linked from the Administration Console
-Help
-
-|Delegated Admin Help URL
+|Admin Help URL +
+Delegated Admin Help URL|
+To use the {product-name} Help, you can designate the URL that is
+linked from the Administration Console Help
 
 |=======================================================================
 
@@ -124,17 +115,13 @@ handling attachments to an email message. You can also set rules by COS and
 for individual accounts. When attachment settings are configured in Global
 Settings, the global rule takes precedence over COS and Account settings.
 
-.Admin Console
-****
+Admin Console: ::
 *Home > Configure > Global Settings > Advanced*
 
 [cols=","]
-|=======================================================================
-|image:images/administration_console_email_attachment_rules.png[Attachment Rules] |
-See <<blocking_email_attachements_by_file_type, Blocking Email Attachments
+image:images/administration_console_email_attachment_rules.png[Attachment Rules] +
+See <<_blocking_email_attachments_by_file_type, Blocking Email Attachments
 by File type>> for information about this section of the screen.
-|=======================================================================
-****
 
 .Global Settings Advanced
 [cols=",",options="header",]
@@ -170,10 +157,8 @@ sender are notified that the message was blocked.
 If you do not want to send a notification to the recipient when messages
 are blocked, you can disable this option.
 
-.Admin Console
-****
-*Global Settings > Attachments* page.
-****
+Admin Console: ::
+*Global Settings > Attachments*
 
 [[mta_configuration]]
 == MTA Configuration
@@ -182,12 +167,10 @@ Use options from the MTA page to enable or disable authentication and
 configure a relay hostname, the maximum message size, enable DNS lookup,
 protocol checks, and DNS checks.
 
-.Admin Console
-****
+Admin Console: ::
 *Home > Configure > Global Settings > MTA*
 
 image:images/administation_console_mta_configuration.png[MTA Configuration]
-****
 
 .MTA Page Options
 [cols=",a"]
@@ -239,7 +222,7 @@ here.
 
 |Messages |
 
-* Set the *Maximum messages size* for a message and it’s attachments that
+* Set the *Maximum messages size* for a message and it's attachments that
 can be sent.
 +
 [TIP]
@@ -258,8 +241,8 @@ suspect SMTP clients).
 * To reject unsolicited commercial email (UCE), for spam control.
 
 |DNS checks |
-* To reject mail if the client’s IP address is unknown, the hostname in the
-greeting is unknown, or if the sender’s domain is unknown.
+* To reject mail if the client's IP address is unknown, the hostname in the
+greeting is unknown, or if the sender's domain is unknown.
 
 * Add other email recipient restrictions to the *List of RBLs* field.
 
@@ -273,18 +256,15 @@ CLI.
 
 Use the IMAP and POP pages to enable global access.
 
-.Admin Console
-****
+Admin Console: ::
 *Home > Configure > Global Settings > IMAP* or *POP*
-****
 
 [NOTE]
 When you make changes to the IMAP or POP settings, you must restart
 {product-name} before the changes take effect.
 
 IMAP and POP3 polling intervals can be set from the Administration Console
-COS Advanced page.
-
+COS Advanced page. +
 Default = No polling interval.
 
 [NOTE]
@@ -292,7 +272,7 @@ If IMAP/POP proxy is set up, ensure that the port numbers are configured
 correctly.
 
 With POP3, users can retrieve their mail stored on the Zimbra server and
-download new mail to their computer. The user’s POP configuration in their
+download new mail to their computer. The user's POP configuration in their
 *Preference > Mail* page determines how their messages are downloaded and
 saved.
 
@@ -314,7 +294,7 @@ sharing.
 
 A domain can be renamed and all account, distribution list, alias and
 resource addresses are changed to the new domain name. The CLI utility is
-used to changing the domain name. See <<renaming_a_domain, Renaming a Domain>>.
+used to changing the domain name. See <<_renaming_a_domain, Renaming a Domain>>.
 
 [NOTE]
 Domain settings override global settings.
@@ -323,14 +303,12 @@ Domain settings override global settings.
 
 Use the *New Domain* Wizard to set options described in this section.
 
-.Admin Console
-****
-*Home > Set up Domain > Create Domain*
+Admin Console: ::
+*Home > 2 Set up Domain > 1. Create Domain...*
 
 image:images/administration_console_create_domain.png[Create Domain]
-****
 
-.New Domain — General Information
+.New Domain -- General Information
 [cols=",a",options="header"]
 |=======================================================================
 |Option |Description
@@ -338,7 +316,7 @@ image:images/administration_console_create_domain.png[Create Domain]
 |Domain name * +
 Public service host name |
 Enter the host name of the REST URL. This is commonly used for sharing. See
-<<setting_up_a_public_service_host_name,Setting up a Public Service Host>>
+<<_setting_up_a_public_service_host_name,Setting up a Public Service Host>>
 
 |Public service protocol |
 Select HTTP or HTTPS from the drop-down field.
@@ -361,7 +339,7 @@ is delivered. Changing the status can affect the status for accounts on the
 domain also. The domain status is displayed on the *Domain > General*
 page. Domain status can be set as follows:
 
-* *Active*. Active is the normal status for domains.Accounts can be created
+* *Active*. Active is the normal status for domains. Accounts can be created
 and mail can be delivered.
 +
 --
@@ -372,22 +350,22 @@ account status overrides the domain status.
 
 * *Closed*. When a domain status is marked as closed,Login for accounts on
 the domain is disabled and messages are bounced. The closed status
-overrides an individual account’s status setting.
+overrides an individual account's status setting.
 
 * *Locked*. When a domain status is marked as locked,users cannot log in to
 check their email, but email is still delivered to the accounts.  If an
-account’s status setting is marked as maintenance or closed, the account’s
+account's status setting is marked as maintenance or closed, the account's
 status overrides the domain status setting.
 
 * *Maintenance*. When the domain status is markedas maintenance, users
-cannot log in and their email is queued at the MTA. If an account’ status
-setting is marked as closed, the account’s status overrides the domain
+cannot log in and their email is queued at the MTA. If an account's status
+setting is marked as closed, the account's status overrides the domain
 status setting.
 
 * *Suspended*. When the domain status is marked assuspended, users cannot
 log in, their email is queued at the MTA, and accounts and distribution
-lists cannot be created, deleted, or modified. If an account’s status
-setting is marked as closed, the account’s status overrides the domain
+lists cannot be created, deleted, or modified. If an account's status
+setting is marked as closed, the account's status overrides the domain
 status setting.
 |=======================================================================
 
@@ -401,7 +379,7 @@ calendars.
 When users share a {product-name} folder, the default is to create
 the URL with the Zimbra server hostname and the Zimbra service host
 name. This is displayed as
-*http://server.domain.com/service/home/username/sharedfolder*. The
+*https://server.domain.com/service/home/username/sharedfolder*. The
 attributes are generated as follows:
 
 * Hostname is server.zimbraServiceHostname
@@ -410,7 +388,7 @@ attributes are generated as follows:
 
 When you configure a public service host name, this name is used instead of
 the server/service name, as
-*http://publicservicename.domain.com/home/username/sharedfolder*. The
+*https://publicservicename.domain.com/home/username/sharedfolder*. The
 attributes to be used are:
 
 * +zimbraPublicServiceHostname+
@@ -418,13 +396,13 @@ attributes to be used are:
 * +zimbraPublicServicePort+
 
 You can use another FQDN as long as the name has a proper DNS entry to
-point at ‘server’ both internally and externally.
+point at 'server' both internally and externally.
 
 === Global Address List (GAL) Mode Configuration
 
 The Global Address List (GAL) is your company-wide listing of users that is
 available to all users of the email system. GAL is a commonly used feature
-in mail systems that enables users to look up another user’s information by
+in mail systems that enables users to look up another user's information by
 first or last name, without having to know the complete email address.
 
 GAL is configured on a per-domain basis. The GAL mode setting for each
@@ -433,14 +411,12 @@ domain determines where the GAL lookup is performed.
 Use the *GAL Mode Settings* tool with your domain configuration to define
 the Global Address List.
 
-.Admin Console
-****
-*Home > 2 Set up Domain > 1 Create Domain, GAL Mode Settings*
+Admin Console: ::
+*Home > 2 Set up Domain > 1 Create Domain..., GAL Mode Settings*
 
 image:images/administration_console_gal.png[GAL Mode Settings]
-****
 
-.New Domain—GAL Mode Settings
+.New Domain -- GAL Mode Settings
 [cols=",a",options="header"]
 |=======================================================================
 |Option |Description
@@ -465,8 +441,7 @@ for GAL lookups.
 |Most results returned by GAL search |
 Maximum number of search results that can be returned in one GAL search.
 If this value is undefined here, the system will use the value defined in
-Global Settings.
-
+Global Settings. +
 Default = 100 results.
 
 |GAL sync account name* |
@@ -476,9 +451,9 @@ Read-only field that displays the galsync name and associated domain.
 Read-only field that displays the name of the internal GAL.
 
 |Internal GAL polling interval |
-Define how often — as days, hours, minutes, or seconds — the GAL sync
+Define how often -- as days, hours, minutes, or seconds -- the GAL sync
 account is to sync with the LDAP server.  With the first sync to the LDAP
-server, all GAL contacts from the LDAP are added to the galsync account’s
+server, all GAL contacts from the LDAP are added to the galsync account's
 address book. On subsequent syncs, the account is updated with information
 about new contacts, modified contacts, and deleted contacts.
 
@@ -493,7 +468,7 @@ GAL sync account gives users faster access to auto complete names from the
 GAL.
 
 When a GAL sync account is created on a server, GAL requests are directed
-to the server’s GAL sync account instead of the domain’s GAL sync
+to the server's GAL sync account instead of the domain's GAL sync
 account. The GalSyncResponse includes a token which encodes the GAL sync
 account ID and current change number. The client stores this and then uses
 it in the next GalSyncRequest. Users perform GAL sync with the GAL sync
@@ -504,7 +479,7 @@ some reason, the traditional LDAP-based search is run.
 The GAL sync accounts are system accounts and do not use a Zimbra license.
 
 When you configure the GAL sync account, you define the GAL datasource and
-the contact data is syncd from the datasource to the GAL sync accounts’
+the contact data is syncd from the datasource to the GAL sync accounts'
 address books. If the mode *Both* is selected, an address book is created
 in the account for each LDAP data source.
 
@@ -528,9 +503,8 @@ associated with this feature is *zmgsautil.*
 When {product-abbrev} is configured with more than one server, you can add an additional
 GAL sync account for each server.
 
-.Admin Console
-****
-In the Administration Console, select *Configure > Domains*.
+Admin Console: ::
+*Configure > Domains*
 
 . Select the domain to add another GAL sync account.
 
@@ -550,7 +524,6 @@ source name for both the internal GAL and the external GAL.
 sync with the LDAP server to update.
 
 . Click *Finish*.
-****
 
 ==== Changing GAL sync account name
 
@@ -561,9 +534,8 @@ created, you cannot rename the account because syncing the data fails.
 To change the account name delete the existing GAL sync account and
 configure a new GAL for the domain.
 
-.Admin Console
-****
-In the Administration Console, select *Configure > Domains*.
+Admin Console: ::
+*Configure > Domains*
 
 . Select the domain where you want to change the GAL sync account name.
 
@@ -571,14 +543,13 @@ In the Administration Console, select *Configure > Domains*.
 and change the GAL mode to internal. Do not configure any other
 fields. Click *Finish*.
 
-. In the domain’s account Content pane, delete the domain’s galsync
+. In the domain's account Content pane, delete the domain's galsync
 account.
 
 . Select the domain again and select Configure GAL to reconfigure the
 GAL. In the GAL sync account name field, enter the name for the account.
 Complete the GAL configuration and click *Finish*. The new account is
 displayed in the Accounts Content pane.
-****
 
 === Authentication Modes
 
@@ -588,11 +559,10 @@ and password information provided when users log in.
 
 Set the authentication method on a per-domain basis.
 
-.Admin Console
-****
-*Home > 2 Set up Domain > 1. create Domain, Authentication Mode*
+Admin Console: ::
+*Home > 2 Set up Domain > 1 Create Domain..., Authentication Mode*
 
-.New Domain — Authentication Mode
+.New Domain -- Authentication Mode
 [cols=",a",options="header",]
 |=======================================================================
 |Option |Description
@@ -614,7 +584,6 @@ identify the Active Directory domain name and URL.
 
 
 |=======================================================================
-****
 
 === Virtual Hosts
 
@@ -625,11 +594,10 @@ When you create a virtual host, this becomes the default domain for a
 user login. Zimbra Web Client users can log in without having to specify
 the domain name as part of their user name.
 
-.Admin Console
-****
-*Home > 2 Set up Domain > 1. Create Domain, Virtual Hosts*
+Admin Console: ::
+*Home > 2 Set up Domain > 1 Create Domain..., Virtual Hosts*
 
-.New Domain — Virtual Hosts
+.New Domain -- Virtual Hosts
 [cols=",",options="header",]
 |=======================================================================
 |*Option* |*Description*
@@ -637,11 +605,10 @@ the domain name as part of their user name.
 |Add virtual host |
 Alphanumeric string to identify the virtual host(s) for this domain. The
 virtual host requires a valid DNS configuration with an A record.  To
-delete a virtual host from the domain, click Remove alongside the host name
+delete a virtual host from the domain, click *Remove* alongside the host name
 displayed in this wizard screen.
 
 |=======================================================================
-****
 
 To open the Zimbra Web Client log in page, users enter the virtual host
 name as the URL address. For example, *https://mail.company.com*.
@@ -670,13 +637,13 @@ license.
 
 When multiple Classes of Service (COS) are available, you can select which
 classes of service can be configured and how many accounts on the domain
-can be assigned to the COS. This is configured in the domain’s Account
+can be assigned to the COS. This is configured in the domain's Account
 Limits page. The number of COS account types used is tracked.  The limits
 for all COSs cannot exceed the number set for the maximum accounts for the
 domain.
 
 The number of COS assigned to accounts is tracked. You can see the number
-assigned/number remaining from any account’s General Information page.
+assigned/number remaining from any account's General Information page.
 
 === Renaming a Domain
 
@@ -694,16 +661,13 @@ After the domain has been renamed
 
 * Update external references that you have set up for the old domain name
 to the new domain name. This may include automatically generated emails
-that were sent to the administrator’s mailbox such as backup ses-sion
+that were sent to the administrator's mailbox such as backup ses-sion
 notifications. Immediately run a full backup of the new domain
 
-.CLI
-****
 [source,bash]
 ----
 zmprov -l rd [olddomain.com] [newdomain.com]
 ----
-****
 
 ==== Domain Rename Process
 
@@ -736,10 +700,8 @@ A domain alias is a domain name just like your primary domain name. You
 must own the domain name and verify your ownership before you can add it as
 an alias.
 
-.Admin Console
-****
+Admin Console: ::
 *Configure > Domains*: from the *Gear* icon select, *Add a Domain Alias*.
-****
 
 === Enabling Support for Domain Disclaimers
 
@@ -747,55 +709,51 @@ Disclaimers are set per-domain. When upgrading, an existing global
 disclaimer is converted to domain specific disclaimers on every domain to
 preserve behavior with previous releases.
 
-.CLI
-****
-
 Per domain disclaimer support can be enabled using the following steps:
 
-. Create a new domain (e.g. example.com), and account (e.g.
+. Create a new domain (e.g. example.com) and account (e.g.
 user2@example.com).
 +
 [source,bash]
 ----
-zimbra@server-064:~$ zmprov cd example.com cb9a4846-6df1-4c18-8044-4c1d4c21ccc5
-zimbra@server-064:~$ zmprov ca user2@example.com test123 95d4caf4-c474-4397-83da-aa21de792b6a
-zimbra@server-064:~$ zmprov -l gaa user1@server-064.eng.example.com user2@example.com
+$ zmprov cd example.com cb9a4846-6df1-4c18-8044-4c1d4c21ccc5
+$ zmprov ca user2@example.com test123 95d4caf4-c474-4397-83da-aa21de792b6a
+$ zmprov -l gaa user1@example.com user2@example.com
 ----
 
 . Enable the use of disclaimers
 +
 [source,bash]
 ----
-zimbra@server-064:~$ zmprov mcf zimbraDomainMandatoryMailSignatureEnabled TRUE
-zimbra@server-064:~$ zmprov gcf zimbraDomainMandatoryMailSignatureEnabled zimbraDomainMandatoryMailSignatureEnabled: TRUE
+$ zmprov mcf zimbraDomainMandatoryMailSignatureEnabled TRUE
+$ zmprov gcf zimbraDomainMandatoryMailSignatureEnabled
+zimbraDomainMandatoryMailSignatureEnabled: TRUE
 ----
 
 . Add disclaimers to the new domain
 +
 [source,bash]
 ----
-zimbra@server-064:~$ zmprov md example.com
+$ zmprov md example.com
 zimbraAmavisDomainDisclaimerText "text disclamer"
 zimbraAmavisDomainDisclaimerHTML "HTML disclaimer"
 
-zimbra@server-064:~$ zmprov gd example.com
-zimbraAmavisDomainDisclaimerText
-zimbraAmavisDomainDisclaimerHTML
+$ zmprov gd example.com zimbraAmavisDomainDisclaimerText zimbraAmavisDomainDisclaimerHTML
 # name example.com
 zimbraAmavisDomainDisclaimerHTML: HTML disclaimer
 zimbraAmavisDomainDisclaimerText: text disclamer
 
-zimbra@server-064:~$ zmprov gd server-064.eng.example.com
+$ zmprov gd eng.example.com
+# name eng.example.com
 zimbraAmavisDomainDisclaimerText
 zimbraAmavisDomainDisclaimerHTML
-# name server-064.eng.example.com
 ----
 
 ..  On the first MTA:
 +
 [source,bash]
 ----
-zimbra@server-064:~$ ./libexec/zmaltermimeconfig -e example.com
+/opt/zimbra/libexec/zmaltermimeconfig -e example.com
 
 Enabled disclaimers for domain: example.comm
 Generating disclaimers for domain example.com.
@@ -806,7 +764,7 @@ Generating disclaimers for domain example.com.
 --
 [source,bash]
 ----
-./libexec/zmaltermimeconfig
+/opt/zimbra/libexec/zmaltermimeconfig
 ----
 * To test, send an email from the account (e.g. user2@example.com) in
 html and plain text format
@@ -820,43 +778,39 @@ plain text disclaimer.
 +
 [source,bash]
 ----
-/libexec/zmaltermimeconfig -d example.com
+/opt/zimbra/libexec/zmaltermimeconfig -d example.com
 ----
 +
 .  On all additional MTAs:
 +
 [source,bash]
 ----
-/libexec/zmaltermimeconfig
+/opt/zimbra/libexec/zmaltermimeconfig
 ----
 --
-****
 
 === Disabling Disclaimers for Intra-domain Emails
 
 You can enable the option for emails between individuals in the same domain
 to not have a disclaimer attached.
 
-Set the attribute `attachedzimbraAmavisOutboundDisclaimersOnly` to TRUE.
+Set the attribute `attachedzimbraAmavisOutboundDisclaimersOnly` to `TRUE`.
 
-To preserve backward-compatibility, this attribute defaults to FALSE.
+To preserve backward-compatibility, this attribute defaults to `FALSE`.
 
 === Disabling the Disclaimer Feature
 
 It is possible to completely remove support for disclaimers by setting the
-related attribute to FALSE
+related attribute to `FALSE`.
 
-.CLI
-****
 [source,bash]
 ----
 zmprov mcf zimbraDomainMandatoryMailSignatureEnabled FALSE
 ----
-****
 
 === Zimlets on the Domain
 
-All Zimlets that are deployed are displayed in the domain’s *Zimlets*
+All Zimlets that are deployed are displayed in the domain's *Zimlets*
 page. If you do not want all the deployed Zimlets made available for users
 on the domain, select from the list the Zimlets that are available for the
 domain. This overrides the Zimlet settings in the COS or for an account.
@@ -870,7 +824,7 @@ registered on the LDAP server.
 In the Administration Console, you can view the current status of all the
 servers that are configured with Zimbra software, and you can edit or
 delete existing server records. You cannot add servers directly to
-LDAP. The {product-name} Installation program must be used to add new
+LDAP. The {product-name} installation program must be used to add new
 servers because the installer packages are designed to register the new
 host at the time of installation.
 
@@ -889,7 +843,7 @@ and enabling DNS lookup if required. Enable the Milter Server and set the
 bind address.
 
 * Enabling POP and IMAP and setting the port numbers for a server. If
-IMAP/POP proxy is set up, making sure that the port numbers are config-ured
+IMAP/POP proxy is set up, making sure that the port numbers are configured
 correctly.
 
 * Index and message volumes configuration. Setting HSM policies.
@@ -917,45 +871,41 @@ information:
 * Server hostname
 
 * LMTP information including advertised name, bind address, and number of
-threads that can simultaneously process data source imports.
-+
+threads that can simultaneously process data source imports. +
 Default = 20 threads.
 
 * Purge setting. The server manages the message purge schedule. You
-configure the duration of time that the server should “rest” between
+configure the duration of time that the server should "rest" between
 purg-ing mailboxes from the Administration Console, Global settings or
-Server settings, or General Information page.
-+
+Server settings, or General Information page. +
 Default = message purge is scheduled to run each minute.
 
-.CLI
-****
 When installing a reverse proxy the communication between the proxy server
 and the backend mailbox server must be in plain text. Checking *This server
 is a reverse proxy lookup target* automatically sets the following
 parameters:
 
 ----
-zimbraImapCleartextLoginEnabled=TRUE
-zimbraReverseProxyLookupTarget=TRUE
-zimbraPop3CleartextLoginEnabled=TRUE
+zimbraImapCleartextLoginEnabled TRUE
+zimbraReverseProxyLookupTarget TRUE
+zimbraPop3CleartextLoginEnabled TRUE
 ----
 
 The Notes text box can be used to record details you want to save.
-****
 
 === Change MTA Server Settings
 
-.Admin Console
-****
-The *MTA* page shows the following settings:
+Admin Console: ::
+*Home > Configure > Servers > _zmhostname_ > MTA*
+
+The *MTA* page show the following settings:
 
 * Authentication enabled.
 +
 Enables SMTP client authentication, so users can authenticate. Only
 authenticated users or users from trusted networks are allowed to relay
 mail. TLS authentication when enabled, forces all SMTP auth to use
-Transaction Level Security (similar to SSL) to avoid passing passwords in
+Transport Layer Security (successor to SSL) to avoid passing passwords in
 the clear.
 
 * Network settings, including Web mail MTA hostname, Web mail MTA time-out,
@@ -966,7 +916,6 @@ ability to enable DNS lookup for the server.
 +
 If *Enable Milter Server* is checked, the milter enforces the rules that
 are set up for who can send email to a distribution list on the server.
-****
 
 === Setting Up IP Address Binding
 
@@ -974,8 +923,8 @@ If the server has multiple IP addresses, you can use IP address binding
 to specify which specific IP addresses you want a particular server to
 bind to.
 
-*Admin Console: Home>Configure>Servers* <host name>; right-click for
-popup menu andselect *Edit> IP Address Bindings*
+Admin Console: ::
+*Home > Configure > Servers > _zmhostname_ > IP Address Bindings*
 
 .IP Address Bindings
 [cols=",",options="header",]
@@ -1013,8 +962,7 @@ its own creator.
 You can use the Certificate Installation Wizard to generate a new
 self-signed certificate. This is useful when you use a self-signed
 certificate and want to change the expiration date. Self-signed
-certificates are normally used for testing.
-+
+certificates are normally used for testing. +
 Default = 1825 days (5 years)
 
 * A *commercial certificate* is issued by a certificate authority (CA) that
@@ -1028,7 +976,7 @@ Server is used in your production environment.
 
 [IMPORTANT]
 ZCO users in a self-signed environment will encounter warnings about
-connection security unless the root CA certificate is added to the client’s
+connection security unless the root CA certificate is added to the client's
 Window Certificate Store. See the
 https://wiki.zimbra.com/wiki/Main_Page[Zimbra Wiki] article
 https://wiki.zimbra.com/wiki/ZCO_Connection_Security[ZCO Connection
@@ -1036,19 +984,17 @@ Security] for more information.
 
 === Installing Certificates
 
-To generate the CSR, you complete a form with details about the domain,
-company, and country, and then generate a CSR with the RSA private key.
-You save this file to your computer and submit it to your commercial
-certificate authorizer.
+To generate the Certificate Signing Request (CSR) you complete a form
+with details about the domain, company, and country, and then generate
+a CSR with the RSA private key.  You save this file to your computer
+and submit it to your commercial certificate authorizer.
 
 To obtain a commercially signed certificate, use the Zimbra Certificates
 Wizard in the Administration Console to generate the RSA Private Key and
-Certificate Signing Request (CSR).
+CSR.
 
-.Admin Console
-****
+Admin Console: ::
 *Home > 1 Get Started > 3. Install Certificates*
-
 
 Use guidelines from the Install Certificates table to set parameters for
 your certificates.
@@ -1090,7 +1036,6 @@ the server name to one of the SAN names.
 
 |=======================================================================
 
-****
 
 Download the CSR from the Zimbra server and submit it to a Certificate
 Authority, such as VeriSign or GoDaddy. They issue a digitally signed
@@ -1107,11 +1052,10 @@ You can view the details of certificates currently deployed. Details
 include the certificate subject, issuer, validation days and subject
 alternative name.
 
-.Admin Console
-****
-*Home > Certificates* and select a service host name.  Certificates display
-fordifferent Zimbra services such as LDAP, mailboxd, MTA and proxy.
-****
+Admin Console: ::
+*Home > Certificates > _zmhostname_*
+
+Certificates display for different Zimbra services such as LDAP, mailboxd, MTA and proxy.
 
 === Maintaining Valid Certificates
 
@@ -1133,8 +1077,6 @@ IP address.
 Each domain must be issued a signed commercial certificate that attests
 that the public key contained in the certificate belongs to that domain.
 
-.CLI
-****
 Configure the Zimbra Proxy Virtual Host Name and IP Address.
 [source,bash]
 ----
@@ -1144,15 +1086,13 @@ zmprov md <domain> +zimbraVirtualHostName {domain.example.com} +zimbraVirtualIPA
 [NOTE]
 The virtual domain name requires a valid DNS configuration with an A
 record.
-****
 
 Edit the certificate for the domain:
 
-.Admin Console
-****
+Admin Console: ::
 *Home > 1 Get Started > 3. Install Certificates*
 
-Copy the domain’s issued signed commercial certificate’s and private key
+Copy the domain's issued signed commercial certificate's and private key
 files to the *Domain Certificate* section for the selected domain.
 
 image:images/certificate_domain_load.jpg[Certificate Domain Load]
@@ -1161,7 +1101,7 @@ image:images/certificate_domain_load.jpg[Certificate Domain Load]
 order, starting with your domain certificate. This allows the full
 certificate chain to be validated.
 
-. Remove any password authentication from the private key before the
+. Remove any password (passphrase) from the private key before the
 certificate is saved.
 +
 See your commercial certificate provider for details about how to remove
@@ -1170,7 +1110,6 @@ the password.
 . Click *Upload*.
 +
 The domain certificate is deployed to `/opt/zimbra/conf/domaincerts`
-****
 
 == Using DKIM to Authenticate Email Message
 
@@ -1178,7 +1117,7 @@ Domain Keys Identified Mail (DKIM) defines a domain-level authentication
 mechanism that lets your organization take responsibility for transmitting
 an email message in a way that can be verified by a recipient. Your
 organization can be the originating sending site or an intermediary. Your
-organization’s reputation is the basis for evaluating whether to trust the
+organization's reputation is the basis for evaluating whether to trust the
 message delivery.
 
 You can add a DKIM digital signature to outgoing email messages,
@@ -1214,8 +1153,6 @@ other undesirable behavior.
 
 DKIM signing to outgoing mail is done at the domain level.
 
-.CLI
-****
 To set up DKIM you must run the CLI zmdkimkeyutil to generate the DKIM keys
 and selector. You then update the DNS server with the selector which is the
 public key.
@@ -1233,7 +1170,7 @@ that must be added for the domain to your DNS server.
 +
 Optional. To specify the number of bits for the new key, include `*-b*` in
 the command line, `-b <\####>`. If you do not add the `-b`, the default
-setting is 1024 bits.
+setting is 2048 bits.
 +
 ----
 DKIM Data added to LDAP for domain example.com with selector B534F5FC-EAF5-11E1-A25D-54A9B1B23156
@@ -1253,13 +1190,13 @@ the DKIM DNS text record.
 record.
 
 . Verify that the public key matches the private key, See the
-<<dkim_identifiers,, Identifiers>> table for `-d`, `-s`, and `-x`
+<<dkim_identifiers, Identifiers>> table for `-d`, `-s`, and `-x`
 descriptions.
 +
 --
 [source,bash]
 ----
-/opt/zimbra/opendkim/sbin/opendkim-testkey -d <example.com> -s <0E9F184A-9577-11E1-AD0E-2A2FBBAC6BCB> -x /opt/zimbra/conf/opendkim.conf
+/opt/zimbra/common/sbin/opendkim-testkey -d <example.com> -s <0E9F184A-9577-11E1-AD0E-2A2FBBAC6BCB> -x /opt/zimbra/conf/opendkim.conf
 ----
 
 [[dkim_identifiers]]
@@ -1273,7 +1210,6 @@ descriptions.
 
 |====================================================
 --
-****
 
 === Update DKIM Data for a Domain
 
@@ -1284,17 +1220,15 @@ Good practice is to leave the previous TXT record in DNS for a period of
 time so that email messages that were signed with the previous key can
 still be verified.
 
-.CLI
-****
 Log in to the {product-abbrev} server and as zimbra:
 [source,bash]
 ----
-opt/zimbra/libexec/zmdkimkeyutil -u -d <example.com>
+/opt/zimbra/libexec/zmdkimkeyutil -u -d <example.com>
 ----
 
 Optional. To specify the number of bits for the new key, include *-b* in
 the command line, `-b <\####>`. If you do not add the `-b`, the default
-setting is 1024 bits.
+setting is 2048 bits.
 
 . Work with your service provider to update your DNS for the domain with
 the DKIM DNS text record.
@@ -1307,9 +1241,8 @@ table for `-d`, `-s`, and `-x` descriptions.
 +
 [source,bash]
 ----
-/opt/zimbra/opendkim/sbin/opendkim-testkey -d <example.com> -s <0E9F184A-9577-11E1-AD0E-2A2FBBAC6BCB> -x /opt/zimbra/conf/opendkim.conf
+/opt/zimbra/common/sbin/opendkim-testkey -d <example.com> -s <0E9F184A-9577-11E1-AD0E-2A2FBBAC6BCB> -x /opt/zimbra/conf/opendkim.conf
 ----
-****
 
 === Remove DKIM Signing from {product-abbrev}
 
@@ -1319,39 +1252,32 @@ good practice is to leave the previous TXT record in DNS for a period of
 time so that email messages that were signed with the previous key can
 still be verified.
 
-.CLI
-****
 Use the following command syntax to remove the file:
 [source,bash]
 ----
 /opt/zimbra/libexec/zmdkimkeyutil -r -d example.com
 ----
-****
 
 === Retrieve DKIM Data for a Domain
 
-.CLI
-****
 Use the following command syntax to view the stored DKIM information for
 the domain, selector, private key, public signature and identity:
 [source,bash]
 ----
 /opt/zimbra/libexec/zmdkimkeyutil -q -d example.com
 ----
-****
 
 == Anti-spam Settings
 
 {product-abbrev} uses SpamAssassin to control spam. SpamAssassin uses predefined rules
 as well as a Bayes database to score messages. Zimbra evaulates spaminess
 based on percentage. Messages tagged between 33%-75% are considered spam
-and delivered to the user’s junk folder. Messages tagged above 75% are not
+and delivered to the user's junk folder. Messages tagged above 75% are not
 sent to the user and are discarded.
 
 You can change the anti-spam settings.
 
-.Admin Console
-****
+Admin Console: ::
 *Home > Configure > Global Settings > AS/AV*
 
 image:images/as_av.jpg[Anti-Spam Settings]
@@ -1369,14 +1295,12 @@ requirements.
 
 |Kill percent |
 Percent that scored mail to be considered as spam, and therefore not to be
-delivered.
-
+delivered. +
 Default = 75%
 
 |Tag percent |
 Percent that scores mail to be considered as spam, which should be
-delivered to the Junk folder.
-
+delivered to the Junk folder. +
 Default = 33%
 
 |Subject prefix |
@@ -1384,10 +1308,9 @@ Text string to be added to the subject line, for messages tagged as spam.
 
 |=======================================================================
 --
-****
 
 When a message is tagged as spam, the message is delivered to the
-recipient’s junk folder. Users can view the number of unread messages that
+recipient's junk folder. Users can view the number of unread messages that
 are in their junk folder and can open the junk folder to review the
 messages marked as spam. If you have the anti-spam training filters
 enabled, when users add or remove messages in the junk folder, their action
@@ -1447,9 +1370,6 @@ items from their junk folder.
 If you do not want users to train the spam filter you can disable this
 function.
 
-.CLI
-****
-
 . Modify the global configuration attributes, `ZimbraSpamIsSpamAccount` and
 `ZimbraSpamIsNotSpamAccount`
 
@@ -1463,7 +1383,6 @@ zmprov mcf ZimbraSpamIsNotSpamAccount ''
 
 When these attributes are modified, messages marked as spam or not spam are
 not copied to the spam training mailboxes.
-****
 
 === Manually Training Spam Filters
 
@@ -1489,8 +1408,6 @@ For information about creating domain aliases, see the
 https://wiki.zimbra.com[Zimbra wiki] article
 https://wiki.zimbra.com/wiki/Managing_Domains[Managing Domains].
 
-.CLI
-****
 . Set the Postfix LC key.
 +
 [source,bash]
@@ -1506,29 +1423,24 @@ zmprov mcf +zimbraMtaRestriction "check_policy_service unix:private/policy"
 ----
 
 The `postfix_policy_time_limit` key is set because by default the Postfix
-spawn (8) daemon kills its child process after 1000 seconds. This is too
+spawn(8) daemon kills its child process after 1000 seconds. This is too
 short for a policy daemon that might run as long as an SMTP client is
 connected to an SMTP process.
-****
 
 === Disabling Postfix Policy Daemon
 
-.CLI
-****
 Disable the SMTPD policy.
 [source,bash]
 ----
 zmlocalconfig -e postfix_enable_smtpd_policyd=no
 ----
-****
 
-.Admin Console
-****
+Admin Console: ::
+*Global Settings > MTA*
+
 Define the policy restriction.Setting Email Recipient
 RestrictionsRealtimeBlackhole Lists and Realtime Right-Hand Side
 Blocking/Black Lists can be turned on or off in the MTA.
-
-*Global Settings > MTA* page
 
 For protocol checks, the following three RBLs can be enabled:
 
@@ -1538,10 +1450,7 @@ For protocol checks, the following three RBLs can be enabled:
   `reject_non_fqdn_hostname`
 
 * Sender address must be fully qualified - reject_non_fqdn_sender
-****
 
-.CLI
-****
 Hostname in greeting violates RFC - `reject_invalid_host`
 [source,bash]
 ----
@@ -1557,38 +1466,26 @@ The following RBLs can also be set.
 
 As part of recipient restrictions, you can also use the
 `reject_rbl_client <rbl hostname>` option.
-****
 
-.Admin Console
-****
+Admin Console: ::
+*Home > Configure > Global Settings > MTA*, *DNS Checks*
+
 Use the DNS tools in MTA configuration to define the restriction lists.
-
-*Home > Configure > MTA > DNS*
 
 image:images/dns_checks.jpg[DNS Checks]
 
-****
-
-For a list of current RBL’s, see the
-http://en.wikipedia.org/wiki/Comparison_of_DNS_blacklists[Comparison of DNS
+For a list of current RBL's, see the
+https://en.wikipedia.org/wiki/Comparison_of_DNS_blacklists[Comparison of DNS
 blacklists] article.
 
 
 === Adding RBLs with the CLI
 
-.CLI
-****
-Log in to the server and go to the Zimbra directory.
-[source,bash]
-----
-su -zimbra
-----
-
 . View the current RBLs.
 +
 [source,bash]
 ----
-zmprov gacf | grep zimbraMtaRestriction
+zmprov gacf zimbraMtaRestriction
 ----
 
 . Add new RBLs: list the existing RBLs and the new Add, in the same command
@@ -1603,47 +1500,42 @@ zmprov mcf zimbraMtaRestriction [RBL type]
 =================================
 [source,bash]
 ----
-zmprov mcf zimbraMtaRestriction reject_invalid_hostname
-zimbraMtaRestriction reject_non-fqdn_hostname zimbraMtaRestriction
-reject_non_fqdn_sender zimbraMtaRestriction “reject_rbl_client
-cbl.abuseat.org” zimbraMtaRestriction “reject_rbl_client bl.spamcop.net”
-zimbraMtaRestriction “reject_rbl_client dnsbl.sorbs.net”
-zimbraMtaRestriction “reject_rbl_client sbl.spamhaus.org”
+zmprov mcf \
+ zimbraMtaRestriction reject_invalid_hostname \
+ zimbraMtaRestriction reject_non-fqdn_hostname \
+ zimbraMtaRestriction reject_non_fqdn_sender \
+ zimbraMtaRestriction "reject_rbl_client cbl.abuseat.org" \
+ zimbraMtaRestriction "reject_rbl_client bl.spamcop.net" \
+ zimbraMtaRestriction "reject_rbl_client dnsbl.sorbs.net" \
+ zimbraMtaRestriction "reject_rbl_client sbl.spamhaus.org"
 ----
 =================================
-****
 
 === Setting Global Rule for Messages Marked as Both Spam and Whitelist
 
 When you use a third-party application to filter messages for spam before
 messages are received by {product-abbrev}, the {product-abbrev} global rule is to send all messages
-that are marked by the third- party as spam to the junk folder. This
+that are marked by the third-party as spam to the junk folder. This
 includes messages that are identified as spam and also identified as
 whitelisted.
 
 If you do not want messages that are identified as whitelisted to be sent
 to the junk folder, you can configure `zimbraSpamWhitelistHeader` and
-`zimbraSpamWhitelistHeaderValue` to pass these messages to the user’s
+`zimbraSpamWhitelistHeaderValue` to pass these messages to the user's
 mailbox. This global rule is not related to the Zimbra MTA spam filtering
-rules. Messages are still passed through a user’s filter rules.
+rules. Messages are still passed through a user's filter rules.
 
-.CLI
-****
 To search the message for a whitelist header:
 [source,bash]
 ----
 zmprov mcf zimbraSpamWhitelistHeader <X-Whitelist-Flag>
 ----
-****
 
-.CLI
-****
 To set the value:
 [source,bash]
 ----
 zmprov mcf zimbraSpamWhitelistHeaderValue <value_of_third-party_white-lists_messages>
 ----
-****
 
 == Anti-virus Settings
 
@@ -1657,8 +1549,7 @@ days.
 From the Admin Console, you can specify ho aggressively spam is to be
 filtered in your {product-name}.
 
-.Admin Console
-****
+Admin Console: ::
 *Home > Configure > Global Settings > AS/AV*
 
 image:images/as_av.jpg[AS/AV]
@@ -1686,8 +1577,6 @@ To alert that a mail message had a virus and was not delivered.
 
 |=======================================================================
 
-****
-
 During {product-name} installation, the administrator notification
 address for anti- virus alerts is configured. The default is to set up
 the admin account to receive the notification. When a virus has been
@@ -1698,7 +1587,7 @@ Updates are obtained via HTTP from the ClamAV website.
 
 == Zimbra Free/Busy Calendar Scheduling
 
-The Free/Busy feature allows users to view each other’s calendars for
+The Free/Busy feature allows users to view each other's calendars for
 efficiently scheduling meetings. You can set up free/busy scheduling across
 {product-abbrev} and Microsoft Exchange servers.
 
@@ -1768,7 +1657,7 @@ Domain Free/Busy Interop page or on the Class of Service (COS) Advanced
 page. Set at the global level this applies to all accounts talking to
 Exchange.
 
-* In the Account’s Free/Busy Interop page, configure the foreign principal
+* In the Account's Free/Busy Interop page, configure the foreign principal
 email address for the account. This sets up a mapping from the
 {product-name} account to the corresponding object in the AD.
 
@@ -1785,8 +1674,6 @@ interoperability is configured on each server.
 [NOTE]
 Each server must be running {product-abbrev} 8.0.x or later.
 
-.CLI
-****
 . Enter the server host names and ports.
 +
 [source,bash]
@@ -1805,7 +1692,6 @@ zmcontrol restart
 ----
 
 . Repeat these steps at all other servers.
-****
 
 == Setting Up S/MIME
 
@@ -1815,7 +1701,7 @@ digital signature to authenticate and encrypt messages.
 === Prerequisites
 
 * To use S/MIME, users must have a PKI certificate and a private key.  The
-private key must be installed in the user’s local certificate store on
+private key must be installed in the user's local certificate store on
 Windows and Apple Mac and in the browser certificate store if they use the
 Firefox browser. See the appropriate computer or browser documentation for
 how to install certificates.
@@ -1837,22 +1723,23 @@ You must have a {product-abbrev} license that is enabled for S/MIME.
 
 === Enable S/MIME Feature
 
-.Admin Console
-****
+Admin Console: ::
+*Home > Configure > Class of Service*, _COS name_, *Features* page +
+*Home > Manage > Accounts*, _account name_, *Features* page
+
 The S/MIME feature can be enabled from either the COS or Account
 FeaturesTab.
 
 . Select the COS or account to edit.
-. In the Features tab S/MME features section, check *Enable S/MIME*.
+. In the Features tab S/MIME features section, check *Enable S/MIME*.
 . Click *Save*.
-****
 
 === Importing S/MIME Certificates
 
 Users can send encrypted messages to recipients if they have the
-recipients’ public-key certificate stored in one of the following:
+recipients' public-key certificate stored in one of the following:
 
-* Recipient’s contact page in their Address Book.
+* Recipient's contact page in their Address Book.
 * Local OS or browser keystore.
 * External LDAP directory.
 
@@ -1866,8 +1753,9 @@ If you use an external LDAP to store certificates, you can configure the
 Zimbra server to lookup and retrieve certificates from the external LDAP,
 on behalf of the client.
 
-.Admin Console
-****
+Admin Console: ::
+*Global Settings > S/MIME* +
+*Domains > S/MIME*
 
 You can configure the external LDAP server settings from either the *Global
 Settings > S/MIME* tab or the *Domains > S/MIME* tab.
@@ -1880,7 +1768,7 @@ Global Settings override Domain settings
 
 . In the *Configuration Name* field, enter a name to identify the external
 LDAP server. Example, *companyLDAP_1*
-. In the *LDAP URL* field, enter the LDAP server’s URL. Example,
+. In the *LDAP URL* field, enter the LDAP server's URL. Example,
 *ldap://host.domain:3268*
 . To use DN to bind to the external server, in the *S/MIME LDAP Bind DN*
 field, enter the bind DN. Example, *administrator@domain*
@@ -1904,14 +1792,13 @@ for expansion:
 * %n - search key with @ (or without, if no @ was specified)
 * %u - with @ removed (For example, mail=%n)
 . In the *S/MIME Ldap Attribute* field, enter attributes in the external
-LDAP server that contain users’ S/MIME certificates. Multiple attributes
+LDAP server that contain users' S/MIME certificates. Multiple attributes
 can be separated by a comma (,).
 +
 Example, "userSMIMECertificate, UserCertificate"
 . Click *Save*.
 
 To set up another external LDAP server, click *Add Configuration*.
-****
 
 == Storage Management
 
@@ -1934,7 +1821,7 @@ volume. You cannot change which volume the account is assigned.
 
 As volumes become full, you can create a new current index volume for new
 accounts. You can add new volumes, set the volume type, and set the
-compression threshold
+compression threshold.
 
 Index volumes not marked current are still actively in use for the accounts
 assigned to them. Any index volume that is referenced by a mailbox as its
@@ -1991,7 +1878,7 @@ cron table. From the Administration Console, when you select a server, you
 can manually start a HSM session, monitor HSM sessions, and abort HSM
 sessions that are in progress from the Volumes page.
 
-You can manually start an HSM session from the server’s gear icon menu.
+You can manually start an HSM session from the server's gear icon menu.
 
 When you abort a session and then restart the process, the HSM session
 looks for entries in the primary store that meet the HSM age criteria.  Any
@@ -2004,8 +1891,6 @@ or per server to specify the maximum number of items to move during a
 single HSM operation. The default value is 10000. If the limit is exceeded
 the HSM operation is repeated until all qualifying items are moved.
 
-.CLI
-****
 Global batch size modification:
 [source,bash]
 ----
@@ -2015,13 +1900,12 @@ zmprov mcf zimbraHsmBatchSize <num>
 Modifying batch size on a server:
 [source,bash]
 ----
-zmprov ms `hostname` zimbraHsmBatchSize <num>
+zmprov ms `zmhostname` zimbraHsmBatchSize <num>
 ----
-****
 
 == Email Retention Management
 
-You can configure retention policies for user account’s email, trash, and
+You can configure retention policies for user account's email, trash, and
 junk folders. The basic email retention policy is to set the email, trash
 and spam message lifetime in the COS or for individual accounts.
 
@@ -2054,20 +1938,16 @@ folders, and the trash and junk folders by COS or for individual accounts.
 
 |Email message lifetime |
 Number of days a message can remain in a folder before it is purged. This
-includes data in RSS folders.
-
-Default = 0
-
-Minimum configuration = 30 days
+includes data in RSS folders. +
+Default = 0 +
+Minimum = 30 days
 
 |Trashed message lifetime |
-Number of days a message remains in the Trash folder before it is purged.
-
+Number of days a message remains in the Trash folder before it is purged. +
 Default = 30 days.
 
-|Spam messageDefault = lifetime|
-Number of days a message can remain in the Junk folder before it is purged.
-
+|Spam message lifetime|
+Number of days a message can remain in the Junk folder before it is purged. +
 Default = 30 days.
 
 |=======================================================================
@@ -2081,8 +1961,7 @@ should "rest" between purging mailboxes.
 Use the global Sleep Time setting to define duration, in minutes, between
 mailbox purges.
 
-.Admin Console
-****
+Admin Console: ::
 *Home > Configure > Global Settings > General Information*
 
 image:images/GeneralInformation.jpg[Purge Interval]
@@ -2093,7 +1972,6 @@ purged of messages that meet the message lifetime setting, the server waits
 
 If the message purge schedule is set to 0, messages are not purged even if
 the mail, trash and spam message lifetime is set.
-****
 
 [NOTE]
 Because users cannot view message lifetime settings, you will
@@ -2105,7 +1983,7 @@ Retention and deletion policies can be configured as a global setting or
 as a COS setting. Users can select these policies to apply to their
 message folders in their account. They can also set up their own
 retention and deletion policies. Users enable a policy you set up or
-create their own policies from their folders’ Edit Properties dialog
+create their own policies from their folders' Edit Properties dialog
 box.
 
 === Global Retention Policy
@@ -2116,25 +1994,20 @@ Administration Console.
 Use the global Retention Policy page to set global retention or deletion
 policies.
 
-.Admin Console
-****
-*Home > Configure > Global Settings > Retention Policy*.
+Admin Console: ::
+*Home > Configure > Global Settings*, *Retention Policy* page
 
 image:images/GlobalRetentionPolicy.jpg[Global Retention Policy]
-
-****
 
 === COS Retention Policy
 
 Use the COS Retention Policy page to set retention or deletion for the
 selected COS.
 
-.Admin Console:
-****
-*Home > Configure > Global Settings > Retention Policy*
+Admin Console: ::
+*Home > Configure > Class of Service*, _COS name_, *Retention Policy* page
 
 image:images/COSRetentionPolicy.jpg[COS Retention Policy]
-****
 
 Ensure that the *Enable COS-level policies instead of inheriting from the
 policy defined in Global Settings* is enabled.
@@ -2142,7 +2015,7 @@ policy defined in Global Settings* is enabled.
 The retention policy is not automatically enforced on a folder. If users
 option an item in a folder that has not met the threshold of the retention
 policy, the following message is displayed, *You are deleting a message
-that is within its folder’s retention period. Do you wish to delete the
+that is within its folder's retention period. Do you wish to delete the
 message?*
 
 When the threshold for the deletion policy is reached, items are deleted
@@ -2179,47 +2052,40 @@ The *Retention lifetime in dumpster before purging setting* sets retention
 lifetime for items in dumpster. Items in dumpster older than the threshold
 are purged and cannot be retrieved.
 
-Administrators can access the individual dumpster’s content, including
+Administrators can access the individual dumpster's content, including
 spam, and they can delete data at any time before the message lifetime is
 reached.
 
 ==== Searching for an item in the dumpster folder
 
-.CLI
-****
 [source,bash]
 ----
-zmmailbox -z -m <user@example.com> s --dumpster -l <#> --types <message,contact,document> <search-field>
+zmmailbox -z -m <user@example.com> search --dumpster -l <#> --types <message,contact,document> <search-field>
 ----
 
-The search field can be a date range: 'before:mm/dd/yyyy and after:mm/dd/
-yyyy' or emails from or to a particular person: 'from: Joe', etc.
-****
+The search field can be a date range: 'before:mm/dd/yyyy and
+after:mm/dd/yyyy' or emails from or to a particular person:
+'from:Joe', etc.
 
 ==== Deleting items in the dumpster folder
 
 Items in the dumpster folder can be deleted with the CLI or from the
 Administration Console:
 
-.CLI
-****
 [source,bash]
 ----
 zmmailbox -z -m <user@example.com> -A dumpsterDeleteItem <item-ids>
 ----
-****
 
-.Admin Console
-****
-*Home > Configure > Class of Service* <COS name>, Features* page, *General
-*Features* section.
+Admin Console: ::
+*Home > Configure > Class of Service* _COS name_, *Features* page,
+*General Features* section.
 
 . Enable (check) the Dumpster folder checkbox.
-. To set *Visibility lifetime in dumpster for end user*, go to the COS’s,
+. To set *Visibility lifetime in dumpster for end user*, go to the COS's,
 *Advanced* page, *Timeout Policy* section.
-. To set *Retention lifetime in dumpster before purging*, go to the COS’s
+. To set *Retention lifetime in dumpster before purging*, go to the COS's
 *Advanced* page, *Email Retention Policy* section.
-****
 
 === Configure Legal Hold on an Account
 
@@ -2227,23 +2093,22 @@ If the dumpster folder feature is enabled, you can set up a legal hold to
 preserve all items in user accounts.
 
 When dumpster is enabled, *Can purge dumpster folder* is also enabled.
-Disabling this feature turns off purging of items in the user’s
-dumpster. This can be set by a COS or for individual accounts. When *Can
-purge dumpster* *folder* is enabled, any deletion policies set up on the
-accounts’ folders areignored.
+Disabling this feature turns off purging of items in the user's
+dumpster. This can be set on a COS or for individual accounts. When *Can
+purge dumpster folder* is enabled, any deletion policies set up on the
+accounts' folders are ignored.
 
-.Admin Console
-****
 Configure legal hold on a COS account:
 
-*Configure > Class of Service > Features* page and deselect *Can purge
-dumpster folder*.
+Admin Console: ::
+*Configure > Class of Service > Features* page +
+deselect *Can purge dumpster folder*
 
 Configure legal hold on individual accounts:
 
-*Manage > Accounts*; select the account, then *Disable* the feature on
-the *Features* page.
-****
+Admin Console: ::
+*Manage > Accounts*, select the _account_ +
+*Disable* the feature on the *Features* page.
 
 == Customized Admin Extensions
 
@@ -2254,7 +2119,7 @@ extend existing objects with new properties, and customize existing views.
 For the most up-to-date and comprehensive information about how to create
 an extended Administration Console UI module, go to the Zimbra wiki
 Extending Admin UI article located at
-http://wiki.zimbra.com/wiki/Extending_Admin_UI[Extending_Admin_UI].
+https://wiki.zimbra.com/wiki/Extending_Admin_UI[Extending_Admin_UI].
 
 All Zimbra extensions currently incorporated at the Administration Console
 UI are listed in the content pane as view only.
@@ -2264,13 +2129,11 @@ Modules).
 
 === Deploying New Administration Console UI Modules
 
-.Admin Console
-****
+Admin Console: ::
+*Home > Configure > Admin Extensions*
 
 Save the module Zip file to the computer you use to access the
 Administration Console.
-
-*Home > Configure > Admin Extensions*
 
 . From the *Gear* icon, select *Deploy* to present the *Deploying a Zimlet
 or an extension* dialog.
@@ -2279,7 +2142,6 @@ or an extension* dialog.
 +
 The file is uploaded and the extension is immediately deployed on the
 server.
-****
 
 === Removing An Admin Extension Module
 
@@ -2287,14 +2149,12 @@ Deleting an Admin Extension results in removal of the selected extension
 and all associated files. This action does not delete the originating zip
 file.
 
-.Admin Console
-****
-Use steps in this section to remove custom Admin Extensions.
-
+Admin Console: ::
 *Home > Configure > Admin Extensions*
+
+Use steps in this section to remove custom Admin Extensions.
 
 . Select the module to remove, and select *Undeploy* from the *Gear*
 icon. A confirmation query is presented.
 
 . At the confirmation query, click *Yes* to proceed.
-****


### PR DESCRIPTION
- prefer https to http in URLs
- avoid smartquotes and emdashes
- fix typos and invalid examples
- fix some inconsistency of term usage (still more that could be done)
- fix some bogus data from format conversion
- attempt to improve some of the formatting conversion