### PR TITLE
Second big run at cleanup:

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -6,11 +6,11 @@ image:https://i.creativecommons.org/l/by-sa/4.0/88x31.png[CC BY-SA] Synacor, Inc
 This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
 International License unless another license agreement between you and
 Synacor, Inc. provides otherwise. To view a copy of this license, visit
-http://creativecommons.org/licenses/by-sa/4.0 or send a letter to Creative
+https://creativecommons.org/licenses/by-sa/4.0 or send a letter to Creative
 Commons, PO Box 1866, Mountain View, CA 94042, USA.
 
 Synacor, Inc., 2016 +
 40 La Riviere Drive, Suite 300 +
 Buffalo, New York 14202
 
-http://www.synacor.com
+https://www.synacor.com

--- a/README.adoc
+++ b/README.adoc
@@ -57,11 +57,11 @@ image:https://i.creativecommons.org/l/by-sa/4.0/88x31.png[CC BY-SA] Synacor, Inc
 This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
 International License unless another license agreement between you and
 Synacor, Inc. provides otherwise. To view a copy of this license, visit
-http://creativecommons.org/licenses/by-sa/4.0 or send a letter to Creative
+https://creativecommons.org/licenses/by-sa/4.0 or send a letter to Creative
 Commons, PO Box 1866, Mountain View, CA 94042, USA.
 
 Synacor, Inc., 2016 +
 40 La Riviere Drive, Suite 300 +
 Buffalo, New York 14202
 
-http://www.synacor.com
+https://www.synacor.com

--- a/adminconsole.adoc
+++ b/adminconsole.adoc
@@ -20,9 +20,9 @@ created. You can perform administration tasks from the Administration
 Console or the command line.
 
 * *Delegated Administrators* are granted customized administrator roles
-bythe global administrator to manage different tasks from the
-Administration Console. See also <<delegated_administration, Delegated
-Administration>> for more details.
+by the global administrator to manage different tasks from the
+Administration Console.
+See also <<delegated_administration,Delegated Administration>> for more details.
 
 == Logging in to the Administration Console
 
@@ -53,32 +53,24 @@ From the Administration Console, use the *Change Password* screen to set
 the new password string, and to define policy for user password
 modifications.
 
-.Admin Console
-****
-*Home> Manage> Accounts*; select/highlight user account
+Admin Console: ::
+*Home > Manage > Accounts*
 
-or
-
-From the *Gear* icon, select *Change Password* from the popup menu.
+Double click select _user account_ *or* from the *Gear* icon, select
+*Change Password* from the popup menu.
 
 image::images/administration_console_password.png[Change Password]
-****
 
-.CLI
-****
 [source,bash]
 ----
 zmprov sp adminname@domain.com password
 ----
-****
 
 === Customizing the Login and Logout Pages
 
 A different login and logout page can be configured either as a global
 setting or as a domain setting.
 
-.CLI
-****
 To specify a URL to redirect administrators if their login is not
 authenticated, or if authentication has expired:
 
@@ -93,10 +85,7 @@ Domain:
 ----
 zmprov md <domain> zimbraAdminConsoleLoginURL <https://example.com>
 ----
-****
 
-.CLI
-****
 To specify a URL to redirect administrators, for logging out:
 
 Global:
@@ -110,7 +99,6 @@ Domain:
 ----
 zmprov md <domain> zimbraAdminConsoleLogoutURL <https://example.com>
 ----
-****
 
 == Managing Tasks
 
@@ -198,11 +186,11 @@ the Navigation Pane.
 
 The Navigation pane options are described in the following topics:
 
-* <<home_ui, Home UI>>.
-* <<monitor_ui, Monitor UI>>.
-* <<manage_ui, Manage UI>>.
-* <<configure_ui, Configure UI>>.
-* <<global_settings_ui, Global Settings UI>>.
+* <<home_ui,Home UI>>.
+* <<monitor_ui,Monitor UI>>.
+* <<manage_ui,Manage UI>>.
+* <<configure_ui,Configure UI>>.
+* <<global_settings_ui,Global Settings UI>>.
 * <<tools_and_migration_ui,Tools and Migration UI>>.
 * <<search_ui,Search UI>>.
 
@@ -226,7 +214,7 @@ image::images/administration_console_home_ui.png[Home UI]
 <9> Navigation Pane
 
 .Home UI
-[cols=",a",options="header",]
+[cols="1,3a",options="header",]
 |=======================================================================
 |Topic |Description
 |Summary |
@@ -244,30 +232,28 @@ Length.
 | 1 Get Started |
 Displays the steps essential to getting started with your {product-name}
 operations, and provides quick inks to the functions in this UI:
---
-.  Install Licenses
+
+. Install Licenses
 . Configure Back-ups
 . Install Certificates
 . Configure Default COS
---
 
 | 2 Set up Domain |
 Displays the steps you use to establish the domain(s) to be managed by the
 Collaborator. Each step is a link to the function in this UI:
---
+
 . Create Domain
 . Configure GAL...
 . Configure Authentication
---
 
 |3 Add Accounts |
 Displays the steps for adding accounts for management by the
 Collaborator. Each step is a link to the function in this UI:
---
+
 . Add Account
 . Manage Accounts
 . Migration and Co-existence
---
+
 |=======================================================================
 
 [[monitor_ui]]
@@ -297,7 +283,7 @@ monitored servers and services listed in the following table.
 Adobe Flash Player must be activated to enable views of the dynamic charts.
 
 .Monitor UI
-[cols=",a",options="header",]
+[cols="1,3a",options="header",]
 |=======================================================================
 |Option |Description
 |Server Status |
@@ -308,14 +294,14 @@ Collaborator.
 System-wide Information page, for Advanced Statistics, which allows you to
 set up a new monitoring chart using parameters from the selection fields
 available from this page: Server, Group, Start, end, and Counters.
-+
+
 From this Advanced Statistics page, you can also elect to perform the
 following operations:
---
+
 * Hide Chart Settings
 * Update Chart
 * Remove Chart
---
+
 |Message Count |
 System-wide Information page, for Message Counts, to examine charts
 depicting counts over the last 48, 30, 60, and 365 days. The information
@@ -389,7 +375,7 @@ image::images/administration_manage_ui.png[Manage UI]
 <8> Navigation Pane
 
 .Manage UI
-[cols=",a",options="header",]
+[cols="1,3a",options="header",]
 |=======================================================================
 |*Option* |*Description*
 |Accounts (count) |
@@ -467,7 +453,7 @@ image::images/administration_console_configure_ui.png[Configure UI]
 <7> Configure Navigation Pane
 
 .Configure UI
-[cols=",a",options="header",]
+[cols="1,3a",options="header",]
 |=======================================================================
 |*Option* |*Description*
 |Class of Service |
@@ -595,7 +581,7 @@ can change the settings at any time from Global Settings at the
 Administration Console.
 
 .Global Settings UI
-[cols=",a",options="header",]
+[cols="1,3a",options="header",]
 |=======================================================================
 |*Option* |*Description*
 |General Information |
@@ -605,8 +591,8 @@ Administration Console.
 * Configure the number of threads that can be used toget the content from
 the remote data sources.
 
-For more information, see <<general_information_configuration, General
-Information Configuration>>
+For more information,
+see <<general_information_configuration,General Information Configuration>>
 --
 
 | Attachments |
@@ -617,7 +603,8 @@ Information Configuration>>
 * Convert attachments to HTML for viewing.
 --
 
-For more information, see <<attachments_configuration, Attachments Configuration>>.
+For more information,
+see <<attachments_configuration,Attachments Configuration>>.
 
 | MTA |
 --
@@ -627,7 +614,8 @@ For more information, see <<attachments_configuration, Attachments Configuration
 * Add X-Originating-IP message headers.
 --
 
-For more information, see <<mta_configuration, MTA Configuration>>.
+For more information,
+see <<mta_configuration,MTA Configuration>>.
 
 |IMAP |
 Enable IMAP service. Changes to these settings do not take effect until the
@@ -650,7 +638,8 @@ not take effect until the server is restarted.
 Change to theme settings require the server theme cache to be flushed, by
 using the Flush Cache toolbar button at Server settings.
 
-For more information, see <<color_and_logo_management, Color and Logo Management>>.
+For more information,
+see <<color_and_logo_management,Color and Logo Management>>.
 
 |Advanced |
 --
@@ -683,7 +672,7 @@ edit, or delete an ACE.
 
 |Backup/Restore |
 Set parameters for backup-for standard or auto- grouped mode. For more
-information see the <<backup_and_restore, Backup and Restore>>.
+information see <<backup_and_restore,Backup and Restore>>.
 
 | HSM |
 (hierarchical storage management): Configure aging of message before it is
@@ -716,7 +705,7 @@ image::images/administration_console_tools_and_migration_ui.png[Tools and Migrat
 <7> _Tools and Migration_ Navigation Pane
 
 .Tools and Migration
-[cols=",",options="header",]
+[cols="1,3",options="header",]
 |=======================================================================
 |Option |Description
 
@@ -725,22 +714,20 @@ Access Zimbra utilities, which provides downloadable zip packages - for
 general administration use, and to synchronize an individual end user -
 containing migration wizards for various platforms, and Outlook connectors.
 Additional information is provided in
-<<downloadable_wizards_and_connectors, Downloadable Wizards and
-Connectors>>.
+<<downloadable_wizards_and_connectors,Downloadable Wizards and Connectors>>.
 
 | Software Updates |
 Find out if your system needs a Zimbra Server update or not, and use this
 page to view polling and email contact information pertinent to software
 updates for your system.
 
-See also <<checking_for_updates, Checking for {product-name} Software
-Updates>>.
+See also <<checking_for_updates,Checking for {product-name} Software Updates>>.
 
 | Account Migration |
 View tabular details about account migrations, as detected by your
 system. This page lists total imports, and status of each. This page also
 provides the name(s) of the owners for each account migration listed. See
-also <<migrating_accounts, Migrating Accounts from a Zimbra Server>>.
+also <<migrating_accounts,Migrating Accounts from a Zimbra Server>>.
 
 |Client Upload |
 Use this page to browse for the latest version of software to be uploaded
@@ -755,7 +742,8 @@ pane to view backup history as associated with the
 selected administrator. The history lists labels, start and end times.
 and success or failure for each backup occurrence; each of these are
 associated with the identical, displayed directory path to the backup
-target. Additional information is provided in <<backup_and_restore, Backup and Restore>>.
+target. Additional information is provided in
+<<backup_and_restore,Backup and Restore>>.
 
 |=======================================================================
 
@@ -845,7 +833,7 @@ image::images/administration_console_search_ui.png[Search UI]
 
 
 .Search UI
-[cols=",",options="header",]
+[cols="1,3",options="header",]
 |===========================================================
 |*Option* |*Description*
 |All Result |
@@ -941,7 +929,7 @@ Each row in a table enables actions you can perform if you require
 additional information and/or access to configuration for the selected
 table entry.
 
-[cols=",,a"]
+[cols="1,2,2a"]
 |====================================================
 |Action at Table Row |Result |
 
@@ -991,23 +979,17 @@ multiple messages to be displayed.
 When creating a message with your command entry, always place double quote
 marks at the beginning and end of the message to be displayed.
 
-.CLI
-****
 Creating a global message or domain-specific message.
 [source,bash]
 ----
 zmprov md <domain> zimbraAdminConsoleLoginMessage "message to display"
 ----
-****
 
-.CLI
-****
 Creating a multiple-message display:
 [source,bash]
 ----
 zmprov md <domain> +zimbraAdminConsoleLoginMessage "second message to display"
 ----
-****
 
 === Removing Message(s) of the Day
 
@@ -1025,23 +1007,17 @@ the beginning and end of an individual message to be deleted.
 * Use single quote marks with the attribute to remove all messages.
 --
 
-.CLI
-****
 Removing a specific message:
 [source,bash]
 ----
 zmprov md <domain> -zimbraAdminConsoleLoginMessage "message to display"
 ----
-****
 
-.CLI
-****
 Removing all messages:
 [source,bash]
 ----
 zmprov md <domain> zimbraAdminConsoleLoginMessage ''
 ----
-****
 
 == Functional Reference
 
@@ -1091,7 +1067,7 @@ The following table provides a high-level view of the operations derived
 from the Gear icon, which vary for particular functions.
 
 .Gear Icon Operations
-[cols=",,a",options="header"]
+[cols="1,1,3a",options="header"]
 |=======================================================================
 |Navigation Pane Topic |Selections |Options image:images/gear_icon.png[Gear Icon]
 .2+|*Home Monitor*
@@ -1189,8 +1165,7 @@ image::images/administration_console_popup_menus.png[Popup Options]
 A wide range of Configuration options are logically grouped into containers
 in the Administration Console. Applicable configuration options inside
 these containers are listed in the
-<<high_level_view_of_administration_console_ui, High-level View of
-Administration Console UI>>
+<<high_level_view_of_administration_console_ui,High-level View of Administration Console UI>>
 
 By default, all containers in a page are opened (expanded). You can opt to
 close (collapse) containers - which can free up additional space in a page

--- a/archive.adoc
+++ b/archive.adoc
@@ -136,8 +136,6 @@ installed.
 The upgrade process begins and the archiving package is installed. At
 this point, the Discovery feature is installed and can be used.
 
-.CLI
-****
 To enable archiving, switch user to *zimbra* and enable archiving on the
 MTA server.
 [source,bash]
@@ -150,7 +148,6 @@ Restart the server.
 ----
 zmcontrol restart
 ----
-****
 
 === Installing zimbra-archiving in a Multi-Server Environment
 
@@ -161,11 +158,11 @@ Before beginning the install process, record the following information.
 You need this information when you install the archiving server. Run the
 `zmlocalconfig -s` command to find the information.
 
-LDAP Admin Password `_ _ _ _ _ _ _ _ _ _ _ _`
-
-LDAP Hostname `_ _ _ _ _ _ _ _ _ _ _ _`
-
-LDAP Port `_ _ _ _ _ _ _ _ _ _ _ _`
+----
+LDAP Admin Password _____________________
+LDAP Hostname       _____________________
+LDAP Port           _____________________
+----
 
 Refer to the Multiple-Server Installation chapter in the {product-name}
 Multi-Server Installation guide for detailed steps on installing the
@@ -177,10 +174,10 @@ software. Run the `./install.sh` command to begin the install process.
 
 . Type *y* and press *Enter* to install the following packages:
 +
-* zimbra-store
-* zimbra-archiving
+* `zimbra-store`
+* `zimbra-archiving`
 +
-The zimbra-core package is installed by default.
+The `zimbra-core` package is installed by default.
 
 . Type *y* and press *Enter* to modify the system.
 
@@ -205,20 +202,15 @@ the Administration Console.
 
 === Enable Archiving
 
-.Admin Console
-****
-Go to the *Global Settings > MTA* page; at the Archiving Configuration
-section, check *Enable archiving*.
-****
+Admin Console: ::
+*Home > Configure > Global Settings > MTA*,
+from *Archiving Configuration* check *Enable archiving*
 
-.CLI
-****
 Restart {product-abbrev} from the command line
 [source,bash]
 ----
 zmcontrol restart
 ----
-****
 
 === Creating a Dedicated Archive COS
 
@@ -226,10 +218,8 @@ You can configure attributes in the COS to set mailbox features, quotas,
 and passwords, turn off spam and virus checks, and hide the archive
 accounts from GAL.
 
-.Admin Console
-****
-
-Go to *Configure > Class of Service*; from the Gear icon menu select *New*.
+Admin Console: ::
+*Home > Configure > Class of Service*, from the *Gear* icon select *New*
 
 . Change *Features* and *Preferences* as required for an Archiving COS.
 
@@ -255,7 +245,6 @@ accounts, modify the two template fields. See the
 section for more information.
 
 . Click *Finish*.
-****
 
 [[setting_up_an_archive_account_name]]
 === Setting Up an Archive Account Name
@@ -266,11 +255,11 @@ COS, these attributes can be changed from the Administration Console, COS
 or individual account’s Archiving page.
 
 * *Account date template*. Sets the date format used in the name
-template.The default is yyyyMMdd. Adding the date to the account name makes
+template. The default is `yyyyMMdd`. Adding the date to the account name makes
 it easier to roll off older data from the system to backups.
 
 * *Account name template*. Sets up how the archive mailbox name is
-created.The default value is `${USER} ${DATE}@${DOMAIN}.archive`.
+created. The default value is `${USER} ${DATE}@${DOMAIN}.archive`.
 
 The archive account address would be similar to the following example:
 
@@ -323,11 +312,11 @@ You can create an archive mailbox with or without an assigned COS. You
 can also forward archive email to a third-party.
 
 [NOTE]
-Accounts with archiving enabled are counted against the number of Zimbra
-licenses purchased for archiving. To see current license information, go to
-the Administration Console, *Global Settings > License* page. Archive
-mailboxes are listed in the Administration Console along with the live
-accounts.
+Accounts with archiving enabled are counted against the number of
+Zimbra licenses purchased for archiving.  Archive mailboxes are listed
+in the Administration Console along with the live accounts. To see
+current license information, go to the Administration Console: +
+*Home > Configure > Global Settings > License*.
 
 === Creating an archive mailbox and assigning a COS
 
@@ -341,14 +330,11 @@ account and set to TRUE.
 * When a message is received in a mailbox with archiving enabled, a copy of
 the message is sent to the archive mailbox.
 
-.CLI
-****
-Log on as zimbra, and use the zmarchiveconfig command:
+Log on as `zimbra`, and use the `zmarchiveconfig` command:
 [source,bash]
 ----
 zmarchiveconfig enable <account@example.com> archive-cos <archive>
 ----
-****
 
 === Creating an Archive Mailbox with No COS or Password
 
@@ -362,28 +348,24 @@ set by default.
 * Hide in GAL is enabled, so the archive account does not display in the
   GAL
 
-.CLI
-****
-Log on as zimbra, and use the `zmarchiveconfig` command:
+Log on as `zimbra`, and use the `zmarchiveconfig` command:
 [source,bash]
 ----
 zmarchiveconfig enable <user@example.com>
 ----
-****
 
 === Enabling Archive Forwarding to a Third-party Archiving Server
 
 If the archive account is not maintained within {product-name},
 you do not need to set a password, COS, or other attributes.
 
-.CLI
-****
-Log on as zimbra, and use the `zmarchiveconfig` command:
+Log on as `zimbra`, and use the `zmarchiveconfig` command:
 [source,bash]
 ----
-zmarchiveconfig enable <account@example.com> archive-address account-archive@offsiteserver.com archive-create false
+zmarchiveconfig enable <account@example.com> \
+ archive-address account-archive@offsite.com \
+ archive-create false
 ----
-****
 
 == Searching Across Mailboxes
 
@@ -403,8 +385,10 @@ mailbox search tool.
 
 The discovery tool, *Search Mail*, is added to *Tools and Migration* on the
 Navigation pane when the archiving package is added. To set up a cross
-mailbox search, in Search Mail, go to the gear icon and select New. You
-configure the following information.
+mailbox search you configure the following information.
+
+Admin Console: ::
+*Home > Tools and Migration > Search Mail*, from the *Gear* icon select *New*
 
 * *Server name*. The server name to be searched.
 

--- a/backuprestore.adoc
+++ b/backuprestore.adoc
@@ -19,8 +19,8 @@ on every {product-name} server and performs both backup and
 restore functions. You do not have to stop the {product-name}
 server in order to run the backup process. The backup manager can be
 used to restore a single user, rather than having to restore the entire
-system in the event that one user’s mailbox becomes corrupted. Full and
-incremental backups are saved in in `opt/zimbra/backup`.
+system in the event that one user's mailbox becomes corrupted. Full and
+incremental backups are saved in in `/opt/zimbra/backup`.
 
 
 === Redo Log
@@ -99,7 +99,7 @@ are replayed to bring the system to the point before the failure.
 The Zimbra MTA is not backed up, as the data is only on the server for a
 very short time.
 
-Custom configurations—such as mailboxd’s server.xml—are not backed up.
+Custom configurations -- such as mailboxd's `jetty/etc/*.xml` -- are not backed up.
 
 ==== Backup Notifcation
 
@@ -126,10 +126,11 @@ automatically at the scheduled times.
 
 The backup destination is known as a backup target. To the backup
 system, it is a path in the file system of the mail server. The Zimbra
-default backup directory is +/opt/zimbra/backup+.
+default backup directory is `/opt/zimbra/backup`.
 
 The backup directory structure created by the standard backup process is
-shown in <<standard_backup_directory_structure, Standard Backup directory structure>>.
+shown in
+<<standard_backup_directory_structure,Standard Backup directory structure>>.
 You can run regularly scheduled backups to the same target area without
 overwriting previous backup sessions.
 
@@ -142,9 +143,9 @@ used to look up the latest full Backup for an account during restore. If
 the accounts.xml file is missing you must specify the backup label to
 restore from.
 
-The redo log directory is located at +/opt/zimbra/redolog/redo.log+. When
+The redo log directory is located at `/opt/zimbra/redolog/redo.log`. When
 the current redo log file size reaches 100MB, the current redo log rolls
-over to an archive directory, +/opt/zimbra/redolog/archive+. At this
+over to an archive directory, `/opt/zimbra/redolog/archive`. At this
 point the server starts a new redo log. All uncommitted transactions
 from the previous redo log are preserved. In the case of a crash, when
 the server restarts, the current redo logs are read to re-apply any
@@ -163,91 +164,91 @@ target. Standard full backup sessions can use a different target
 directory.
 
 .Standard Backup directory structure
-[cols=",",options=""]
+[cols="1,3",options=""]
 |=======================================================================
-|+/opt/zimbra/backup+ |
+|`/opt/zimbra/backup` |
 Default root of backups
 
-|+accounts.xml/+ |
+|`accounts.xml/` |
 List of all accounts, each with email file address, Zimbra ID, and latest
 full backup label. The accounts.xml maintains the mapping of email
 addresses to their current zimbraIds and also the most recent full backup
 for each account.
 
-|+sessions/+ |
+|`sessions/` |
 Root of backup sessions.
 
-|+full-<timestamp>/+ |
+|`full-<timestamp>/` |
 A full backup directory. The timestamp for a session is the backup start
 time in GMT, including milliseconds. GMT is used rather than local time to
 preserve visual ordering across daylight savings transitions.
 
-|+session.xml+ |
+|`session.xml` |
 Metadata about this backup label for full or incremental session, such as
 start and stop times.
 
-|+shared_blobs/+ |
+|`shared_blobs/` |
 Contains message files that are shared among accounts in this backup.
 
-|+sys/+ |
+|`sys/` |
 Global database tables and localconfig.
 
-|+db_schema.xml+ |
+|`db_schema.xml` |
 Database schema information for global tables. Each table dump file has a
 .csv format.
 
-|+localconfig.xml+ |
-Copy of +/opt/zimbra/conf/localconfig.xml+ at the time of the backup.
+|`localconfig.xml` |
+Copy of `/opt/zimbra/conf/localconfig.xml` at the time of the backup.
 
-|+<table name>.dat+ |
+|`<table name>.dat` |
 Database table data dump.
 
-|+LDAP/ldap.bak+ |
+|`LDAP/ldap.bak` |
 LDAP dumps.
 
-|+accounts/+ |
-Each account’s data is saved in a subdirectory of this.
+|`accounts/` |
+Each account's data is saved in a subdirectory of this.
 
-|+<.../zimbraId>/+ |
+|`<.../zimbraId>/` |
 Root for each account.
 
-|+meta.xml+ |
-Metadata about this account’s backup.
+|`meta.xml` |
+Metadata about this account's backup.
 
-|+ldap.xml+ |
-Account’s LDAP information, including aliases, identities, data sources,
+|`ldap.xml` |
+Account's LDAP information, including aliases, identities, data sources,
 distribution lists, etc.
 
-|+ldap_latest.xml+ |
+|`ldap_latest.xml` |
 If this is present, this files links to ldap.xml of the most recent
 incremental backup.
 
-|+db/+ |
+|`db/` |
 Account-specific database table dumps.
 
-|+db_schema.xml+ |
-Database schema information for this account’s tables.
+|`db_schema.xml` |
+Database schema information for this account's tables.
 
-|+<table name>.dat+ |
+|`<table name>.dat` |
 Database table data dump.
 
-|+blobs/+ |
+|`blobs/` |
 Contains blob files.
 
-|+index/+ |
+|`index/` |
 Contains Lucene index files.
 
-|+incr-<timestamp>+ |
+|`incr-<timestamp>` |
 An incremental backup directory. This directory is similar to the full
 backup directory schema and includes these meta files.
 
-|+session.xml+ |
+|`session.xml` |
 
-|+sys/db_schema.xml+ |
+|`sys/db_schema.xml` |
 
-|+accounts/..../<zimbraID>/ldap.xml+ |
-+incr-<timestamp>+ does not include
-+accounts/.../<zimbraId>/db/db_schema.xml+ because incremental backup does
+|`accounts/.../<zimbraID>/ldap.xml` |
+`incr-<timestamp>` does not include
+`accounts/.../<zimbraId>/db/db_schema.xml` because incremental backup does
 not dump account tables.
 
 |=======================================================================
@@ -279,8 +280,9 @@ backups into.
 The standard backup is the default and is automatically scheduled. You do
 not need to make any additional changes. But when running the auto-grouped
 backup you must manually configure the backup schedule. To do so, access
-the CLI and follow the steps under <<scheule_auto_group_backups, Schedule
-Auto-Group Backups>> to run +zmschedulebackup -D+ to set the default
+the CLI and follow the steps under
+<<scheule_auto_group_backups,Schedule Auto-Group Backups>>
+to run `zmschedulebackup -D` to set the default
 schedule for auto-grouped backups.
 
 *Throttling option with auto-grouped backup.* The auto-grouped backup
@@ -292,47 +294,40 @@ Enabling *Throttle automatic* *backups* limits the mailbox count in a
 daily backup to T/N. This breaks theconstraint of backing up all
 mailboxes in N days, but it helps backup to finish during off hours.
 
-.CLI
-****
-When all mailboxes are backed up at least once, disable
-throttling:
+When all mailboxes are backed up at least once, disable throttling:
 [source, bash]
 ----
 zmprov mcf zimbraBackupAutoGroupedThrottled TRUE
 ----
-****
 
 == Backup and Restore Using the Command Line Interface
 
 The Zimbra backup and restore procedures can be run as CLI commands.
 
-.CLI
-****
 The following utilities are provided to create backup schedules,
 perform full and incremental backups, restore the mail server, or
 restore the LDAP server.
 
-* +zmschedulebackup+. This command is used to schedule full backups,
+* `zmschedulebackup` -- This command is used to schedule full backups,
 incremental backups, and deletion of old backups.
-* +zmbackup+. This command executes full or incremental backup of the mail
+* `zmbackup` -- This command executes full or incremental backup of the mail
 server. This is run on a live server, while the mailboxd process and the
 mailbox server are running. This command also has an option to manually
 delete old backups when they are no longer needed.
-* +zmbackupabort+. This command stops a full backup that is in process.
-* +zmbackupabort -r+. This command stops an ongoing restore.
-* +zmbackupquery+. This command lists the information about ongoing and
+* `zmbackupabort` -- This command stops a full backup that is in process.
+* `zmbackupabort -r` -- This command stops an ongoing restore.
+* `zmbackupquery` -- This command lists the information about ongoing and
 completed backups, including labels and dates.
-* +zmrestore+. This command executes a full or incremental restore to the
+* `zmrestore` -- This command executes a full or incremental restore to the
 Zimbra mail server. The *zmrestore* command is performed on a server
 that is running.
-* +zmrestoreoffline+. This command restores the Zimbra mail server when
+* `zmrestoreoffline` -- This command restores the Zimbra mail server when
 the mailboxd process is stopped.
-* +zmrestoreldap+. This command restores the complete LDAP directory
+* `zmrestoreldap` -- This command restores the complete LDAP directory
 server, including accounts, domains, servers, COS and other data.
 
-Refer to <<appendix_a, Appendix A Command Line Utilities>>
+Refer to <<appendix_a,Appendix A Command Line Utilities>>
 for usage and definitions for each of these commands.
-****
 
 == Backing up using the Standard Method
 
@@ -352,22 +347,22 @@ crontab. Under the default schedule, the full backup is scheduled for
 By default, backups older than a month are deleted every night at 12
 a.m.
 
-You can change the backup schedule using the +zmschedulebackup+ command.
+You can change the backup schedule using the `zmschedulebackup` command.
 
 Specify the fields as follows, separate each field with a blank space:
 
-* minute — 0 through 59
-* hour — 0 through 23
-* day of month — 1 through 31
-* month — 1 through 12
-* day of week — 0 through 7 (0 or 7 is Sunday, or use names)
+* minute -- 0 through 59
+* hour -- 0 through 23
+* day of month -- 1 through 31
+* month -- 1 through 12
+* day of week -- 0 through 7 (0 or 7 is Sunday, or use names)
 
 Type an asterisk (*) in the fields you are not using.
 
-*Example of* +zmschedulebackup+ *options*
-
+.`zmschedulebackup` options
+========
 * Replace the existing full backup, incremental backup and delete backup
-schedule. When you use +-R+, the complete backup schedule is replaced. If
+schedule. When you use `-R`, the complete backup schedule is replaced. If
 you use this command, remember to set the delete schedule, if you want
 backup sessions to be scheduled for automatic deletion. This example
 replaces the existing schedule to have full backups run on Sunday at 1
@@ -401,8 +396,8 @@ zmschedulebackup -s
 ----
 
 [NOTE]
-If you change the default schedule and want to return to it,
-enter the command +zmschedulebackup -D+.
+To return backups to the default schedule use the command `zmschedulebackup -D`.
+========
 
 ==== Default Standard Backup Schedule
 
@@ -443,11 +438,11 @@ Read as follows:
 ****
 Each crontab entry contains six fields that appear in this order:
 
-[options="header",]
+[cols="1,1,1,1,1,5",options="header",]
 |=======================================================================
 6+|Field
 |*1* |*2* |*3* |*4* |*5* |*6*
-|*0* |*1* |* |* |*6* |+/opt/zimbra/bin/zmbackup -f -all+
+|*0* |*1* |* |* |*6* |`/opt/zimbra/bin/zmbackup -f -all`
 |=======================================================================
 
 . minute (0-59 allowed)
@@ -460,40 +455,42 @@ Sunday
 
 [NOTE]
 The asterisk character works as a wild card, representing every
-occurrence of the field’s value.
+occurrence of the field's value.
 ****
 
+Admin Console: ::
+*Home > Configure > Global Settings > Backup/Restore*
+
 You can add additional recipient addresses or change the notification email
-address in the Administration Console *Global Settings>Backup/Restore*
-page.
+address in the Administration Console.
 
 === Full Backup Process
 
 The full backup process goes through the following steps to backup the
 mailbox, the database, the indexes, and the LDAP directory:
 
-. Backs up the global system data including system tables and the
-local config.xml file.
+. Backs up the global system data including system tables and
+`localconfig.xml`.
 . Iterates through each account to be backed up and backs up the LDAP
 entries for those accounts.
-. Places the account’s mailbox in maintenance mode to temporarily
+. Places the account's mailbox in maintenance mode to temporarily
 block mail delivery and user access to that mailbox.
 . Backs up the mailbox.
-.. Creates MySQL dump for all data related to that mailbox.
+.. Creates MariaDB dump for all data related to that mailbox.
 .. Backs up the message directory for that mailbox.
 .. Creates a backup of the index directory for that mailbox.
-. Returns that account’s mailbox to active mode and moves on to the
+. Returns that account's mailbox to active mode and moves on to the
 next one.
 . Backs up the LDAP directory.
 
 Full backup is usually run asynchronously. When you begin the full
 backup, the label of the ongoing backup process is immediately
 displayed. The backup continues in the background. You can use the
-+zmbackupquery+ command to check the status of the running backup at any
+`zmbackupquery` command to check the status of the running backup at any
 time.
 
 Backup files are saved as zip files without compression. To change the
-default zip option, see <<appendix_a, Appendix A Command Line Interface>>,
+default zip option, see <<appendix_a,Appendix A Command Line Interface>>,
 zmbackup section.
 
 === Incremental Backup Process
@@ -501,19 +498,19 @@ zmbackup section.
 Incremental backups are run using the CLI command, *zmbackup*. The
 process for incremental backup is as follows:
 
-. Backs up the global system data including system tables and the
-local +config.xml+.
+. Backs up the global system data including system tables and
+`localconfig.xml`.
 
 . Iterates through each account to be backed up and backs up the LDAP
 entries for those accounts.
 
 . Moves the archive redo logs, created since the last backup, to the
-+<backup target>/redologs+ directory.
+`<backup_target>/redologs` directory.
 +
 Archived logs that are less than an hour old at the time of incremental
 backup are copied to the backup and are not deleted. These redologs are
 deleted one hour after the backup. The interval is set by the
-localconfig key +backup_archived_redolog_keep_time+. The default is 3600
+localconfig key `backup_archived_redolog_keep_time`. The default is 3600
 seconds.
 +
 If no full backup for this account is found, the backup process performs
@@ -524,10 +521,7 @@ specified.
 
 ==== Performing Manual Backups
 
-.CLI
-****
-Use the zmbackup command to perform the following backup
-operations:
+Use the zmbackup command to perform the following backup operations:
 
 * Perform a manual back up all mailboxes on server<1>:
 [source,bash]
@@ -540,12 +534,11 @@ since last full backup
 ----
 zmbackup -i -s server1.domain.com -a all
 ----
-* Perform a manual, full backup of only *user1’s* mailbox on *server1*
+* Perform a manual, full backup of only *user1's* mailbox on *server1*
 [source,bash]
 ----
 zmbackup -f -s server1.domain.com -a user1@domain.com
 ----
-****
 
 ==== Deleting Backup Sessions
 
@@ -556,18 +549,15 @@ that session.
 * Deleting by date deletes all backup session prior to the specified
 date.
 
-.CLI
-****
-For example, +zmbackup -del 7d+ deletes backups older than 7 days
-from now. You can specify day (+d+), month (+m+), or year (+y+).
-****
+For example, `zmbackup -del 7d` deletes backups older than 7 days
+from now. You can specify day (`d`), month (`m`), or year (`y`).
 
 === Finding a Specific Backups
 
 Each full or incremental backup is a backup session.
 
 Each backup session is labeled with date and time. For example, the
-label +full-20070712.155951.123+ says this is a backup from July 12,
+label `full-20070712.155951.123` says this is a backup from July 12,
 2007 at 3:59:51.123.
 
 [NOTE]
@@ -575,9 +565,7 @@ The times set in the session label are GMT, not the local time. GMT is used
 rather than local time to preserve visual ordering across daylight savings
 transitions.
 
-.CLI
-****
-Use the +zmbackupquery+ command to find full backup sessions.
+Use the `zmbackupquery` command to find full backup sessions.
 
 * To find a specific full backup session:
 [source,bash]
@@ -600,22 +588,21 @@ time window
 ----
 zmbackupquery -a user1@example.com --type full --from "2007/07/05 12:01:15" --to "2007/07/12 17:01:45"
 ----
-****
 
 [NOTE]
 If a backup session is interrupted because the server crashes during backup
 (not aborted), the interrupted backup session is saved as a temporary
-session. The temporary backup session is put in +<backup
-target>/sessions_tmp+ directory. You can use the +rm+ command to delete the
+session. The temporary backup session is put in
+`<backup_target>/sessions_tmp` directory. You can use the `rm` command to delete the
 directory.
 
 == Aborting a Full Backup in Progress
 
 . Before you can abort a backup, you must know the backup session
-label. This label is displayed when +zmbackup+ first starts. If you do not
-know the full backup label, use +zmbackupquery+ to find the label.
+label. This label is displayed when `zmbackup` first starts. If you do not
+know the full backup label, use `zmbackupquery` to find the label.
 
-.  Use the +zmbackupabort+ command to stop a backup that is in progress.
+.  Use the `zmbackupabort` command to stop a backup that is in progress.
 The backup is immediately stopped and becomes a partially successful
 backup.
 +
@@ -636,13 +623,9 @@ zmbackupabort -s server1 -lb full-20070712.155951.123
 The auto-grouped backup method is configured either from the
 Administration Console or from the CLI.
 
-.Admin Console
-****
-*Configure> Global Settings*, *Backup/Restore* page, or,
-to set it by servers:
-
-*Configure> Servers* <server> *Backup/Restore* page.
-****
+Admin Console: ::
+*Home > Configure > Global Settings > Backup/Restore* or +
+*Home > Configure > Servers -> _server_ -> Backup/Restore*
 
 === Configuring Auto-Grouped Backup from the CLI
 
@@ -650,36 +633,31 @@ Set the backup method in the global configuration, and you can override
 the configuration on a per server basis if you do not want a particular
 server to use the auto-grouped backup method.
 
-.CLI
-****
 To set up auto-grouped backup, you modify LDAP attributes with
 the zmprov command:
 [source, bash]
 ----
 zmprov mcf <ldap_attribute> <arg>
 ----
-You can also set the attributes at the server level using +zmprov ms+.
+You can also set the attributes at the server level using `zmprov ms`.
 
 The following LDAP attributes are modified:
 
-* +zimbraBackupMode+. Set it to be *Auto-Grouped*. The default is
+* `zimbraBackupMode` -- Set it to be *Auto-Grouped*. The default is
 Standard.
-* +zimbraBackupAutoGroupedInterval+. Set this to the interval in either
+* `zimbraBackupAutoGroupedInterval` -- Set this to the interval in either
 days or weeks that backup sessions should run for a group. The default
 is 1d. Backup intervals can be 1 or more days, entered as xd (1d); or 1
 or more weeks, entered as xw (1w).
-* +zimbraBackupAutoGroupedNumGroups+. This is the number of groups to
+* `zimbraBackupAutoGroupedNumGroups` -- This is the number of groups to
 spread mailboxes over. The default is 7 groups.
-****
 
 === Schedule Auto-Group Backups
 
 You must configure the auto-group backup schedule.
 
-.CLI
-****
-Run +zmschedulebackup -D+ to set the default schedule for
-auto-grouped backups based on your +zimbraBackupAutoGroupedInterval+
+Run `zmschedulebackup -D` to set the default schedule for
+auto-grouped backups based on your `zimbraBackupAutoGroupedInterval`
 setting.
 
 One group is backed up each interval. The auto- grouped backup
@@ -703,15 +681,14 @@ one-seventh of the total are backed up again. Accounts with the oldest
 backup date are backed up first. The backup continues with newly
 provisioned account and approximately one-seventh of accounts being
 backed up daily over seven days.
-****
 
 When backing up shared messages, if a file representing a message
 already exists in the backup, it flags this object as such and does not
 copy its content again.
 
 Backup files are saved as zip files without compression. To change the
-default zip option, see <<appendix_a, Appendix A Command Line Interface>>, zmbackup
-section.
+default zip option, see <<appendix_a,Appendix A Command Line Interface>>,
+zmbackup section.
 
 These backup files can be used to restore the complete {product-name}
 system or individual mailboxes so that account and message data is
@@ -723,56 +700,56 @@ failure.
 == Backup Options
 
 The backup process can be configured to selectively back up content and
-to backup the MySQL database.
+to backup the MariaDB database.
 
 === Backup Up content Options
 
 You can configure these backup options so that search indexes, blobs,
 and HSM blobs are not backed up during a full backup session.
 
-* +zimbraBackupSkipSearchIndex+. Default is *FALSE*. If set to *TRUE*,
+* `zimbraBackupSkipSearchIndex` -- Default is *FALSE*. If set to *TRUE*,
 search index is not backed up. The mailbox will have to be reindexed
 after restoring from a backup without the search index.
-* +zimbraBackupSkipBlobs+. The default is *FALSE*. If this is set to
+* `zimbraBackupSkipBlobs` -- Default is *FALSE*. If this is set to
 *TRUE*, blobs are not backed up. This might be useful for getting a
 quicker backup of just database data when the blobs reside on a
 fault-tolerant storage. This configuration applies to all blobs, those
 on the primary volumes as well as secondary (HSM) volumes.
-* +zimbraBackupSkipHsmBlobs+. The default is false. If this is set to
-true, blobs on HSM volumes are no backed up. Set this if
-+zimbraBackupSkipBlobs+ is false but you want to skip blobs on HSM
+* `zimbraBackupSkipHsmBlobs` -- Default is *FALSE*. If this is set to
+*TRUE*, blobs on HSM volumes are no backed up. Set this if
+`zimbraBackupSkipBlobs` is *FALSE* but you want to skip blobs on HSM
 volumes.
 
-=== Back Up the MySQL Database
+=== Back Up the MariaDB Database
 
 You can configure {product-name} backups to run mysqldump to
-backup your MySQL database during backup sessions. When this is enabled,
+backup your MariaDB database during backup sessions. When this is enabled,
 a mysqldump backup runs with each full, incremental, and auto-grouped
 backup.
 
-The mysqldump is a backup of your MySQL database at a specific time.
+The mysqldump is a backup of your MariaDB database at a specific time.
 Data changes that occur later than the dump file are written to the
-binary log.To recover to a specific point in time, binary logging must
-be enabled. See the Zimbra wiki article, MySQL Backup and Restore at
+binary log. To recover to a specific point in time, binary logging must
+be enabled. See the Zimbra wiki article, MariaDB Backup and Restore at
 https://wiki.zimbra.com/wiki/MySQL_Backup_and_Restore.
 
-The MySQL dump files are gzipped and placed in the backup target
-directory, or to +/opt/zimbra/backup+, if no directory is specified.
+The MariaDB dump files are gzipped and placed in the backup target
+directory, or to `/opt/zimbra/backup`, if no directory is specified.
 
 These files can be quite large. Make sure that the free disk space is at
-least three times greater than the actual mySQL database file for each
-mySQL database backup file that is saved.
+least three times greater than the actual MariaDB database file for each
+MariaDB database backup file that is saved.
 
 * Enable mysqldump to run automatically with your backups, type
 [source, bash]
 ----
 zmlocalconfig edit mysql_backup_retention=<N>
 ----
-*N* is the number of copies of the mySQL database backups that
+*N* is the number of copies of the MariaDB database backups that
 areretained.
 
 [NOTE]
-To restore a MySQL database, contact Zimbra support for assistance.
+To restore a MariaDB database, contact Zimbra support for assistance.
 
 == Managing Disk Space for Backups
 
@@ -782,29 +759,24 @@ data backed up in the backup session is discarded and deleted.
 You can choose to receive notification when your disk might not have
 enough space to complete the backup
 
-.CLI
-****
-Configuring the +zimbraBackupMinFreeSpace+ attribute helps you
+Configuring the `zimbraBackupMinFreeSpace` attribute helps you
 manage running backup session by notifying you.
 
-Set the value for attribute +zimbraBackupMinFreeSpace+ to the amount of
+Set the value for attribute `zimbraBackupMinFreeSpace` to the amount of
 free space required on the backup target disk before a backup session is
 run. If the disk has less space than the value set in the attribute, the
 backup session will not run and an email notification is sent to the
 administrator.
 
 [NOTE]
-If you are also backing up the MySQL database, make sure you set the value
+If you are also backing up the MariaDB database, make sure you set the value
 large enough to include the myslqdump file size.
 
 The value for this attribute can be specified as a percentage of the
 total disk space, for example 25%, or as number of bytes, for example
 300MB, 50GB, etc. The default value is 0, meaning the check is disabled
 and backup is always allowed to start.
-****
 
-.CLI
-****
 The attribute can be set globally or by server.
 
 * As global:
@@ -823,25 +795,20 @@ set. If your backup file is larger than the value, the backup session
 fails. You should monitor the size of the backup files and adjust the
 attribute value if the backup require more space than the configured
 value.
-****
 
 == Restoring Data
 
 Three types of restore procedures can be run:
 
-.CLI
-****
-
 The `zmrestore` command is used to restore the mailboxes while the
 {product-name} mailbox server is running.
 
-* +zmrestoreoffline+ — to restore the mail server when the mail server is
+* `zmrestoreoffline` -- to restore the mail server when the mail server is
 down. This command is run for disaster recovery.
-* +zmrestoreldap+ — to restore the content of the LDAP directory server.
+* `zmrestoreldap` -- to restore the content of the LDAP directory server.
 
 The restore process allows all accounts or individual accounts to be
 specified.
-****
 
 === Restore Process
 
@@ -852,7 +819,7 @@ mailbox, the database, the indexes, and the LDAP directory.
 all accounts that have been backed up.
 .  Iterates through each mailbox:
 ..  Deletes the mailbox on the server to clear any existing data
-..  Restores the last full backup of the MySQL data, the index directory,
+..  Restores the last full backup of the MariaDB data, the index directory,
 and the message directory for that mailbox
 ..  Replays redo logs in all incremental backups since last full backup
 ..  Replays all archived redo logs for that mailbox, from the redo log
@@ -902,15 +869,15 @@ restore problems with those accounts.
 A restore that is run using any of the following options is a
 point-in-time restore:
 
-* +-restoreToTime+ *<arg>* - Replay the redo logs until the time
+* `-restoreToTime` *<arg>* - Replay the redo logs until the time
 specified.
-* +-restoreToIncrLabel+ *<arg>* - Replay redo logs up to and including
+* `-restoreToIncrLabel` *<arg>* - Replay redo logs up to and including
 this incremental backup.
-* +-restoreToRedoSeq+ *<arg>* - Replay up to and including this
+* `-restoreToRedoSeq` *<arg>* - Replay up to and including this
 redo log sequence.
-* +-br+ - Replays the redo logs in backup only, therefore excluding
+* `-br` - Replays the redo logs in backup only, therefore excluding
 archived and current redo logs of the system.
-* +-rf+ - Restores to the full backup only. This does not include any
+* `-rf` - Restores to the full backup only. This does not include any
 incremental backups at all.
 ====
 
@@ -924,8 +891,8 @@ zmrestore -a account@company.com-restoreToTime <arg>
 ----
 Two common ways to write the <timearg> are
 
-* +"YYYY/MM/DD hh:mm:ss"+
-* +YYYYMMDD.hhmmss+
+* `"YYYY/MM/DD hh:mm:ss"`
+* `YYYYMMDD.hhmmss`
 ====
 
 .Perform an incremental restore only to last full backup, excluding incremental backups since then, for all accounts
@@ -955,7 +922,7 @@ The result from the above example would be an account called
 restoreaccount@company.com.
 ====
 
-.Restore system tables in the database (db) and the local config
+.Restore system tables in the database (db) and `localconfig.xml`
 ====
 [source,bash]
 ----
@@ -963,13 +930,13 @@ zmrestore -sys
 ----
 ====
 
-.Include +--contineOnError+ (+-c+) to the command so that the restore process continues if an error is encountered.
+.Include `--contineOnError` (`-c`) to the command so that the restore process continues if an error is encountered.
 ====
 [source,bash]
 ----
 zmrestore -a all -c
 ----
-When +-c+ is designated, accounts that could not be restored are displayed
+When `-c` is designated, accounts that could not be restored are displayed
 when the restore process is complete.
 ====
 
@@ -1002,13 +969,13 @@ zmrestore -a account@company.com --skipDeletes
 ----
 [NOTE]
 When the latest point in time is requested, do not add a backup label
-(+-lb+). Without specifying the label, the most recent full backup before the
+(`-lb`). Without specifying the label, the most recent full backup before the
 requested point is automatically used as the starting point.
 ====
 
 === Stop a Restore Process
 
-The +zmbackupabort -r+ command interrupts a restore that is in process.
+The `zmbackupabort -r` command interrupts a restore that is in process.
 The restore process stops after the current account finishes being
 restored. The command displays a message showing which accounts were not
 restored.
@@ -1048,7 +1015,7 @@ does not specify any mailbox address, the list of all mailboxes on the
 specified mail host are retrieved from Zimbra LDAP directory server.
 . Iterates through each mailbox:
 .. Deletes the mailbox on the server to clear any existing data
-.. Restores the last full backup of the MySQL data, the index
+.. Restores the last full backup of the MariaDB data, the index
 directory, and the message directory for that mailbox
 .. Replays redo logs in all incremental backups since last full backup
 .. Replays all archived redo logs for that mailbox, from the redo log
@@ -1073,7 +1040,7 @@ zmcontrol startup
 === Restore Individual Accounts on a Live System
 
 Use the *zmrestore* command to restore one or more selected accounts. In
-the event that a user’s mailbox has become corrupted, you might want to
+the event that a user's mailbox has become corrupted, you might want to
 restore that user from the last full and incremental backup sets.
 
 . For each account to be restored, put the account into maintenance mode
@@ -1086,7 +1053,7 @@ zmprov ma <account> zimbraAccountStatus maintenance
 Maintenance mode prevents delivery of new emails during the restore.
 Otherwise, the emails would be overwritten during the restore process.
 
-. Run the +zmrestore+ command to restore the accounts
+. Run the `zmrestore` command to restore the accounts
 +
 [source,bash]
 ----
@@ -1109,7 +1076,7 @@ longer exists, the default COS is assigned to the account.
 When you restore from a full backup, you can exclude the search index
 and blobs.
 
-* *Search index*. If you do not restore the search index data, the
+* *Search index* -- If you do not restore the search index data, the
 mailbox willhave to be reindexed after the restore.
 +
 [source,bash]
@@ -1117,7 +1084,7 @@ mailbox willhave to be reindexed after the restore.
 zmrestore -a <all|account> --exclude-search-index
 ----
 
-* *Blobs*. This is a useful option when all blobs for the mailbox being
+* *Blobs* -- This is a useful option when all blobs for the mailbox being
 restoredalready exists.
 +
 [source,bash]
@@ -1125,7 +1092,7 @@ restoredalready exists.
 zmrestore <all or account>|--exclude-blobs
 ----
 
-* *HSM-blobs*. This is useful when all HSM blobs for the mailbox
+* *HSM-blobs* -- This is useful when all HSM blobs for the mailbox
 beingrestored already exists.
 +
 [source,bash]
@@ -1218,14 +1185,14 @@ installation guide.
 You do the following to restore to a new server:
 
 .  Prepare the new server.
-.  Block client access to the old server’s IP address with firewall
+.  Block client access to the old server's IP address with firewall
 rules.
 .  Mount any volumes that were in use on the older server.
-.  Delete the MySQL data that is set up in the initial installation of
+.  Delete the MariaDB data that is set up in the initial installation of
 {product-name}.
 .  Copy the backup files to the new server.
-.  Run +zmrestoreldap+ to restore the global LDAP data.
-.  Run +zmrestoreoffline+ to restore account data from the backup
+.  Run `zmrestoreldap` to restore the global LDAP data.
+.  Run `zmrestoreoffline` to restore account data from the backup
 sessions.
 .  Prepare and run a new backup.
 
@@ -1242,11 +1209,11 @@ is still running, but the server hardware needs to be replaced.
 
 *If server is still running, to prepare the move to the new server:*
 
-.  Block client access to the server’s IP address with firewall rules.
+.  Block client access to the server's IP address with firewall rules.
 .  Run a full backup of the old service, or if the backup is recent,
 run an incremental backup to get the most current incremental backup
 session.
-.  Run +zmcontrol stop+, to stop {product-name}. In order to
+.  Run `zmcontrol stop`, to stop {product-name}. In order to
 restore to the most current state, no new mail should be received after
 the last incremental backup has run.
 .  Change the hostname and IP address on the old server to something
@@ -1272,14 +1239,14 @@ server.
 .  Copy the {product-name} License.xml file to a directory on the
 new server. You cannot complete the {product-name} installation if
 the license is not on the new server.
-.  Run +./install.sh+ and follow the directions in the installation guide
+.  Run `./install.sh` and follow the directions in the installation guide
 to install {product-name}. Make sure that you configure the same
 domain, hostname, passwords as on the old server. During Zimbra
 Collaboration install, the following settings must be changed to match
 the original server settings:
-..  *Zimbra LDAP Server*. For *Domain to create*, identify the same
+..  *Zimbra LDAP Server* -- For *Domain to create*, identify the same
 defaultdomain as on the old server.
-..  *Zimbra Mailbox Server*. An administrator’s account is
+..  *Zimbra Mailbox Server* -- An administrator's account is
 automaticallycreated.
 * Make sure that the account name for *Admin user to create* is the same
 name as on the original server.
@@ -1290,7 +1257,7 @@ the old server
 * Change the *Spam training user* and the *Non-spam (HAM) training*
 *user* account names to be the same as the spam account names onthe old
 server.
-* *Global Document Account* – This account name is
+* *Global Document Account* -- This account name is
 automatically generated and is usually named wiki. If you changed this,
 change the Global Document Account name to be the same account name as
 on the original server.
@@ -1311,7 +1278,7 @@ zmcontrol stop
 .  If the old server had additional storage volumes configured, mount
 the additional volumes now.
 
-.  Delete the mysql data and reinitialize an empty data directory. If
+.  Delete the MariaDB data and reinitialize an empty data directory. If
 you do not do this, zmrestoreoffline will have errors. As zimbra, type
 +
 [source,bash]
@@ -1319,10 +1286,10 @@ you do not do this, zmrestoreoffline will have errors. As zimbra, type
 rm -rf /opt/zimbra/db/data/* /opt/zimbra/libexec/zmmyinit
 ----
 +
-The mySQL service is now running.
+The MariaDB service is now running.
 
-.  Copy all the files in the +/backup+ directory from the old server or
-from an archive location to +/opt/zimbra/backup+.
+.  Copy all the files in the `/backup` directory from the old server or
+from an archive location to `/opt/zimbra/backup`.
 
 .  Restore the LDAP.
 +
@@ -1336,11 +1303,11 @@ such as the UNIX command, nohup, so that the session does not terminate
 before the restore is complete.
 +
 [NOTE]
-To find the LDAP session label to restore, type +zmrestoreldap –lbs+.
+To find the LDAP session label to restore, type `zmrestoreldap –lbs`.
 
 .  Because some {product-name} services are running at this
-point, type +zmconvertctl start+. This is required before running
-+zmrestoreoffline+.
+point, type `zmconvertctl start`. This is required before running
+`zmrestoreoffline`.
 
 .  Sync your LDAP password from backup directory to the new production
 servers LDAP config.
@@ -1358,15 +1325,15 @@ zmrestoreoffline -sys -a all -c -br
 ----
 +
 You might run a command such as nohup here also. To watch the progress,
-tail +/opt/zimbra/log/mailbox.log+.
+tail `/opt/zimbra/log/mailbox.log`.
 +
 [NOTE]
-Use +–c+ on the command line so that accounts are restored,
+Use `–c` on the command line so that accounts are restored,
 even if some accounts encounter errors during the offline restore
 process.
 
 .  Because some {product-name} services are running at this
-point, type +zmcontrol stop+ to stop all services.
+point, type `zmcontrol stop` to stop all services.
 
 .  Remove any old backup sessions because these sessions are no longer
 valid.
@@ -1405,10 +1372,10 @@ type of failure.
 .  Reinstall the LDAP server. See the {product-name} Installation
 guide.
 .  Find the label for the LDAP session to restore. Run the
-+zmrestoreldap - lb <label>+ command, with no arguments to restore all
+`zmrestoreldap - lb <label>` command, with no arguments to restore all
 accounts, domains, servers, COS, etc. for the LDAP server.
 .  Make sure that all accounts are in active mode. From the command
-line, type +zmprov ma zimbraAccountStatus active+
+line, type `zmprov ma zimbraAccountStatus active`
 
 ==== Restore After Replacing Corrupted Partitions
 
@@ -1485,30 +1452,30 @@ latest data backed up, because the latest redo log is not available.
 
 === Change Local Configuration Files After Restoring Zimbra
 
-The +localconfig.xml+ file, located in the +/opt/zimbra/conf+ directory,
+The `localconfig.xml` file, located in the `/opt/zimbra/conf` directory,
 includes the core Zimbra server configuration, such as paths and passwords,
 This file is backed up in full and incremental backups. When you run an
-incremental or full restore, the backed-up version of the +localconfig.xml+
-is renamed localconfig.xml.restore and is copied to the +/opt/zimbra/conf+
+incremental or full restore, the backed-up version of the `localconfig.xml`
+is renamed `localconfig.xml.restore` and is copied to the `/opt/zimbra/conf`
 directory.
 
 If you have made changes since the last backup, you might need to replace
 the localconfig.xml file with the restored copy. Compare these files, and
 if the *.restore* file has the latest local configuration data, delete the
-localconfig.xmlfile and rename the file with the +.restore+ extension to
-localconfig.xml.
+`localconfig.xml` file and rename the file with the `.restore` extension to
+`localconfig.xml`.
 
 == Using snapshots to Backup and Restore
 
 You can back up and restore a server using the snapshot feature provided
-by the storage layer rather than using Zimbra’s backup and restore
+by the storage layer rather than using Zimbra's backup and restore
 feature. Using snapshots, you can maintain a standby site if the primary
 site fails and reroute users to the standby site to keep operations
 running.
 
 Snapshots are taken for all volumes of data and are transferred to the
 standby site periodically. Data volumes that are backed up using
-snapshots include mysql, blobs, lucene index, and redologs.
+snapshots include MariaDB, blobs, lucene index, and redologs.
 
 When the primary site is down, the zmplayredo command is used to bring
 consistency to the snapshots and to reapply any changes in data to
@@ -1516,7 +1483,7 @@ minimize data loss across volumes
 
 There are four volumes of data:
 
-* Mysql
+* MariaDB
 * Blob
 * Lucene index
 * Redologs
@@ -1527,38 +1494,28 @@ could be a second to a minute apart from each other. Also, snapshots of
 redologs may be taken more frequently. The sequence of events could look
 like:
 
-+8:00:00+ - snapshot mysql
-
-+8:00:01+ - snapshot blob
-
-+8:00:02+ - snapshot index
-
-+8:00:03+ - snapshot redolog
-
-+8:05:00+ - transfer the snapshot set to remote site completed
-
+----
+8:00:00 - snapshot mysql
+8:00:01 - snapshot blob
+8:00:02 - snapshot index
+8:00:03 - snapshot redolog
+8:05:00 - transfer the snapshot set to remote site completed
 ...
-
-+8:15:00+ - snapshot redolog
-
-+8:15:05+ - transfer of redolog snapshot to remote site completed
-
+8:15:00 - snapshot redolog
+8:15:05 - transfer of redolog snapshot to remote site completed
 ...
-
-+8:30:00+ - snapshot redolog
-
-+8:30:05+ - transfer of redolog snapshot to remote site completed
-
+8:30:00 - snapshot redolog
+8:30:05 - transfer of redolog snapshot to remote site completed
 ...
-
-+8:35:00+ - primary site fails
+8:35:00 - primary site fails
+----
 
 On the remote site, there are snapshots from the 8:00 set of data as
 well as subsequent snapshots of the redologs. They all have to be
 brought together so that the most recent information is available on the
 standby site once users are rerouted to it.
 
-You can now run the +zmplayredo+ command to replay changes from 8:00:00.
+You can now run the `zmplayredo` command to replay changes from 8:00:00.
 
 [source,bash]
 ----

--- a/cmdlineutils.adoc
+++ b/cmdlineutils.adoc
@@ -80,313 +80,311 @@ image:images/cli.png[CLI]
 
 The table below lists the CLI commands in `/opt/zimbra/bin`.
 
-[cols=",",options="header",]
+[cols="1m,3",options="header",]
 |=======================================================================
 |CLI |Description
 
-|`antispam-mysqladmin` |
+|antispam-mysqladmin |
 anti-spam SQL server admin utility
 
-|`antispam-mysql` |
+|antispam-mysql |
 anti-spam SQL client
 
-|`antispam-mysql.server` |
+|antispam-mysql.server |
 Start, stop the anti-spam SQL instance
 
-|`ldap` |
+|ldap |
 Start, stop, or find the status of Zimbra LDAP
 
-|`ldapsearch` |
+|ldapsearch |
 Perform a search on an LDAP server
 
-|`logmysqladmin` |
+|logmysqladmin |
 Send mysqladmin commands to the logger SQL instance
 
-|`mysql` |
+|mysql |
 Enters interactive command-line for the mailbox SQL instance
 
-|`mysql.server` |
+|mysql.server |
 Start, stop the mailbox SQL instance
 
-|`mysqladmin` |
+|mysqladmin |
 Send admin commands to the mailbox SQL instance
 
-|`postconf` |
-
+|postconf |
 Postfix command to view or modify the postfix configuration
 
-|`postfix` |
+|postfix |
 Start, stop, reload, flush, check, upgrade-configuration of postfix
 
-|`qshape` |
+|qshape |
 Examine postfix queue in relation to time and sender/recipient domain
 
-|`zmaccts` |
+|zmaccts |
 Lists the accounts and gives the status of accounts on domain
 
-|`zmamavisdctl` |
+|zmamavisdctl |
 Start, stop, restart, or find the status of the Amavis-D New
 
-| `zmantispamctl` |
+| zmantispamctl |
 Start, stop, reload, status for anti-spam service
 
-|`zmantivirusctl` |
+|zmantivirusctl |
 Start, stop, reload, status for the anti-virus service
 
-|`zmantispamdbpasswd` |
+|zmantispamdbpasswd |
 Changes anti-spam SQL database password
 
-|`zmapachectl` |
+|zmapachectl |
 Start, stop, reload, or check status of Apache service (for spell check)
 
-|`zmarchiveconfig` |
+|zmarchiveconfig |
 Command to view, modify, or configure archiving
 
-|`zmarchivectl` |
+|zmarchivectl |
 Start, stop, reload, status for archiving
 
-|`zmarchivesearch` |
+|zmarchivesearch |
 Search archives on the account
 
-|`zmauditswatchctl` |
+|zmauditswatchctl |
 Start, stop, restart, reload, status of the auditswatch
 
-|`zmbackup` |
+|zmbackup |
 Performs full backups and incremental backups for a designated mail host.
 
-|`zmbackupabort` |
+|zmbackupabort |
 Stops a backup that is in process.
 
-|`zmbackupquery` |
+|zmbackupquery |
 Find a specific full backup set
 
-|`zmblobchk` |
+|zmblobchk |
 Check consistency of the Zimbra blob store
 
-|`zmcalchk` |
+|zmcalchk |
 Check consistency of appointments and attendees in the Zimbra calendar
 
-|`zmcbpolicydctl` |
+|zmcbpolicydctl |
 Start, stop, and restart the cluebringer policyd service, if enabled
 
-|`zmconfigdctl` |
+|zmconfigdctl |
 Start, stop, kill, restart status of the MTA configuration daemon.
 
-|`zmcertmgr` |
+|zmcertmgr |
 Manage self-signed and commercial certificates
 
-|`zmclamdctl` |
+|zmclamdctl |
 Start, stop, or find the status of Clam AV
 
-|`zmcleaniplanetics` |
+|zmcleaniplanetics |
 Clean iPlanet ICS calendar files
 
-|`zmcontrol` |
+|zmcontrol |
 Start, stop, restart, status of the Zimbra servers.  Also can use to find
 the Zimbra version installed
 
-|`zmconvertctl` |
+|zmconvertctl |
 Start, stop, the conversion server or find the status of the converted
 attachments conversion/indexing
 
-|`zmdevicesstats` |
+|zmdevicesstats |
 Number of unique ActiveSync device IDs per server
 
-|`zmgdcutil` |
+|zmgdcutil |
 (get devices count) gives the total devices system wide without the need of
 specifying individual servers.
 
-|`zmdumpenv` |
+|zmdumpenv |
 General information about the server environment is displayed
 
-|`zmgsautil` |
+|zmgsautil |
 Global Address Book (GAL) synchronization utility.
 Create, delete the GAL sync account and initiate manual syncs.
 
-|`zmhostname` |
+|zmhostname |
 Find the hostname of the Zimbra server
 
-|`zmhsm` |
+|zmhsm |
 Start, stop and status of a HSM session.
 
-|`zmitemdatafile` |
+|zmitemdatafile |
 Extracts and packs tgz files that {product-abbrev} uses for REST import/export
 
-|`zmjava` |
+|zmjava |
 Execute Java with Zimbra-specific environment settings
 
-|`zmjavaext` |
+|zmjavaext |
 Execute Java and Zimbra-specific environment settings including extension
 based jars.
 
-|`zmldappasswd` |
+|zmldappasswd |
 Changes the LDAP password
 
-|`zmlicense` |
+|zmlicense |
 View and install your Zimbra license
 
-|`zmlmtpinject` |
+|zmlmtpinject |
 Testing tool
 
-|`zmlocalconfig` |
+|zmlocalconfig |
 Used to set or get the local configuration of a Zimbra server
 
-|`zmloggerctl` |
+|zmloggerctl |
 Start, stop, reload, or find the status of the Zimbra logger service
 
-|`zmloggerhostmap` |
+|zmloggerhostmap |
 Used to manually map a DNS hostname to a zmhostname.
 
-|`zmlogswatchctl` |
+|zmlogswatchctl |
 Start, stop, status of the swatch that is monitoring logging.
 
-|`zmmailbox` |
+|zmmailbox |
 Performs mailbox management tasks
 
-|`zmmailboxdctl` |
+|zmmailboxdctl |
 Start, stop, reload, or find the status of the mailbox components
-(zmmailboxd, MySQL, convert)
+(zmmailboxd, MariaDB, convert)
 
-|`zmmboxsearch` |
+|zmmboxsearch |
 (Cross Mailbox Search) Search across mailboxes to find messages and
 attachments
 
-|`zmmboxmove` |
+|zmmboxmove |
 7.1.3 and later.  Used to move selected mailboxes from one Zimbra server to
 another.
 
-|`zmmboxmovequery` |
+|zmmboxmovequery |
 7.1.3 and later.  Used to query ongoing mailbox moves on a server
 
-|`zmpurgeoldmbox` |
+|zmpurgeoldmbox |
 7.1.3 and later.  Purges a mailbox from the old server after a mailbox move
 
-|`zmmemcachedctl` |
+|zmmemcachedctl |
 Start, stop, and restart
 
-|`zmmetadump` |
+|zmmetadump |
 Support tool that dumps an item's metadata in a human-readable form
 
-|`zmmilterctl` |
+|zmmilterctl |
 Start, stop, and restart the Zimbra milter server if enabled
 
-|`zmmtaconfigdctl` |
+|zmmtaconfigdctl |
 Beginning in {product-abbrev} 7.0, this command is not used.  Use `zmconfigdctl`.
 
-|`zmmtactl` |
+|zmmtactl |
 Start, stop, or find the status of the MTA
 
-|`zmmypasswd` |
+|zmmypasswd |
 Change SQL passwords
 
-|`zmmysqlstatus` |
+|zmmysqlstatus |
 Status of mailbox SQL instance
 
-|`zmnginxconf` |
+|zmnginxconf |
 Output the reverse proxy configuration
 
-|`zmnginxctl` |
+|zmnginxctl |
 Start, stop, and restart the Zimbra reverse proxy
 
-|`zmplayredo` |
+|zmplayredo |
 Performs data restore using backed up snapshots taken periodically.  Users
 who use snapshots to backup and restore their information from a standby
 site use this command.
 
-|`zmprov` |
+|zmprov |
 Performs all provisioning tasks in Zimbra LDAP, including creating
 accounts, domains, distribution lists and aliases
 
-
-|`zmproxyconfgen` |
+|zmproxyconfgen |
 Generates configuration for the nginx proxy
 
-|`zmproxyctl` |
+|zmproxyctl |
 Start, stop, restart, and find the status of the IMAP proxy service
 
-|`zmproxypurge` |
+|zmproxypurge |
 Purges POP/IMAP routing information from one or more memcached servers
 
-|`zmpython` |
+|zmpython |
 Ability to write Python scripts that access Zimbra Java libraries.  It sets
 the Zimbra class path and starts the Jython interpreter.
 
-|`zmredodump` |
+|zmredodump |
 Support tool for dumping contents of a redolog file for debugging purposes
 
-|`zmrestore` |
+|zmrestore |
 Performs full restores and incremental restores for a designated mail host
 
-|`zmrestoreldap` |
+|zmrestoreldap |
 Restore accounts from the LDAP backup
 
-|`zmrestoreoffline` |
+|zmrestoreoffline |
 (Offline Restore) Performs full restore when the Zimbra server (i.e.,
 the mailboxd process) is down
 
-|`zmsaslauthdctl`  |
+|zmsaslauthdctl  |
 Start, stop, or find the status of saslauthd (authentication)
 
-|`zmschedulebackup` |
+|zmschedulebackup |
 Schedule backups and add the command to your cron table
 
-|`zmshutil` |
+|zmshutil |
 Used for other zm scripts, do not use
 
-|`zmskindeploy` |
+|zmskindeploy |
 Deploy skins
 
-|`zmsoap` |
+|zmsoap |
 Print mail, account, and admin information in the SOAP format
 
-|`zmspellctl` |
+|zmspellctl |
 Start, stop, or find the status of the spell check server
 
-|`zmsshkeygen` |
+|zmsshkeygen |
 Generate Zimbra's SSH encryption keys
 
-|`zmstat-chart` |
+|zmstat-chart |
 Generate charts from zmstat data collected in a directory
 
-|`zmstat-chart-config` |
+|zmstat-chart-config |
 Outputs an XML configuration that describes the current state of the data
 gathered from zmstat-chart to generate charts on the Administration
 Console.
 
-|`zmstatctl` |
+|zmstatctl |
 Start, stop, check status, or rotate logs of zmstat data collectors
 
-|`zmstorectl` |
+|zmstorectl |
 Start, stop, or find the status of Zimbra store services
 
-|`zmswatchctl` |
+|zmswatchctl |
 Start, stop, or find the status of the Swatch process, which is used in
 monitoring
 
-|`zmsyncreverseproxy` |
+|zmsyncreverseproxy |
 Decodes the sync request/responses and logs them when verbose mode is
 turned on.
 
-|`zmthrdump` |
+|zmthrdump |
 Initiate a thread dump and save the data to a file with a timestamp
 
-|`zmtlsctl` |
+|zmtlsctl |
 Set the Web server mode to the communication protocol options:
 HTTP, HTTPS or mixed
 
-|`zmtrainsa` |
+|zmtrainsa |
 Used to train the anti-spam filter to recognize what is spam or ham
 
-|`zmtzupdate` |
+|zmtzupdate |
 Provides mechanism to process time zone changes
 
-|`zmupdateauthkeys` |
+|zmupdateauthkeys |
 Used to fetch the ssh encryption keys created by `zmsshkeygen`
 
-|`zmvolume` |
+|zmvolume |
 Manage storage volumes on your Zimbra Mailbox server
 
-|`zmzimletctl` |
+|zmzimletctl |
 Deploy and configure Zimlets
 
 |=======================================================================
@@ -434,28 +432,28 @@ zmprov ma user1 +zimbraZimletUserProperties "com_company_testing:favoriteColor:b
 The attributes for the tasks zmprov can be used with are listed when you
 type `zmprov -h`.  The task area divided into the following sections:
 
-[cols=",",options="header",]
+[cols="1m,1m,2",options="header",]
 |==================================================================
-|Long Name |Syntax, Example, and Notes
-|`--help` (`-h`) |display usage
-|`--file` (`-f`) |use file as input stream
-|`--server` (`-s`) |{host}[:{port}] server hostname and optional port
-|`--ldap` (`-l`) |provision via LDAP instead of SOAP
-|`--logpropertyfile` (`-L`) |log4j property file, valid only with `-l`
-|`--account {name}` (`-a`) |account name to auth as
-|`--password {pass}` (`-p`) |password for account
-|`--passfile {file}` (`-P`) |read password from file
-|`--zadmin` (`-z`) |
+|Long Name | Short Name | Syntax, Example, and Notes
+|--help |-h |display usage
+|--file |-f |use file as input stream
+|--server |-s |{host}[:{port}] server hostname and optional port
+|--ldap |-l |provision via LDAP instead of SOAP
+|--logpropertyfile |-L |log4j property file, valid only with `-l`
+|--account {name} |-a |account name to auth as
+|--password {pass} |-p |password for account
+|--passfile {file} |-P |read password from file
+|--zadmin |-z |
 use Zimbra admin name/password from localconfig for admin/password
-|`--authtoken {authtoken}` (`-y`) |
+|--authtoken {authtoken} |-y |
 use auth token string (has to be in JSON format) from command line
-|`--authtokenfile {authtoken-file}` (`-Y`) |
+|--authtokenfile {authtoken-file} |-Y |
 use auth token string (has to be in JSON format) from a file
-|`--verbose` (`-v`) |
+|--verbose |-v |
 verbose mode (dumps full exception stack trace)
-|`--debug` (`-d`) |debug mode (dumps SOAP messages)
-|`--master` (`-m`) |use LDAP master.  This only valid with `-l`
-|`--replace` (`-r`)|
+|--debug |-d |debug mode (dumps SOAP messages)
+|--master |-m |use LDAP master.  This only valid with `-l`
+|--replace |-r |
 allow replacement of safe-guarded multi-value attribute configured in
 localconfig key `zmprov_saveguarded_attrs`
 
@@ -500,17 +498,17 @@ topics:
 ==== Account Provisioning Commands
 
 .`zmprov` -- Account Provisioning Commands
-[cols=",,a",options="header",]
+[cols="1m,2m,2a",options="header",]
 |=======================================================================
 |Commnad |Syntax |Example/Notes
-|`addAccountAlias (aaa)` |
+|addAccountAlias (aaa) |
 {name@domain \| id \| adminName} {alias@domain}|
 [source,bash]
 ----
 zmprov aaa joe@domain.com joe.smith@engr.domain.com
 ----
 
-|`checkPasswordStrength (cps)` |
+|checkPasswordStrength (cps) |
 {name@doman \| id} {password} |
 
 [source,bash]
@@ -521,98 +519,96 @@ zmprov cps joe@domain.com test123
 [NOTE]
 This command does not check the password age or history.
 
-|`createAccount (ca)` |
+|createAccount (ca) |
 {name@domain} {password} [attr1 value1]... |
 [source,bash]
 ----
 zmprov ca joe@domain.com test123 displayName JSmith
 ----
 
-|`createDataSource (cds)` |
+|createDataSource (cds) |
 {name@domain} {ds-type} {ds-name} zimbraDataSourceEnabled {TRUE \| FALSE} zimbraDataSourceFolderId {folder-id} [attr1 value1 [attr2 value2]...] |
 
-|`createIdentity (cid)` |
+|createIdentity (cid) |
 {name@domain} {identity-name} [attr1 value1 [attr2 value2]...] |
 
-|`createSignature (csig)` |
+|createSignature (csig) |
 {name@domain} {signature-name} [attr1 value1 [attr2 value2]...] |
 
-|`deleteAccount (da)` |
+|deleteAccount (da) |
 {name@domain \| id \| adminName} |
 [source,bash]
 ----
 zmprov da joe@domain.com
 ----
 
-|`deleteDataSource (dds)` |
+|deleteDataSource (dds) |
 {name@domain \| id} {ds-name \| ds-id} |
 
-|`deleteIdentity (did)` |
+|deleteIdentity (did) |
 {name@domain \| id} {identity-name} |
 
-|`deleteSignature (dsig)` |
+|deleteSignature (dsig) |
 {name@domain \| id} {signature-name} |
 
-|`getAccount (ga)` |
+|getAccount (ga) |
 {name@domain \| id \| adminName} |
 [source,bash]
 ----
 zmprov ga joe@domain.com
 ----
-|`getAccountMembership (gam)` |
+|getAccountMembership (gam) |
 {name@domain \| id} |
 
-|`getAllAccounts (gaa)` |
+|getAllAccounts (gaa) |
 [-v] [domain] |
 Must include `-l`/`--ldap`
-
 [source,bash]
 ----
 zmprov -l gaa
-
 zmprov -l gaa -v domain.com
 ----
 
-|`getAllAdminAccounts (gaaa)` |
+|getAllAdminAccounts (gaaa) |
 |
 [source,bash]
 ----
 zmprov gaaa
 ----
 
-|`getDataSources (gds)` |
+|getDataSources (gds) |
 {name@domain \| id} [arg1 [arg2]...] |
 
-|`getIdentities (gid)` |
+|getIdentities (gid) |
 {name@domain \| id} [arg1 [arg2]...] |
 
-|`getSignatures (gsig)` |
+|getSignatures (gsig) |
 {name@domain \| id} [arg1 [arg2]...] |
 
-|`modifyAccount (ma)` |
+|modifyAccount (ma) |
 {name@domain \| id \| adminName} [attr1 value1]... |
 [source,bash]
 ----
 zmprov ma joe@domain.com zimbraAccountStatus maintenance
 ----
 
-|`modifyDataSource (mds)` |
+|modifyDataSource (mds) |
 {name@domain \| id} {ds-name \| ds-id} [attr1 value1 [attr2 value2]...] |
 
-|`modifyIdentity (mid)` |
+|modifyIdentity (mid) |
 {name@domain \| id} {identity-name} [attr1 value1 [attr2 value 2]...] |
 
-|`modifySignature (msig)` |
+|modifySignature (msig) |
 {name@domain \| id} {signature-name \| signature-id} [attr1 value1 [attr2 value2]...] |
 
-|`removeAccountAlias (raa)` |
+|removeAccountAlias (raa) |
 {name@domain \| id \| adminName} {alias@domain} |
 [source,bash]
 ----
 zmprov raa joe@domain.com joe.smith@engr.domain.com
 ----
 
-|`renameAccount (ra)` |
+|renameAccount (ra) |
 {name@domain \| id} {newname@domain} |
 [source,bash]
 ----
@@ -627,14 +623,14 @@ After you rename an account, you should run a full backup for that account.
 zmbackup -f -s <servername.com> -a <newaccountname@servername.com>
 ----
 
-|`setAccountCOS (sac)` |
+|setAccountCOS (sac) |
 {name@domain \| id \| adminName} {cos-name \| cos-id} |
 [source,bash]
 ----
 zmprov sac joe@domain.com FieldTechnician
 ----
 
-|`setPassword (sp)` |
+|setPassword (sp) |
 {name@domain \| id \| adminName} {password} |
 [source,bash]
 ----
@@ -651,30 +647,30 @@ accented characters that cannot be used: ã, é, í, ú, ü, ñ.
 ==== Calendar Resource Provisioning Commands
 
 .`zmprov` -- Calendar Resource Provisioning Commands
-[cols=",",options="header",]
+[cols="2m,3",options="header",]
 |=======================================================================
 |Commnad |Syntax
 
-|`createCalendarResource (ccr)` |
+|createCalendarResource (ccr) |
 {name@domain} [attr1 value1 [attr2 value2]...]
 
-|`deleteCalendarResource (dcr)` |
+|deleteCalendarResource (dcr) |
 {name@domain \| id}
 
-|`getAllCalendarResources (gacr)` |
+|getAllCalendarResources (gacr) |
 [-v] [domain]
 
 
-|`getCalendarResource (gcr)` |
+|getCalendarResource (gcr) |
 {name@domain \| id}
 
-|`modifyCalendarResource (mcr)` |
+|modifyCalendarResource (mcr) |
 {name@domain \| id} [attr1 value1 {attr2 value2]...]
 
-|`purgeAccountCalendarCache (pacc)` |
+|purgeAccountCalendarCache (pacc) |
 {name@domain} [...]
 
-|`renameCalendarResource (rcr)` |
+|renameCalendarResource (rcr) |
 {name@domain \| id} {newName@domain}
 
 |=======================================================================
@@ -683,65 +679,65 @@ accented characters that cannot be used: ã, é, í, ú, ü, ñ.
 ==== Free Busy Commands
 
 .`zmprov` -- Free Busy Commands
-[cols=",",options="header",]
+[cols="2m,3",options="header",]
 |=======================================================================
 |Commnad |Syntax
 
-|`getAllFbp (gafbp)` | [-v]
+|getAllFbp (gafbp) | [-v]
 
-|`getFreebusyQueueInfo (gfbqi)` | [{provider-name}]
+|getFreebusyQueueInfo (gfbqi) | [{provider-name}]
 
-|`pushFreebusy (pfb)` | {domain \| account-id} [account-id...]
+|pushFreebusy (pfb) | {domain \| account-id} [account-id...]
 
-|`pushFreebusyDomain (pfbd)` | {domain}
+|pushFreebusyDomain (pfbd) | {domain}
 
-|`purgeFreebusyQueue (pfbg)` | [{provider-name}]
+|purgeFreebusyQueue (pfbg) | [{provider-name}]
 |=======================================================================
 
 [[domain_provisioning_cmds]]
 ==== Domain Provisioning Commands
 
 .`zmprov` -- Domain Provisioning Commands
-[cols=",,a",options="header",]
+[cols="1m,2m,2a",options="header",]
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`countAccount (cta)` |
+|countAccount (cta) |
 {domain \| id} |
 This lists each COS, the COS ID and the number of accounts assigned to each
 COS
 
-|`createAliasDomain (cad)` |
+|createAliasDomain (cad) |
 {alias-domain-name} {local-domain-name \| id} [attr1 value1 [attr2 value2]...] |
 
-|`createDomain (cd)` |
+|createDomain (cd) |
 {domain} [attr1 value1]... |
 [source,bash]
 ----
 zmprov cd mktng.domain.com zimbraAuthMech zimbra
 ----
 
-|`deleteDomain (dd)` |
+|deleteDomain (dd) |
 {domain \| id} |
 [source,bash]
 ----
 zmprov dd mktng.domain.com
 ----
 
-|`getDomain (gd)` |
+|getDomain (gd) |
 {domain \| id} |
 [source,bash]
 ----
 zmprov gd mktng.domain.com
 ----
 
-|`getDomainInfo (gdi)` |
+|getDomainInfo (gdi) |
 name \| id \| virtualHostname {value} [attr1 [attr2]...] |
 
-|`getAllDomains (gad)` |
+|getAllDomains (gad) |
 [-v] |
 
-|`modifyDomain (md)` |
+|modifyDomain (md) |
 {domain \| id} [attr1 value1]... |
 [source,bash]
 ----
@@ -751,7 +747,7 @@ zmprov md domain.com zimbraGalMaxResults 500
 Do not modify `zimbraDomainRenameInfo` manually.  This is automatically
 updated when a domain is renamed.
 
-|`renameDomain (rd)` |
+|renameDomain (rd) |
 {domain \| id} {newDomain} |
 
 [NOTE]
@@ -762,49 +758,49 @@ updated when a domain is renamed.
 ==== COS Provisioning Commands
 
 .`zmprov` -- COS Provisioning Commands
-[cols=",,a",options="header",]
+[cols="1m,2m,2a",options="header",]
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`copyCos (cpc)` |
+|copyCos (cpc) |
 {src-cos-name \| id} {dest-cos-name} |
 
-|`createCos (cc)` |
+|createCos (cc) |
 {name} [attr1 value1]... |
 [source,bash]
 ----
 zmprov cc Executive zimbraAttachmentsBlocked FALSE zimbraAuthTokenLifetime 60m zimbraMailQuota 100M zimbraMailMessageLifetime 0
 ----
 
-|`deleteCos (dc)` |
+|deleteCos (dc) |
 {name \| id} |
 [source,bash]
 ----
 zmprov dc Executive
 ----
 
-|`getCos (gc)` |
+|getCos (gc) |
 {name \| id} |
 [source,bash]
 ----
 zmprov gc Executive
 ----
 
-|`getAllCos (gac)` |
+|getAllCos (gac) |
 [-v] |
 [source,bash]
 ----
 zmprov gac -v
 ----
 
-|`modifyCos (mc)` |
+|modifyCos (mc) |
 {name \| id} [attr1 value1]... |
 [source,bash]
 ----
 zmprov mc Executive zimbraAttachmentsBlocked TRUE
 ----
 
-|`renameCos (rc)` |
+|renameCos (rc) |
 {name \| id} {newName} |
 [source,bash]
 ----
@@ -817,46 +813,46 @@ zmprov rc Executive Business
 ==== Server Provisioning Commands
 
 .`zmprov` -- Server Provisioning Commands
-[cols=",,a",options="header",]
+[cols="1m,2m,2a",options="header",]
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`createServer (cs)` |
+|createServer (cs) |
 {name} [attr1 value1]... |
 
-|`deleteServer (ds)` |
+|deleteServer (ds) |
 {name \| id} |
 [source,bash]
 ----
 zmprov ds domain.com
 ----
 
-|`getServer (gs)` |
+|getServer (gs) |
 {name \| id} |
 [source,bash]
 ----
 zmprov gs domain.com
 ----
 
-|`getAllServers (gas)` |
+|getAllServers (gas) |
 [-v] |
 [source,bash]
 ----
 zmprov gas
 ----
 
-|`modifyServer (ms)` |
+|modifyServer (ms) |
 {name \| id} [attr1 value1]... |
 [source,bash]
 ----
 zmprov ms domain.com zimbraVirusDefinitionsUpdateFrequency 2h
 ----
 
-|`getAllMtaAuthURLs (gamau)` | |
+|getAllMtaAuthURLs (gamau) | |
 Used to publish into saslauthd.conf what servers should be used for
 saslauthd.conf MTA auth
 
-|`getAllMemcachedServers (gamcs)` | |
+|getAllMemcachedServers (gamcs) | |
 Used to list memcached servers (for nginix use).
 
 |=======================================================================
@@ -865,31 +861,31 @@ Used to list memcached servers (for nginix use).
 ==== Config Provisioning Commands
 
 .`zmprov` -- Config Provisioning Commands
-[cols=",,a",options="header",]
+[cols="1m,2m,2a",options="header",]
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`getAllConfig (gacf)` |
+|getAllConfig (gacf) |
 [-v] |
 All LDAP settings are displayed
 
-|`getConfig (gcf)` |
+|getConfig (gcf) |
 {name} |
 
-|`modifyConfig (mcf)` |
+|modifyConfig (mcf) |
 attr1 value1 |
 Modifies the LDAP settings.
 
-|`createXMPPComponent (csc)` |
+|createXMPPComponent (csc) |
 {short-name} {domain} {server} {classname} {category} {type} [attr1 value1 [attr2 value2]...] |
 
-|`deleteXMPPComponent (dxc)` |
+|deleteXMPPComponent (dxc) |
 {xmpp-component-name} |
 
-|`getXMPPComponent (gxc)` |
+|getXMPPComponent (gxc) |
 {name@domain} [attr1 [attr2]...] |
 
-|`modifyXMPPComponent (mxc)` |
+|modifyXMPPComponent (mxc) |
 {name@domain} [attr1 value1 [attr2 value2]...] |
 
 |=======================================================================
@@ -898,64 +894,64 @@ Modifies the LDAP settings.
 ==== Distribution List Provisioning Commands
 
 .`zmprov` -- Distribution List Provisioning Commands
-[cols=",,a",options="header",]
+[cols="1m,2m,2a",options="header",]
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`createDistribution List (cdl)` |
+|createDistributionList (cdl) |
 {list@domain} |
 [source,bash]
 ----
 zmprov cdl needlepoint-list@domain.com
 ----
 
-|`addDistributionListMember (adlm)` |
+|addDistributionListMember (adlm) |
 {list@domain \| id} {member@domain} |
 [source,bash]
 ----
 zmprov adlm needlepoint-list@domain.com singer23@mail.free.net
 ----
 
-|`removeDistributionListMember (rdlm)` |
+|removeDistributionListMember (rdlm) |
 {list@domain \| id} |
 [source,bash]
 ----
 zmprov rdlm needlepoint-list@domain.com singer23@mail.free.net
 ----
 
-|`getAlldistributionLists (gadl)` |
+|getAlldistributionLists (gadl) |
 [-v] |
 
-|`getDistributionListmembership (gdlm)` |
+|getDistributionListmembership (gdlm) |
 {name@domain \| id} |
 [NOTE]
 `gdlm` can not be used for gynamic groups, as dynamic groups cannot be
 nested.
 
-|`getDistributionList (gdl)` |
+|getDistributionList (gdl) |
 {list@domain \| id} |
 [source,bash]
 ----
 zmprov gdl list@domain.com
 ----
 
-|`modifyDistributionList (mdl)` |
+|modifyDistributionList (mdl) |
 {list@domain \| id} attr1 value1 [attr2 value2]... |
 [source,bash]
 ----
 zmprov md list@domain.com
 ----
 
-|`deleteDistributionList (ddl)` |
+|deleteDistributionList (ddl) |
 {list@domain \| id} |
 
-|`addDistributionListAlias (adla)` |
+|addDistributionListAlias (adla) |
 {list@domain \| id} {alias@domain} |
 
-|`removeDistributionListAlias (rdla)` |
+|removeDistributionListAlias (rdla) |
 {list@domain \| id} {alias@domain} |
 
-|`renameDistributionList (rdl)` |
+|renameDistributionList (rdl) |
 {list@domain \| id} {newName@domain} |
 
 |=======================================================================
@@ -964,17 +960,17 @@ zmprov md list@domain.com
 ==== Mailbox Commands
 
 .`zmprov` -- Mailbox Commands
-[cols=",,a",options="header",]
+[cols="1m,2m,2a",options="header",]
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`getMailboxInfo (gmi)` |
+|getMailboxInfo (gmi) |
 {account} |
 
-|`getQuotaUsage (gqu)` |
+|getQuotaUsage (gqu) |
 {server} |
 
-|`recalculateMailboxCounts (rmc)` |
+|recalculateMailboxCounts (rmc) |
 {name@domain \| id} |
 
 When unread message count and quota usage are out of sync with the data
@@ -987,22 +983,22 @@ usage and message count should be schedule to
 run in off peak hours and used on one mailbox
 at a time.
 
-|`reIndexMailbox (rim)` |
+|reIndexMailbox (rim) |
 {name@domain \| id} {start \| status \| cancel} [type \| id]... |
 
-|`compactIndexMailbox (cim)` |
+|compactIndexMailbox (cim) |
 {name@domain \| id} {start \| status} |
 
-|`verifyIndex (vi)` |
+|verifyIndex (vi) |
 {name@domain \| id} |
 
-|`getIndexStats (gis)` |
+|getIndexStats (gis) |
 {name@domain \| id} |
 
-|`selectMailbox (sm)` |
+|selectMailbox (sm) |
 {account-name} [{zmmailbox commands}] |
 
-|`unlockMailbox (ulm)` |
+|unlockMailbox (ulm) |
 {name@domain \| id} [hostname] |
 
 Only specify the hostname parameter when unlocking a mailbox after a failed move attempt.
@@ -1012,41 +1008,41 @@ Only specify the hostname parameter when unlocking a mailbox after a failed move
 ==== Miscellaneous Provisioning Commands
 
 .`zmprov` -- Miscellaneous Provisioning Commands
-[cols=",,a",options="header",]
+[cols="1m,2m,2a",options="header",]
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`countObjects (cto)` |
+|countObjects (cto) |
 {type} [-d {domain \| id}] |
 
 `countObjects` can only be used with `zmprov -l/--ldap`
 
-|`createBulkAccounts (cabulk)` |
+|createBulkAccounts (cabulk) |
 {domain} {namemask} {number of accounts to create} |
 
-|`describe (desc)` |
+|describe (desc) |
 [[-v] [-ni] [{entry-type}]] \| [-a {attribute-name}] |
 Prints all attribute names (account, domain, COS, servers, etc.).
 
-|`flushCache (fc)` |
+|flushCache (fc) |
 [-a] {acl \| locale \| skin \| uistrings \| license \| all \| account \| config \| glo \| balgrant \| cos \| domain \| galgroup \| group \| mime \| server \| zimlet \| <extension-cache-type>} [name1 \| id1 [name2 \| i d2]...] |
 
 Flush cached LDAP entries for a type.  See <<zimbra_ldap_service,Zimbra LDAP Service>>.
 
-|`generateDomainPreAuth Key (gdpak)` |
+|generateDomainPreAuth Key (gdpak) |
 {domain \| id} |
 Generates a pre-authentication key to enable a trusted third party to
 authenticate to allow for single-sign on.  Used in conjunction with
 `GenerateDomainPreAuth`.
 
-|`generateDomainPreAuth (gdpa)` |
+|generateDomainPreAuth (gdpa) |
 {domain \| id} {name} {name \| id \| foreignPrincipal} {timestamp \| 0} {expires \| 0} |
 Generates preAuth values for comparison.
 
-|`syncGal (syg)` |
+|syncGal (syg) |
 {domain} [{token}] |
 
-|`getAccountLogger (gal)` |
+|getAccountLogger (gal) |
 [-s /--server hostname] {name@domain \| id} |
 
 |=======================================================================
@@ -1055,27 +1051,27 @@ Generates preAuth values for comparison.
 ==== Logs Commands
 
 .`zmprov` -- Logs Commands
-[cols=",,a",options="header",]
+[cols="1m,2m,2a",options="header",]
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`addAccountLogger (aal)` |
+|addAccountLogger (aal) |
 {name@domain \| id} {logging-category} {debug \| info \| warn \| error} |
 Creates custom logging for a single account.
 
-|`getAccountLoggers (gal)` |
+|getAccountLoggers (gal) |
 [-s/--server hostname] {name@domain \| id} {logging-category} {debug \| info \| warn \| error} |
 
-|`getAllAccountLoggers (gaal)` |
+|getAllAccountLoggers (gaal) |
 [-s/--server hostname] |
 Shows all individual custom logger account.
 
-|`removeAccountLogger (ral)` |
+|removeAccountLogger (ral) |
 [-s/ --server hostname] {name@domain \| id} {logging-category} |
 When name@domain is specified, removes the custom logger created for the
 account otherwise removes all accounts all account loggers from the system.
 
-|`resetAllLoggers (rlog)`  |
+|resetAllLoggers (rlog)  |
 [-s/--server hostname] |
 This command removes all account loggers and
 reloads `/opt/zimbra/conf/log4j.properties`.
@@ -1089,21 +1085,21 @@ logging categories.
 ==== Search Commands
 
 .`zmprov` -- Search Commands
-[cols=",,a",options="header",]
+[cols="1m,2m,2a",options="header",]
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`searchGAL (sg)` |
+|searchGAL (sg) |
 {domain} {name} |
 `zmprov sg joe`
 
-|`autoCompleteGal (acg)` |
+|autoCompleteGal (acg) |
 {domain} {name} |
 
-|`searchAccounts (sa) |
+|searchAccounts (sa) |
 [-v] {ldap-query} [limit] [offset] [sortBy {attribute}] [sortAscending 0 \| 1] [domain {domain}] |
 
-|`searchCalendarResources (scr)` |
+|searchCalendarResources (scr) |
 [-v] domain {attr op value} [attr op value]... |
 
 |=======================================================================
@@ -1113,11 +1109,11 @@ logging categories.
 
 .`zmprov` -- Share Provisioning Commands
 
-[cols=",,a",options="header",]
+[cols="1m,2m,2a",options="header",]
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`getShareInfo (gsi)` |
+|getShareInfo (gsi) |
 {owner-name \| owner-id} |
 
 |=======================================================================
@@ -1125,26 +1121,26 @@ logging categories.
 ==== Unified Communication Service Commands
 
 .`zmprov` -- Unified Communication Service Commands
-[cols=",,a",options="header",]
+[cols="1m,2m,2a",options="header",]
 |=======================================================================
 |Commnad |Syntax |Example/Notes
 
-|`createUCService (cucs)` |
+|createUCService (cucs) |
 {name} [attr1 value1 [attr2 value2]...] |
 
-|`deleteUCService (ducs)` |
+|deleteUCService (ducs) |
 {name \| id} |
 
-|`getAllUCServices (gaucs)` |
+|getAllUCServices (gaucs) |
 [-v] |
 
-|`getUCService (gucs)` |
+|getUCService (gucs) |
 [-e] {name \| id} [attr1 [attr2]...] |
 
-|`modifyUCService (mucs)` |
+|modifyUCService (mucs) |
 {name \| id} [attr1 value1 [attr2 value2]...] |
 
-|`renameUCService (rucs)` |
+|renameUCService (rucs) |
 {name \| id} {newName} |
 
 |=======================================================================
@@ -1153,22 +1149,22 @@ logging categories.
 ==== IMAP/POP Proxy Commands
 
 .`zmprov` -- IMAP/POP Proxy Commands
-[cols=",",options="header",]
+[cols="1m,2",options="header",]
 |=======================================================================
 |Commnad |Example/Notes
 
-|`--getAllReverseProxyURLs (garpu)` |
+|getAllReverseProxyURLs (garpu) |
 Used to publish into nginx.conf the servers that should be used for reverse
 proxy lookup.
 
-|`--getAllReverseProxy Backends (garpb)|
+|getAllReverseProxy Backends (garpb)|
 Returns the list of servers that have
 `zimbraReverseProxyLookupTarget=TRUE`.
 
 Basically if a mailbox server is available for lookup requests from the
 proxy.
 
-|`--getAllReverseProxyDomains (garpd) |
+|getAllReverseProxyDomains (garpd) |
 Returns a list of all domains configured with `ZimbraSSLCertificate
 zimbraVirtualHostname` and `zimbraVirtualIPAddress` configured.  This
 allows the proxy to configure a list of domains to serve customized/domain
@@ -1333,10 +1329,11 @@ zmprov ms server.com zimbraMailPurgeSleepInterval <Xm>
 ----
 
 *X* is the duration of time between mailbox purges; *m* represents
-minutes.You could also set *<xh>* for hours.
+minutes. You could also set *<xh>* for hours.
 ====
 
 .Customize the notification email
+[[custom_new_mail_notification]]
 ====
 
 Modify `zimbraNewMailNotification` to customize the notification email
@@ -1411,6 +1408,7 @@ or more weeks, entered as `xw` (`1w`).
 * `zimbraBackupAutoGroupedNumGroups` -- This the number of groups to spread
 mailboxes over.  The default is 7 groups.
 
+[[conversation_threading]]
 ==== Changing Conversations Thread Default
 
 Messages can be grouped into conversations by a common thread.  The default
@@ -1469,38 +1467,38 @@ zmprov rim <user@example.com> start
 
 [[zmprov_log_categories]]
 .`zmprov` -- Log Categories
-[cols=",",options="",]
+[cols="1m,3",options="",]
 |============================================
-|`zimbra.account` |Account operations
-|`zimbra.acl` |ACL operations
-|`zimbra.backup` |Backup and restore
-|`zimbra.cache` |Inmemory cache operations
-|`zimbra.calendar` |Calendar operations
-|`zimbra.dav` |DAV operations
-|`zimbra.dbconn` |Database connection tracing
-|`zimbra.extensions` |Server extension loading
-|`zimbra.filter` |Mail filtering
-|`zimbra.gal` |GAL operations
-|`zimbra.imap` |IMAP protocol operations
-|`zimbra.index` |Index operations
-|`zimbra.io` |Filesystem operations
-|`zimbra.ldap` |LDAP operations
-|`zimbra.lmtp` |LMTP operations (incoming mail)
-|`zimbra.mailbox` |General mailbox operations
-|`zimbra.misc` |Miscellaneous
-|`zimbra.op` |Changes to mailbox state
-|`zimbra.pop` |POP protocol operations
-|`zimbra.redolog` |Redo log operations
-|`zimbra.security` |Security events
-|`zimbra.session` |User session tracking
-|`zimbra.smtp` |SMTP operations (outgoing mail)
-|`zimbra.soap` |SOAP protocol
-|`zimbra.sqltrace` |SQL tracing
-|`zimbra.store` |Mail store disk operations
-|`zimbra.sync` |Sync client operations
-|`zimbra.system` |Startup/shutdown and other system messages
-|`zimbra.wiki` |Wiki operations
-|`zimbra.zimlet` |Zimlet operations
+|zimbra.account |Account operations
+|zimbra.acl |ACL operations
+|zimbra.backup |Backup and restore
+|zimbra.cache |Inmemory cache operations
+|zimbra.calendar |Calendar operations
+|zimbra.dav |DAV operations
+|zimbra.dbconn |Database connection tracing
+|zimbra.extensions |Server extension loading
+|zimbra.filter |Mail filtering
+|zimbra.gal |GAL operations
+|zimbra.imap |IMAP protocol operations
+|zimbra.index |Index operations
+|zimbra.io |Filesystem operations
+|zimbra.ldap |LDAP operations
+|zimbra.lmtp |LMTP operations (incoming mail)
+|zimbra.mailbox |General mailbox operations
+|zimbra.misc |Miscellaneous
+|zimbra.op |Changes to mailbox state
+|zimbra.pop |POP protocol operations
+|zimbra.redolog |Redo log operations
+|zimbra.security |Security events
+|zimbra.session |User session tracking
+|zimbra.smtp |SMTP operations (outgoing mail)
+|zimbra.soap |SOAP protocol
+|zimbra.sqltrace |SQL tracing
+|zimbra.store |Mail store disk operations
+|zimbra.sync |Sync client operations
+|zimbra.system |Startup/shutdown and other system messages
+|zimbra.wiki |Wiki operations
+|zimbra.zimlet |Zimlet operations
 |============================================
 
 === zmaccts
@@ -1531,42 +1529,42 @@ zmarchiveconfig [args] [cmd] [cmd-args]...
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--help` |`-h` |
+|--help |-h |
 Displays the usage options for this command
 
-|`--server` |`-s` |
+|--server |-s |
 (host)[:(port)] Displays the server hostname and optional port
 
-|`--account` |`-a` |
+|--account |-a |
 (name) Returns the value of the account name to be authorized
 
-|`--ldap` |`-l` |
+|--ldap |-l |
 Allows archiving to be provisioned via LDAP
 
-|`--password` |`-p` |
+|--password |-p |
 (pass) Returns the password for auth account
 
-|`--passfile` |`-P` |
+|--passfile |-P |
 (file) Allows password to be read from file
 
-|`--zadmin` |`-z` |
+|--zadmin |-z |
 Allows use of Zimbra admin/password from local
 
-|`--debug` |`-d` |
+|--debug |-d |
 Activates debug mode (dumps SOAP messages)
 
 3+|*Command in ...*
 
-|`enable <account>` | |
+|enable <account> | |
 
 [archive-address <aaddr> [archive-cos <cos>] [archive-create <TRUE/FALSE>]
 [archive-password <pa [zimbraAccountAttrName <archive-attr-value]+
 
-|`disable <account>` | |
+|disable <account> | |
 
 |=======================================================================
 
@@ -1580,7 +1578,7 @@ account archive.
 
 [source,bash]
 ----
-/opt/zimbra/bin/zmarchivectl start|stop|reload|status
+zmarchivectl start|stop|reload|status
 ----
 
 === zmarchivesearch
@@ -1598,34 +1596,34 @@ zmarchivesearch {-m <user@domain.com>} {-q <query_string>} [-o <offset>] [-l <li
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--dir` |`-d` |
+|--dir |-d |
 <arg> Directory to write messages to.  If none is specified, then only the
 headers are fetched.  Filenames are generated in the form
 RESULTNUM_ACCOUNT-ID_MAILITEMID
 
-|`--help` |`-h` |
+|--help |-h |
 Displays help messages
 
-|`--limit` |`-l` |
+|--limit |-l |
 <arg> Sets the limit for the number of results returned.  The default is 25
 
-|`--mbox` |`-m` |
+|--mbox |-m |
 <arg> Name of archive account to search
 
-|`--offset` |`-o` |
+|--offset |-o |
 <arg> Specifies where the hit list should begin.  The default is 0
 
-|`--query` |`-q` |
+|--query |-q |
 <arg> The query string for archive search
 
-|`--server` |`-s` |
+|--server |-s |
 <arg> Mail server hostname.  Default is localhost
 
-|`--verbose` |`-v` |
+|--verbose |-v |
 Allows printing of status messages while the search is being executed
 
 |=======================================================================
@@ -1659,75 +1657,75 @@ zmbackup {-f | -i | del} {-a <arg>} [options]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--account` |`-a` |
+|--account |-a |
 <arg> Account email addresses separated by white space or all for all
 accounts.  This option is not specified for auto-grouped backups since the
 system knows which accounts to backup every night.
 
-|`--debug` |`-d` |
+|--debug |-d |
 Display diagnostics for debugging purposes.
 
-|`--delete` |`-del` |
+|--delete |-del |
 <arg> Deletes the backups including and prior to the specified label, date
 (YYYY/MM/DD[-hh:mm:ss]) or period (nn(d \| m \| y]).
 
-|`--excludeBlobs` | |
+|--excludeBlobs | |
 Exclude blobs from full backup.  If unspecified, use server config
 
-|`--excludeHsmBlobs` | |
+|--excludeHsmBlobs | |
 Exclude blobs on HSM volumes from full backup; if unspecified, use server
 config
 
-|`--excludeSearchIndex` | |
+|--excludeSearchIndex | |
 Exclude search index from full backup; if unspecified, use server config
 
-|`--fullBackup` |`-f` |
+|--fullBackup |-f |
 Starts a full backup.  In auto-grouped backup mode, this option also copies
 the redologs since the last backup (which is the main function of an
 incremental backup).
 
-|`--help` |`-h` |
+|--help |-h |
 Displays the usage options for this command.
 
-|`--incrementalBackup` |`-i` |
+|--incrementalBackup |-i |
 Starts an incremental backup.  This option is not available in the
 auto-grouped backup mode.
 
-|`--includeBlobs` | |
+|--includeBlobs | |
 Include blobs in full backup.  If this is unspecified, the server config is
 used.
 
-|`--includeHsmBlobs` | |
+|--includeHsmBlobs | |
 Include blobs on HSM volumes in full backup.  If this is unspecified, the
 server config is used.
 
-|`--includeSearchIndex` | |
+|--includeSearchIndex | |
 Include search index in full backup.  If this is unspecified, the server
 config is used.
 
-|`--noZip` | |
+|--noZip | |
 Backs up blobs as individual files rather than in zip files.
 
-|`--server` |`-s` |
+|--server |-s |
 <arg> Mail server host name.  For format, use either the plain host name or
 the server.domain.com name.  The default is the localhost name.
 
-|`--sync` |`-sync` |
+|--sync |-sync |
 Runs full backup synchronously.
 
-|`--target` |`-t` |
+|--target |-t |
 <arg> Specifies the target backup location.  The default is
-`<zimbra_home>/backup`.
+`/opt/zimbra/backup`.
 
-|`--zip` |`-z` |
+|--zip |-z |
 Backs up blobs in compressed zip files.  Ignored if `--zipStore` is
 specified.
 
-|`--zipStore` | |
+|--zipStore | |
 Backup blobs in zip file without compression.  (default)
 
 |=======================================================================
@@ -1736,7 +1734,7 @@ Backup blobs in zip file without compression.  (default)
 
 In these examples, the server (`-s`) is `server1.domain.com`.  The (`-t`)
 is not required if the target is the default directory,
-(`zimbra_home/backup`).
+(`/opt/zimbra/backup`).
 
 .Perform a full backup of all mailboxes on *server1*
 ====
@@ -1790,36 +1788,36 @@ check.  The ID values are separated by commas.
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--export-dir` | |
+|--export-dir | |
 <path> Target directory for database export files.
 
-|`--help` |`-h` |
+|--help |-h |
 Displays help messages
 
-|`--mailboxes` |`-m` |
+|--mailboxes |-m |
 <mailbox-ids> Specify which mailboxes to check.  If not specified, check
 all mailboxes.
 
-|`--missing-blob-delete-item` | |
+|--missing-blob-delete-item | |
 Delete any items that have a missing blob.
 
-|`--no-export` | |
+|--no-export | |
 Delete items without exporting
 
-|`--skip-size-check` | |
+|--skip-size-check | |
 Skip blob size check
 
-|`--unexpected-blob-list` | |
+|--unexpected-blob-list | |
 <path> Write the paths of any unexpected blobs to a file
 
-|`--verbose` |`-v` |
+|--verbose |-v |
 Display verbose output; display stack trace on error
 
-|`--volumes` | |
+|--volumes | |
 <volume-ids> Specify which volumes to check.  If not specified, check all
 volumes
 
@@ -1843,18 +1841,18 @@ zmcalchk [-d] [-n <type>] <user> <start-time-spec> <end-time-spec>
 
 ==== Description
 
-[cols=",",options="header",]
+[cols="1m,3",options="header",]
 |=======================================================================
 |Short Name |Description
 
-|`-d` |
+|-d |
 Debugs verbose details
 
-|`-m` |
+|-m |
 Allows the user to specify the maximum number of attendees to check.  The
 default value is 50.
 
-|`-n` |
+|-n |
 `-n none \| user \| organizer \| attendee \| all`
 
 Send email notifications to selected users if they are out of sync for an
@@ -1893,47 +1891,47 @@ zmschedulebackup {-q|-s|-A|-R|-F|-D}[f|i|d|] ["schedule"]
 
 ==== Description
 
-[cols=",,a",options="header",]
+[cols="1m,1m,2a",options="header",]
 |=======================================================================
 |Name |Command Name |Description
 
-|`help` |`-h` |
+|help |-h |
 Displays the usage options for this command.
 
-|`query` |`-q` |
+|query |-q |
 Default command.  Displays the existing Zimbra backup schedule.
 
-|`save` |`-s` |
+|save |-s |
 Save the schedule.  Allows you to save the schedule command to a text file
 so that you can quickly regenerate the backup schedule when the system is
 restored.
 
-|`flush` |`-F` |
+|flush |-F |
 Removes the current schedule and cancels all scheduled backups.
 
-|`append` |`-A` |
+|append |-A |
 Adds an additional specified backup to the current schedule.
 
-|`replace` |`-R` |
+|replace |-R |
 Replaces the current schedule with the specified schedule.
 
-|`default` |`-D` |
+|default |-D |
 Replaces the current schedule with the default schedule.
 
 
 3+|*Options that will be passed to zmbackup*
 
-|`no compression` |`-n` |
+|no compression |-n |
 Backs up blobs as individual files rather than in zip files
 
-|`compress` |`-z` |
+|compress |-z |
 Backs up blobs in compressed zip files.  Ignored if `--zipStore` is
 specified.
 
-|`--zipStore` | |
+|--zipStore | |
 Backs up blobs in zip file without compression.
 
-|`target` |`-t` |
+|target |-t |
 Can be used only to designate a full back target location.  The default is
 `/opt/zimbra/backup`.
 
@@ -1941,51 +1939,51 @@ Can be used only to designate a full back target location.  The default is
 You cannot designate a target for incremental backups.  If a target (`-t`)
 location is added for incremental scheduled backups, it is ignored.
 
-|`account` |`-a` |
+|account |-a |
 Account specific.  The default is all accounts.
 
-|`--mail-report` | |
+|--mail-report | |
 Send an email report to the admin user.
 
-|`--server` | |
+|--server | |
 server - Mail server hostname.  Default is localhost.
 
-|`--sync` | |
+|--sync | |
 Runs full backup synchronously.
 
-|`--excludeBlobs` | |
+|--excludeBlobs | |
 Exclude blobs from full backup.  If unspecified, server config is used.
 
-|`--includeBlobs` | |
+|--includeBlobs | |
 Include blobs in full backup.  If unspecified, the server config is used.
 
-|`--excludeHsmBlobs` | |
+|--excludeHsmBlobs | |
 Exclude blobs on HSM volumes from full backup.  If unspecified, the server
 config is used.
 
-|`--includeHsmBlobs` | |
+|--includeHsmBlobs | |
 Include blobs on HSM volumes in full backup.  If unspecified, the server
 config is used.
 
-|`--excludeSearchIndex` | |
+|--excludeSearchIndex | |
 Exclude search index form full backup.  If unspecified, the server config
 is used.
 
-|`--includeSearchIndex` | |
+|--includeSearchIndex | |
 Include search index in full backup.  If unspecified, the server config is
 used.
 
 3+|*Cron schedule* -- backup-type: `<i \| f \| d arg>`
 
-|`incremental backup` |`i` |
+|incremental backup |i |
 `<time specifier>` Incremental backup.
 
 Incremental backup is not used with the auto-grouped backup mode.
 
-|`full backup` |`f` |
+|full backup |f |
 Full backup
 
-|`delete` |`d <arg>` |
+|delete |d <arg> |
 Delete backups.  `<arg>` is `n(d \| m \| y)`
 
 |=======================================================================
@@ -2064,32 +2062,32 @@ zmbackupabort [options]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--debug` |`-d` |
+|--debug |-d |
 Display diagnostics for debugging purposes
 
-|`--help` |`-h` |
+|--help |-h |
 Displays the usage options for this command
 
-|`--label` |`-lb` |`
-<arg>` Label of the full backup to be aborted.
+|--label |-lb |
+`<arg>` Label of the full backup to be aborted.
 
-Use the `zmbackupquery`, to find the label name.
+Use the zmbackupquery, to find the label name.
 
-|`--restore` |`-r` |
+|--restore |-r |
 Abort the restore in process
 
-|`--server` |`-s` |
+|--server |-s |
 `<arg>` Mail server host name.  For format, use either the plain host name
 or the server.domain.com name.  The default is the localhost name.
 
-|`--target` |`-t` |
+|--target |-t |
 `<arg>` Specifies the target backup location.
 
-The default is `<zimbra_home>/backup`.
+The default is `/opt/zimbra/backup`.
 
 |=======================================================================
 
@@ -2115,62 +2113,62 @@ zmbackupquery [options]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--account` |`-a` |
+|--account |-a |
 `<arg>` Account email addresses separated by white space or all for all
 accounts
 
-|`--debug` |`-d` |
+|--debug |-d |
 Display diagnostics for debugging purposes
 
-|`--help` |`-h` |
+|--help |-h |
 Displays the usage options for this command
 
-|`--from` | |
+|--from | |
 `<arg>` List backups whose start date/time is at or after the date/time
 specified here.
 
-|`--label` |`-lb` |
+|--label |-lb |
 `<arg>` The label of the full backup session to query.  An example of a
 label is `backup200507121559510`.
 
-|`--server` |`-s` |
+|--server |-s |
 `<arg>` Mail server host name.  For format, use either the plain host name
 or the server.domain.com name.  The default is the localhost name.
 
-|`--target` |`-t` |
+|--target |-t |
 `<arg>` Specifies the backup target location (The default is
-`<zimbra_home>/backup`.)
+`/opt/zimbra/backup`.)
 
-|`--to` | |
+|--to | |
 `<arg>` List backups whose start date/time is at or before the date/time
 specified here.
 
-|`--type` | |
+|--type | |
 `<arg>` Backup set type to query.  "full" or "incremental", both are
 queried if one is not specified.
 
-|`--verbose` |`-v` |
+|--verbose |-v |
 Returns detailed status information
 
 |=======================================================================
 
 Specify date/time in one of these formats:
 
-[cols="",options=""]
+[cols="m",options=""]
 |=======================================================================
-|`2008/12/16 12:19:23`
-|`2008/12/16 12:19:23 257`
-|`2008/12/16 12:19:23.257`
-|`2008/12/16-12:19:23-257`
-|`2008/12/16-12:19:23`
-|`20081216.121923.257`
-|`20081216.121923`
-|`20081216121923257`
-|`20081216121923`
+|2008/12/16 12:19:23
+|2008/12/16 12:19:23 257
+|2008/12/16 12:19:23.257
+|2008/12/16-12:19:23-257
+|2008/12/16-12:19:23
+|20081216.121923.257
+|20081216.121923
+|20081216121923257
+|20081216121923
 |=======================================================================
 
 Specify year, month, date, hour, minute, second, and optionally
@@ -2200,81 +2198,81 @@ zmrestore [options]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--account` |`-a` |
+|--account |-a |
 `<arg>` Specifies the account email addresses.  Separate accounts with a
 blank space or type all to restore all accounts.
 
-|`--backedupRedologs` |`-br` |
+|--backedupRedologs |-br |
 Replays the redo logs in backup only, which Only excludes archived and
 current redo logs of the system.
 
-|`--continueOnError` |`-c` |
+|--continueOnError |-c |
 Continue to restore other accounts when an error occurs.
 
-|`--createAccount` |`-ca` |
+|--createAccount |-ca |
 Restores accounts to target accounts whose names are prepended with prefix.
 
 (Can only be used in commands that use the `-pre` option.)
 
-|`--debug` |`-d` |
+|--debug |-d |
 Display diagnostics for debugging purposes.
 
-|`--excludeBlobs` | |
+|--excludeBlobs | |
 Do not restore blobs (HSM or not).
 
-|`--excludeHsmBlobs` | |
+|--excludeHsmBlobs | |
 Do not restore HSM blobs.
 
-|`--excludeSearchIndex` | |
+|--excludeSearchIndex | |
 Do not restore search index.
 
-|`--help` |`-h` |
+|--help |-h |
 Displays the usage options for this command.
 
-|`--label` |`-lb` |
+|--label |-lb |
 `<arg>` The label of the full backup to restore.  Restores to the latest
 full backup if this is omitted.
 
-|`--prefix` |`-pre` |
+|--prefix |-pre |
 `<arg>` The prefix to pre-pend to the original account names.
 
-|`--restoreAccount` |`-ra` |
+|--restoreAccount |-ra |
 Restores the account in directory service.
 
-|`--restoreToIncrLabel` | |
+|--restoreToIncrLabel | |
 `<arg>` Replay redo logs up to and including this incremental backup
 
-|`--restoreToRedoSeq` | |
+|--restoreToRedoSeq | |
 `<arg>` Replay up to and including this redo log sequence.
 
-|`--restoreToTime` | |
+|--restoreToTime | |
 `<arg>` Replay rodo logs until this time.
 
-|`--restorefullBackupOnly` |`-rf` |
+|--restorefullBackupOnly |-rf |
 Restores to the full backup only, not any incremental backups since that
 backup.
 
-|`--server` |`-s` |
+|--server |-s |
 `<arg>` Mail server host name.  For format, use either the plain host name
 or the server.domain.com name.  The default is the localhost name.
 
-|`--skipDeletes` | |
+|--skipDeletes | |
 If true, do not execute delete operation during redo log replay.
 
-|`--skipDeletedAccounts` | |
+|--skipDeletedAccounts | |
 Do not restore if named accounts were deleted or did not exist at backup
 time.  (This option is always enabled with `-a all`)
 
-|`--systemData` |`-sys` |
+|--systemData |-sys |
 Restores global tables and local config.
 
-|`--target` |`-t` |`
-<arg>` Specifies the backup target location.  The default is
-`<zimbra_home>/backup`.
+|--target |-t |
+`<arg>` Specifies the backup target location.  The default is
+`/opt/zimbra/backup`.
 
 |=======================================================================
 
@@ -2323,72 +2321,72 @@ zmrestoreoffline [options]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--account` |`-a` |
+|--account |-a |
 `<arg>` Specifies the account email addresses.  Separate accounts with a
 blank space or state `all` for restoring all accounts.  *Required*.
 
-|`--backedupRedologsOnly` |`-br` |
+|--backedupRedologsOnly |-br |
 Replays the redo logs in backup only, which excludes archived and current
 redo logs of the system.
 
-|`--continueOnError` |`-c` |
+|--continueOnError |-c |
 Continue to restore other accounts when an error occurs.
 
-|`--createAccount` |`-ca` |
+|--createAccount |-ca |
 Restores accounts to new target accounts whose names are pre-pended with
 prefix.
 
-|`--debug` |`-d` |
+|--debug |-d |
 Display diagnostics for debugging purposes.
 
-|`--help` |`-h` |
+|--help |-h |
 Displays the usage options for this command.
 
-|`--ignoreRedoErrors` | |
+|--ignoreRedoErrors | |
 If true, ignore all errors during redo log replay.
 
-|`--label` |`-lb` |
+|--label |-lb |
 `<arg>` The label of the full backup to restore.  Type this label to
 specify a backup file other then the latest.
 
-|`--prefix` |`-pre` |
+|--prefix |-pre |
 `<prefix>` The prefix to pre-pend to the original account names.
 
-|`--restoreAccount` |`-ra` |
+|--restoreAccount |-ra |
 Restores the account in directory service.
 
-|`--restoreToIncrLabel` | |
+|--restoreToIncrLabel | |
 `<arg>` Replay redo logs up to and including this incremental backup.
 
-|`--restoreToRedoSeq` | |
+|--restoreToRedoSeq | |
 `<arg>` Replay up to and including this redo log sequence.
 
-|`--restoreToTime` | |
+|--restoreToTime | |
 `<arg>` Replay rodo logs until this time.
 
-|`--restoreFullBackupOnly` |`-rf` |
+|--restoreFullBackupOnly |-rf |
 Restores to the full backup only, not any incremental backups since that
 backup.
 
-|`--server` |`-s` |
+|--server |-s |
 `<arg>` Mail server host name.  For format, use either the plain host name
 or the server.domain.com name.  The default is the localhost name.  If `-s`
 is specified, this must be localhost.
 
-|`--skipDeletedAccounts` | `-skipDeletedAccounts` |
+|--skipDeletedAccounts | -skipDeletedAccounts |
 Do not restore if named accounts were deleted or did not exist at backup
 time.  (This option is always enabled with `-a all`)
 
-|`--systemData` |`-sys` |
+|--systemData |-sys |
 Restores global tables and local config.
 
-|`--target` |`-t` |
+|--target |-t |
 `<arg>` Specifies the backup target location.  The default is
-`<zimbra_home>/backup`.
+`/opt/zimbra/backup`.
 
 |=======================================================================
 
@@ -2420,24 +2418,24 @@ zmrestoreldap {-lb <arg>} {-t <arg>} [options]
 
 ==== Description
 
-[cols=",",options="header",]
+[cols="1m,3",options="header",]
 |=======================================================================
 |Short Name |Description
 
-|`-lb` |
+|-lb |
 `<arg>` Session label to restore from.  For example, `full200612291821113`.
 
-|`-t` |
+|-t |
 `<arg>` Specifies the backup target location.  The default is
 `/opt/zimbra/backup`.
 
-|`-lbs` |
+|-lbs |
 Lists all session labels in backup.
 
-|`-l` |
+|-l |
 Lists accounts in file.
 
-|`-a` |
+|-a |
 `<arg>` Restores named account(s).  List account names separated by white
 space.
 
@@ -2456,17 +2454,17 @@ zmcontrol [ -v -h ] command [args]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-| | `-v` |
+| | -v |
 Displays {product-abbrev} software version.
 
-| |`-h` |
+| |-h |
 Displays the usage options for this command.
 
-| |`-H` |
+| |-H |
 Host name (localhost).
 
 
@@ -2510,35 +2508,35 @@ zmmboxsearch {-m <arg>} {-q <arg>} [-o <arg>] [-l <arg>] [-d <arg>] [options]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--dir` |`-d` |
+|--dir |-d |
 `<arg>` Directory to write the messages to.  If none is specified, then
 only the headers are fetched.  Files names are generated in the form
 `RESULTNUM_ACCOUNT-ID_MAILITEMID`.
 
-|`--help` |`-h` |
+|--help |-h |
 Displays help information.
 
-|`--limit` |`-l` |
+|--limit |-l |
 Sets the limit for the number of results returned.  The default is 25.
 
-|`--mbox` |`-m` |
+|--mbox |-m |
 `<arg>` Comma-separated list of mailboxes to search.  UIDs or email-address
 or `/SERVER/MAILBOXID` or `*`.
 
-|`--offset` |`-o` |
+|--offset |-o |
 `<arg>` Specify where the hit list should start.  The default is 0.
 
-|`--query` |`-q` |
+|--query |-q |
 `<arg>` The query string for the search.
 
-|`--server` |`-s` |
+|--server |-s |
 `<arg>` Mail server hostname.  default is the localhost
 
-|`--verbose` |`-v` |
+|--verbose |-v |
 Request that the status message print while the search is being executed.
 
 |=======================================================================
@@ -2580,24 +2578,24 @@ zmmboxmove -a <email> --from <src> --to <dest> [--sync]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--account` |`-a` |
+|--account |-a |
 `<arg>` Email address of account to move.
 
-|`--help` |`-h` |
+|--help |-h |
 Displays the usage options for this command.
 
-|`--from` |`-f` |
+|--from |-f |
 `<arg>` Mail server hostname.  Server where the `--account` mailbox is
 located.
 
-|`--to` |`-t` |
+|--to |-t |
 `<arg>` Destination server.
 
-|`--sync` |`-sync`
+|--sync |-sync
 |Run synchronously
 
 |=======================================================================
@@ -2626,17 +2624,17 @@ zmpurgeoldmbox -a <account email> [-s <server to purge>]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--account` |`-a` |
+|--account |-a |
 `<arg>` Email address of account to purge.
 
-|`--help` |`-h` |
+|--help |-h |
 Displays the usage options for this command
 
-|`--server` |`-s` |
+|--server |-s |
 `<arg>` Mail server hostname.  Old server where the account existed
 
 |=======================================================================
@@ -2654,11 +2652,11 @@ To see attributes and settings for a GAL sync account, run `zmprov gds`
 against the account.
 
 
-[cols=",a",options="header",]
+[cols="1m,2a",options="header",]
 |=======================================================================
 |Long Name |Description
 
-|`createAccount` |
+|createAccount |
 Creates the GAL sync account.  This should be done from
 the Administration Console.
 
@@ -2666,19 +2664,19 @@ The parameter "server" is required.
 
 `-a {account-name} -n {datasource-name} --domain {domain-name} -t zimbra\|ldap -s {server} [-f {folder-name}] [-p {polling-interval}]`
 
-|`addDataSource` |
+|addDataSource |
 When configuring a datasource for a server, specify a folder name other
 than `/Contacts`.  The datasource folder name must be unique.
 
 `-a {account-name} -n {datasource-name} --domain {domain-name} -t zimbra\|ldap [-f {folder-name}] [-p {polling-interval}]`
 
-|`deleteAccount` |
+|deleteAccount |
 Deletes the GAL sync account and the references to the LDAP server.  The
 account can also be deleted from the Administration Console.
 
 `deleteAccount [-a {galsynceaccountname}\|-i {account-id}]`
 
-|`trickleSync` |
+|trickleSync |
 This syncs new and updated contact data only.
 
 `[-a {galsynceaccountname}\|-i {account-id}]` +
@@ -2689,14 +2687,14 @@ of the address book (folder) in the GAL account created to sync LDAP to.
 
 A cron job can be set up to run trickleSync.
 
-|`fullSync` |
+|fullSync |
 This syncs all LDAP contact data.  You can also set this from the
 Administration Console.
 
 `[-a {galsynceaccountname}\|-i {account-id}]` +
 `[-d {datasource-id}] [-n {datsource-name}]`
 
-|`forceSync` |
+|forceSync |
 This should be used to reload the entire GAL if there is change in the
 filter, attribute mapping or LDAP server parameters.
 
@@ -2735,37 +2733,37 @@ same as the password on the LDAP master server.
 ==== Syntax
 [source,bash]
 ----
-/opt/zimbra/bin/zmldappasswd [-h] [-r] [-p] [-l] new-password
+zmldappasswd [-h] [-r] [-p] [-l] new-password
 ----
 
 ==== Description
 
-[cols=",",options="header",]
+[cols="1m,3",options="header",]
 |=======================================================================
 |Name |Syntax, Example, Notes
 
-|`-h` |
+|-h |
 Displays the help.
 
-|`-a` |
+|-a |
 Changes `ldap_amavis-password`.
 
-|`-b` |
+|-b |
 Changes `ldap_bes_searcher_password`.
 
-|`-l` |
+|-l |
 Changes `ldap_replication_password`.
 
-|`-p` |
+|-p |
 Changes `ldap_postfix_password`.
 
-|`-n` |
+|-n |
 Changes `ldap_nginx_password`.
 
-|`-r` |
+|-r |
 Changes `ldap_root_passwd`.
 
-|`-c` |
+|-c |
 Updates the password in the config database on replicas.  Must be used with
 `-1` and must be run on a replica after changing the password on the
 master.
@@ -2791,61 +2789,61 @@ To see the local config type `zmlocalconfig`.
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--config` |`-c` |
+|--config |-c |
 `<arg>` File in which the configuration is stored.
 
-|`--default` |`-d` |
+|--default |-d |
 Show default values for keys listed in `[args]`.
 
-|`--edit` |`-e` |
+|--edit |-e |
 Edit the configuration file, change keys and values specified.  The
 `[args]` is in the `key=value` form.
 
-|`--force` |`-f` |
+|--force |-f |
 Edit the keys whose change is known to be potentially dangerous.
 
-|`--help` |`-h` |
+|--help |-h |
 Shows the help for the usage options for this tool.
 
-|`--info` |`-i` |
+|--info |-i |
 Shows the list of supported properties.
 
-|`--format` |`-m` |
+|--format |-m |
 `<arg>` Shows the values in one of these formats: `plain` (default), `xml`,
 `shell`, `nokey`.
 
-|`--changed` |`-n` |
+|--changed |-n |
 Shows the values for only those keys listed in the `[args]` that have been
 changed from their defaults.
 
-|`--path` |`-p` |
+|--path |-p |
 Shows which configuration file will be used.
 
-|`--quiet` |`-q` |
+|--quiet |-q |
 Suppress logging.
 
-|`--random` |`-r` |
+|--random |-r |
 This option is used with the edit option.  Specified key is set to a random
 password string.
 
-|`--show` |`-s` |
+|--show |-s |
 Forces the display of the password strings.
 
-|`--unset` |`-u` |
+|--unset |-u |
 Remove a configuration key.  If this is a key with compiled-in defaults,
 set its value to the empty string.
 
-|`--expand` |`-x` |
+|--expand |-x |
 Expand values.
 
-|`--zimbraAmavisMaxServers` | |
+|--zimbraAmavisMaxServers | |
 Allows control of the concurrency of Amavisd (default 10).
 
-|`--zimbraClamAVMaxThreads` | |
+|--zimbraClamAVMaxThreads | |
 Allows control of the concurrency of ClamAV (default 10).
 
 |=======================================================================
@@ -2871,56 +2869,56 @@ zmmailbox [args] [cmd] [cmd-args]...
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Short Name |Long Name |Syntax, Example, and Notes
 
-|`-h` |`--help` |
+|-h |--help |
 Display usage.
 
-|`-f` |`--file` |
+|-f |--file |
 Use file as input stream.
 
-|`-u` |`--url` |
+|-u |--url |
 `http[s]://{host}[:{port}]` server hostname and optional port.  Must use
 admin port with `-z`/`-a`.
 
-|`-a` |`--account` |
+|-a |--account |
 Account name to auth as `{name}`.
 
-|`-z` |`--zadmin` |
+|-z |--zadmin |
 Use zimbra admin name/password from localconfig for admin/password.
 
-|`-y` |`--authtoken {authtoken}` |
+|-y |--authtoken {authtoken} |
 Use authtoken string (has to be in JSON format) from command line.
 
-|`-Y` |`--authtoken {authtoken-file}` |
+|-Y |--authtoken {authtoken-file} |
 Use authtoken string (has to be in JSON format) from a file.
 
-|`-m` |`--mailbox {name}` |
+|-m |--mailbox {name} |
 Mailbox to open.  Can be used as both authenticated and targeted unless
 other options are specified.
 
-| |`--auth {name}` |
+| |--auth {name} |
 Account name to authorize as.  Defaults to
 `--mailbox` unless `--admin-priv` is used.
 
-|`-A` |`--admin-priv` |
+|-A |--admin-priv |
 Execute requests with admin privilege.
 
-|`-p` |`--password {pass}` |
+|-p |--password {pass} |
 Password for admin account and or mailbox.
 
-|`-P` |`--passfile {file}` |
+|-P |--passfile {file} |
 Read password from file.
 
-|`-t` |`--timeout` |
+|-t |--timeout |
 Timeout (in seconds).
 
-|`-v` |`--verbose` |
+|-v |--verbose |
 Verbose mode (dumps full exception stack trace)
 
-|`-d` |`--debug` |
+|-d |--debug |
 Debug mode (dumps SOAP messages)
 
 |=======================================================================
@@ -2929,44 +2927,44 @@ Specific CLI tools are available for the different components of a mailbox.
 Usage is described in the CLI help for the following.
 
 
-[cols=",",options="",]
+[cols="1m,2",options="",]
 |=======================================================================
-|`zmmailbox help admin` |
+|zmmailbox help admin |
 Help on admin-related commands.
 
-|`zmmailbox help commands` |
+|zmmailbox help commands |
 Help on all `zmmailbox` commands.
 
-|`zmmailbox help appointment` |
+|zmmailbox help appointment |
 Help on appointment-related commands.
 
-|`zmmailbox help contact` |
+|zmmailbox help contact |
 Help on contact-related commands (address book).
 
-|`zmmailbox help conversation` |
+|zmmailbox help conversation |
 Help on conversation-related commands.
 
-|`zmmailbox help filter` |
+|zmmailbox help filter |
 Help on filter-related commands.
 
-|`zmmailbox help folder` |
+|zmmailbox help folder |
 Help on folder-related commands.
 
-|`zmmailbox help item` |
+|zmmailbox help item |
 Help on item-related commands.
 
-|`zmmailbox help message` |
+|zmmailbox help message |
 Help on message-related commands.
 
-|`zmmailbox help misc` |
+|zmmailbox help misc |
 Help on miscellaneous commands.
 
-|`zmmailbox help right` |
+|zmmailbox help right |
 Help on right commands.
-|`zmmailbox help search` |
+|zmmailbox help search |
 Help on search-related commands.
 
-|`zmmailbox help tag` |
+|zmmailbox help tag |
 Help on tag-related commands.
 
 |=======================================================================
@@ -2981,7 +2979,7 @@ folders.  You can invoke `zmmailbox` inside of `zmprov` by using
 
 [source,bash]
 ----
-domain.example.com$ /opt/zimbra/bin/zmprov
+$ zmprov
 prov> ca user10@domain.example.com test123
 9a993516-aa49-4fa5-bc0d-f740a474f7a8
 prov> sm user10@domain.example.com
@@ -3168,27 +3166,27 @@ zmhsm {abort|start|status} {server} <name>
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--abort` |`-a` |
+|--abort |-a |
 Aborts the current HSM session.  If all the messages in a mailbox being
 processed were not moved before you clicked *Abort*, no messages from that
 mailbox are moved from the primary volume.  Messages for mailboxes that
 have completed the move to the secondary volume are not moved back to the
 primary volume.
 
-|`--help` |`-h` |
+|--help |-h |
 Shows the help for the usage options for this tool.
 
-|`--server` |`-s` |
+|--server |-s |
 `<arg>` The mail server host name.  The default is the localhost `[args]`.
 
-|`--start` |`-t` |
+|--start |-t |
 Manually starts the HSM process.
 
-|`--status` |`-u` |
+|--status |-u |
 The status of the last HSM session is displayed.
 
 |=======================================================================
@@ -3207,23 +3205,23 @@ zmlicense [options]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--check` |`-c` |
+|--check |-c |
 Check to see if a valid license is installed.
 
-|`--help` |`-h` |
+|--help |-h |
 Shows the help for the usage options for this tool.
 
-|`--install` |`-i` |
+|--install |-i |
 `<arg>` Installs the specified license file.
 
-|`--ldap` |`-l` |
+|--ldap |-l |
 Install on LDAP only.
 
-|`--print` |`-p` |
+|--print |-p |
 Displays the license information.
 
 |=======================================================================
@@ -3247,9 +3245,9 @@ zmmetadump -f <file containing encoded metadata>
 === zmmypasswd
 
 Use `zmmypasswd` to change `zimbra_mysql_password`.  If the `--root` option
-is specified, the `mysql_root_passwd` is changed.  In both cases, MySQL is
-updated with the new passwords.  Refer to the MySQL documentation to see
-how you can start the MySQL server temporarily to skip grant tables, to
+is specified, the `mysql_root_passwd` is changed.  In both cases, MariaDB is
+updated with the new passwords.  Refer to the MariaDB documentation to see
+how you can start the MariaDB server temporarily to skip grant tables, to
 override the root password.
 
 [NOTE]
@@ -3276,40 +3274,40 @@ zmplayredo <option>
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--fromSeq` | |
+|--fromSeq | |
 `<arg>` Replays snapshots from the specified redolog sequence.
 
-|`--fromTime` | |
+|--fromTime | |
 `<arg>` Replays snapshots from the specified time.
 
-|`--help` |`-h` |
+|--help |-h |
 Shows the help information for this command.
 
-|`--logfiles` | |
+|--logfiles | |
 `<arg>` Replays the specified logfiles in order.
 
-|`--mailboxId` | |
+|--mailboxId | |
 `<arg>` Replays snapshots for the specified mailbox.
 
-|`--queueCapacity | |
+|--queueCapacity | |
 `<arg>` Used for specifying the queue capacity per player thread.  The
 default value is 100.
 
-|`--stopOnError` | |
+|--stopOnError | |
 Stops the replay on occurrence of any error.
 
-|`--threads` | |
+|--threads | |
 `<arg>` Specifies the number of parallel redo threads.  The default value is
 50.
 
-|`--toSeq` | |
+|--toSeq | |
 `<arg>` Replays snapshots to the specified redolog sequence.
 
-|`--toTime` | |
+|--toTime | |
 `<arg>` Replays snapshots to the specified time.
 
 |=======================================================================
@@ -3335,51 +3333,51 @@ ProxyConfGen [options]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--config` |`-c` |
+|--config |-c |
 `<arg>` Overrides a config variable.  The `<arg>` format should be
 `name=value`.  To see a list of names, use `-d` or `-D`.
 
-|`--defaults` |`-d` |
+|--defaults |-d |
 Prints the default variable map.
 
-|`--definitions` |`-D` |
+|--definitions |-D |
 Prints the Definitions variable map after loading LDAP configuration and
 processing overrides.
 
-|`--help` |`-h` |
+|--help |-h |
 Displays help information.
 
-|`--include-dir` |`-i` |
+|--include-dir |-i |
 `<arg>` Displays the directory path (relative to `$workdir/conf`), where
 included configuration files are written.
 
-|`--dry-run` |`-n` |
+|--dry-run |-n |
 Specifies not to write configuration and only display the files that would
 be written.
 
-|`--prefix` |`-p` |
+|--prefix |-p |
 `<arg>` Displays the config file prefix.  The default value is `nginx.conf`
 
-|`--template-prefix` |`-P` |
+|--template-prefix |-P |
 `<arg>` Displays the template file prefix.  The default value is `$prefix`.
 
-|`--server` |`-s` |
+|--server |-s |
 `<arg>` Specifies a valid server object.  Configuration is generated based
 on the specified server's attributes.  The default is to generate
 configuration based on global configuration values.
 
-|`--templatedir` |`-t` |
+|--templatedir |-t |
 `<arg>` Specifies the proxy template directory.  The default value is
 `$workdir/conf/nginx/templates`.
 
-|`--verbose` |`-v` |
+|--verbose |-v |
 Displays verbose data.
 
-|`--workdir` |`-w` |
+|--workdir |-w |
 `<arg>` Specifies the proxy working directory.  The default value is
 `/opt/zimbra`.
 
@@ -3400,26 +3398,26 @@ ProxyPurgeUtil [-v] [-i] -a account [-L accountlist] [cache1] [cache2]...]
 
 ==== Description
 
-[cols=",,a",options="header",]
+[cols="1m,1m,2a",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--help` |`-h` |
+|--help |-h |
 Shows the help for the usage options for this tool.
 
-|`--verbose` |`-v` |
+|--verbose |-v |
 Displays verbose data.
 
-|`--info` |`-i` |
+|--info |-i |
 Displays account routing information.
 
-|`--account` |`-a` |
+|--account |-a |
 Displays account name.
 
-|`--list` |`-L` |
+|--list |-L |
 Displays file containing list of accounts, one per line.
 
-|`--output` |`-o` |
+|--output |-o |
 Specifies the format to be used for printing routing information with
 information.  The fields that display by default are
 
@@ -3427,7 +3425,7 @@ information.  The fields that display by default are
 * account name
 * route information
 
-|`cacheN` | |
+|cacheN | |
 (optional command) Specifies additional memcache server in the form of
 server:port.
 
@@ -3450,28 +3448,28 @@ zmredodump [options] <redolog file/directory> [...]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--help` |`-h` |
+|--help |-h |
 Displays help messages.
 
-| |`-m` |
+| |-m |
 Specifies the mailbox ids separated by a comma or a space.  The entire list
 of mailbox ids must be quoted if using space as a separator.
 
 To dump contents of all the redolog files, omit this option.
 
-|`--no-offset` | |
+|--no-offset | |
 Specifies if file offsets and size for each redolog dump should not be
 shown.
 
-|`--quiet` |`-q` |
+|--quiet |-q |
 Activates the quiet mode.  Used to only print the log filename and errors,
 if any.  Useful for verifying integrity of redologs with minimal output.
 
-|`--show-blob` | |
+|--show-blob | |
 Shows blob content.  The specified item's blob is printed with `<START OF
 BLOB>` and `<END OF BLOB>` marking the start and end of the blob.
 
@@ -3506,49 +3504,49 @@ zmsoap [options] {path1} [path2]...
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--help` |`-h` |
+|--help |-h |
 Prints usage information.
 
-|`--mailbox` |`-m` |
+|--mailbox |-m |
 `<name>` Displays mailbox account name.  Mail and account requests are sent
 to this account.  This attribute is also used for authentication if `-a`
 and `-z` are not specified.
 
-|`--target` | |
+|--target | |
 `<name>` Displays the target account name to which the requests are sent.
 Used only for non-admin sessions.
 
-|`--admin name` |`-a` |
+|--admin name |-a |
 `<name>` Displays the admin account name to authenticate as.
 
-|`--zadmin` |`-z` |
+|--zadmin |-z |
 Displays the Zimbra admin name and password to authenticate as.
 
-|`--password` |`-p` |
+|--password |-p |
 `<pass>` Displays account password.
 
-|`--passfile` |`-P` |
+|--passfile |-P |
 `<path>` Reads password from a file.
 
-|`--element` |`-e` |
+|--element |-e |
 `<path>` Displays the root element path.  If specified, all path arguments
 that do not start with a slash (`/`) are relative to this element.
 
-|`--type` |`-t` |
+|--type |-t |
 `<type>` Displays the SOAP request type.  Can either be `mail`, `account`,
 or `admin`.
 
-|`--url` |`-u` |
+|--url |-u |
 `<http[s]://...>` Displays the server hostname and optional port value.
 
-|`--verbose` |`-v` |
+|--verbose |-v |
 Prints the SOAP request and other status information.
 
-|`path` | |
+|path | |
 `<[path]...>` Displays the element or attribute path and value.  Roughly
 follows the XPath syntax as: `[/]element1[/element2][/@attr][=value]`.
 
@@ -3557,7 +3555,7 @@ follows the XPath syntax as: `[/]element1[/element2][/@attr][=value]`.
 === zmstat-chart
 
 Use `zmstat-chart` to collect statistical information for the CPU, IO,
-mailboxd, MTAqueue, MySQL, and other components and to run a script on the
+mailboxd, MTAqueue, MariaDB, and other components and to run a script on the
 csv files to display the usage details in various charts.  These csv files
 are saved to `/opt/zimbra/zmstat/`.
 
@@ -3580,40 +3578,40 @@ zmstat-chart -s <arg> -d <arg> [options]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--aggregate-end-at` | |
+|--aggregate-end-at | |
 `<arg>` If this is specified, the aggregate computation ends at this
 timestamp.  Usage is `MM/dd/yyyy HH:mm:ss`.
 
-|`--aggregate-start-at` | |
+|--aggregate-start-at | |
 `<arg>` If this is specified, the aggregate computation starts at this
 timestamp.  Usage is `MM/dd/yyyy HH:mm:ss`.
 
-|`--end-at` | |
+|--end-at | |
 `<arg>` If this is specified, all samples after the specified timestamp are
 ignored.  Usage is `MM/dd/yyyy HH:mm:ss`.
 
-|`--start-at` | |
+|--start-at | |
 `<arg>` If this is specified, all samples before this timestamp are
 ignored.
 
-|`--title` | |
+|--title | |
 `<arg>` This gives the chart a title that displays.  Defaults to the last
 directory name of srcdir.
 
-|`--no-summary` | |
+|--no-summary | |
 Summary data generation is not included.
 
-|`--conf` |`-c` |
+|--conf |-c |
 `<arg>` Chart the configuration xml files.
 
-|`--destdir` |`-d` |
+|--destdir |-d |
 `<arg>` The directory where the generated chart files are saved.
 
-|`--srcdir` | |
+|--srcdir | |
 One or more directories where the csv files are located.  The csv files are
 moved to directories listed by date under `zmstat/`.
 
@@ -3652,31 +3650,31 @@ zmthrdump [-h] [-i] [-t <timeout seconds>] [-p <pid file>] [-f <file>] [-o <out-
 
 ==== Description
 
-[cols=",",options="header",]
+[cols="1m,3",options="header",]
 |=======================================================================
 |Short Name |Description
 
-|`-h` |
+|-h |
 Displays help messages.
 
-|`-i` |
+|-i |
 Appends the timestamp to the LOGFILE before invoking SIGQUIT.
 
-|`-p` |
+|-p |
 Returns the PID to send SIGQUIT.  The default value can be found in
 `zmmailboxd_java.pid`
 
 
-|`-f` |
+|-f |
 Specifies the LOGFILE to save the thread dump output in.  The default value
 is `zmmailbox.out`.
 
-|`-o` |
+|-o |
 
 Specifies the output file of the thread
 dump.  The default value is stdout.
 
-|`-t` |
+|-t |
 Specifies the timeout value (in seconds) to exit if the process becomes
 unresponsive.  The default value is 30 seconds.
 
@@ -3720,30 +3718,30 @@ zmtzupdate --rulefile <rule file> -a <"all" or list of specific email addresses>
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name* |Short Name |Description
 
-|`--account` |`-a` |
+|--account |-a |
 `<arg>` account email addresses separated by a white space.  Use "all" for
 all accounts to be updated.
 
-|`--after` | |
+|--after | |
 `<arg>` Appointments occurring after the specified date/time in this field
 are updated.  The default cut off time is January 1st, 2008.
 
-|`--help` |`-h` |
+|--help |-h |
 Displays help information.
 
-|`--rulefile` | |
+|--rulefile | |
 Specifies the .ics XML file that should be used to update time zone
 definitions.
 
-|`--server` |`-s` |
+|--server |-s |
 `<arg>` Specifies the mail server hostname.  The default value is
 localhost.
 
-|`--sync` | |
+|--sync | |
 If specified, this option causes the `zmtzupdate` command to block till the
 server processes all requested accounts.  The default value is no.
 
@@ -3762,53 +3760,53 @@ zmvolume {-a|-d|-l|-e|-dc|-sc} [options]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short Name |Description
 
-|`--add` |`-a` |
+|--add |-a |
 Adds a volume.
 
-|`--compress` |`-c` |
+|--compress |-c |
 `<arg>` Compress BLOBs; "true" or "false".
 
-|`--compressionThreshold` |`-ct` |
+|--compressionThreshold |-ct |
 Compression threshold; default 4KB.
 
-|`--delete` |`-d` |
+|--delete |-d |
 Deletes a volume.
 
-|`--displayCurrent` |`-dc` |
+|--displayCurrent |-dc |
 Displays the current volume.
 
-|`--edit` |`-e` |
+|--edit |-e |
 Edits a volume.
 
-|`--help` |`-h` |
+|--help |-h |
 Shows the help for the usage options for this tool.
 
-|`--id` |`-id` |
+|--id |-id |
 `<arg>` Volume ID.
 
-|`--list` |`-l` |
+|--list |-l |
 Lists volumes.
 
-|`--name` |`-n` |
+|--name |-n |
 `<arg>` Volume name.
 
-|`--path` |`-p` |
+|--path |-p |
 `<arg>` Root path.
 
-|`--server` |`-s` |
+|--server |-s |
 `<arg>` Mail server hostname.  Default is localhost.
 
-|`--setCurrent` |`-sc` |
+|--setCurrent |-sc |
 Sets the current volume.
 
-|`--type` |`-t` |
+|--type |-t |
 `<arg>` Volume type (primaryMessage, secondaryMessage, or index)
 
-|`--turnOffSecondary` |`-ts` |
+|--turnOffSecondary |-ts |
 Turns off the current secondary message volume.
 
 |=======================================================================
@@ -3827,52 +3825,52 @@ zmzimletctl [-l] {command} [<zimlet.zip>|<config.xml>|<zimlet>]
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,2",options="header",]
 |=======================================================================
-|Long Name |Short Name |Description
+|Long Name | Description
 
-|deploy | |
+|deploy |
 `<zimlet.zip>` Creates the Zimlet entry in the LDAP server, installs the
 zimlet files on the Server, grants, access to the members of the default
 COS, and turns on the Zimlet.
 
-|`undeploy` | |
+|undeploy |
 `<zimlet>` Uninstall a zimlet from the Zimbra server.
 
-|`install` | |
+|install |
 `<zimlet.zip>` Installs the Zimlet files on the host.
 
 
-|`ldapDeploy` | |
+|ldapDeploy |
 `<zimlet>` Adds the Zimlet entry to the LDAP.
 
-|`enable` | |
+|enable |
 `<zimlet>` Enables the Zimlet.
 
-|`disable` | |
+|disable |
 `<zimlet>` Disables the Zimlet.
 
-|`acl` | |
+|acl |
 `<zimlet> <cos1> {grant \| deny} \| [<cos2> {grant\|deny}...]`
 
 Sets the access control, grant\|deny, to a COS.
 
-|`listAcls` | |
+|listAcls |
 `<zimlet>` Lists the ACLs for the Zimlets.
 
-|`listZimlets` | |
+|listZimlets |
 View details about all Zimlets on the server.
 
-|`getConfigTemplate` | |
+|getConfigTemplate |
 `<zimlet.zip>` Extracts the configuration template from the Zimlet.zip file.
 
-|`configure` | |
+|configure |
 `<config.xml>` Installs the configuration.
 
-|`listPriority` | |
+|listPriority |
 Shows the current Zimlet priorities (0 is high, 9 is low)
 
-|`setPriority` | |
+|setPriority |
 `<zimlet>` Sets the Zimlet priority.
 
 |=======================================================================
@@ -3894,59 +3892,59 @@ Previous to {product-abbrev} 6.0, this command was called `zmproxyinit`.
 
 ==== Description
 
-[cols=",",options="header",]
+[cols="1m,3",options="header",]
 |=======================================================================
 |Short Name |Description
 
-|`-h` |
+|-h |
 Displays help messages.
 
-|`-H` |
+|-H |
 Hostname of the server on which enable/disable proxy functionality.
 
-|`-a` |
+|-a |
 Colon separated list of Web ports to use.  Format:
 *HTTP-STORE:HTTP-PROXY:HTTPS-STORE:HTTPS-PROXY* (Ex: 8080:80:8443:443)
 
-|`-d` |
+|-d |
 Disable proxy.
 
-|`-e` |
+|-e |
 Enable proxy.
 
-|`-f` |
+|-f |
 Full reset on memcached port and search queries and POP/IMAP throttling.
 
-|`-i` |
+|-i |
 Colon separated list of IMAP ports to use.  Format:
 *IMAP-STORE:IMAP-PROXY:IMAPS-STORE:IMAPS-PROXY* (Ex: 7143:143:7993:993)
 
-|`-m` |
+|-m |
 Toggle mail proxy portions.
 
-|`-o` |
+|-o |
 Override enabled checks.
 
-|`-p` |
+|-p |
 Colon separated list of POP ports to use.  Format:
 *POP-STORE:POP-PROXY:POPS-STORE:POPS-PROXY* (Ex: 7110:110:7995:995)
 
-|`-r` |
+|-r |
 Run against a remote host.  Note that this requires the server to be
 properly configured in the LDAP master.
 
-|`-s` |
+|-s |
 Set Cleartext to FALSE (secure mode) on disable.
 
-|`-t` |
+|-t |
 Disable reverse proxy lookup target for the store server.  Only valid with
 `-d`.  Make sure that you intend for all proxy functions for the server to
 be disabled.
 
-|`-w` |
+|-w |
 Toggle Web proxy portions.
 
-|`-x` |
+|-x |
 `zimbraMailMode` to use on disable (Default is HTTP)
 
 |=======================================================================
@@ -3967,12 +3965,12 @@ Required options are `-f` by itself, or `-f` with `-d` or `-e`.
 The following are the defaults for `-a`, `-i`, `-p`, and `-x` if they are
 not supplied as options.
 
-[cols=",,",options=""]
+[cols="1m,2,2",options=""]
 |=======================================================================
-|`-a` |default on enable: 8080:80:8443:443  |default on disable: 80:0:443:0
-|`-i` |default on enable: 7143:143:7993:993 |default on disable: 143:7143:993:7993
-|`-p` |default on enable: 7110:110:7995:995 |default on disable: 110:7110:995:7995
-|`-x` |default on store disable: http |default on proxy enable/disable: http
+|-a |default on enable: 8080:80:8443:443  |default on disable: 80:0:443:0
+|-i |default on enable: 7143:143:7993:993 |default on disable: 143:7143:993:7993
+|-p |default on enable: 7110:110:7995:995 |default on disable: 110:7110:995:7995
+|-x |default on store disable: http |default on proxy enable/disable: http
 |=======================================================================
 
 === zmsyncreverseproxy
@@ -3989,32 +3987,32 @@ zmsyncreverseproxy [-v] [-d] [-L log4j.properties] -p <port number> -fs <fwd ser
 
 ==== Description
 
-[cols=",,",options="header",]
+[cols="1m,1m,2",options="header",]
 |=======================================================================
 |Long Name |Short |Description
 
-|`--help` |`-h` |
+|--help |-h |
 Displays help.
 
-|`--verbose` |`-v` |
+|--verbose |-v |
 Verbose mode, dumps full exception stack trace.
 
-|`--debug` |`-d` |
+|--debug |-d |
 Debug mode, dumps decoded sync messages.
 
-|`--port` |`-p` |
+|--port |-p |
 The port this service listens on.
 
-|`--forwardserver` |`-fs` |
+|--forwardserver |-fs |
 The server host to forward requests to.
 
-|`--forwardport` |`-fp` |
+|--forwardport |-fp |
 The server port to forward requests to.
 
-|`--syncversions` |`-sv` |
+|--syncversions |-sv |
 Active sync versions supported.
 
-|`--logpropertyfile` |`-L` |
+|--logpropertyfile |-L |
 `log4j` property file, valid only with `-l`.
 
 |=======================================================================

--- a/colorandlogo.adoc
+++ b/colorandlogo.adoc
@@ -118,7 +118,7 @@ theme categories:
 
 Admin Console: ::
 *Home > Configure > Global Settings > Themes* or +
-*Home > Configure > Domains > _domain_ > Themes*
+*Home > Configure > Domains -> _domain_ -> Themes*
 
 1.  Click on the field alongside the theme category to be modified, then
 use the popup color selector to define the color for your selection.
@@ -156,9 +156,9 @@ changed.
 Use the *Customize the logo of the themes* container to a logo to
 accompany the theme:
 
-Admin Console ::
+Admin Console: ::
 *Home > Configure > Global Settings > Themes* or +
-*Home > Configure > Domains > _domain_ > Themes*
+*Home > Configure > Domains -> _domain_ -> Themes*
 
 .Logo Settings
 
@@ -193,7 +193,7 @@ global config setting or as a domain settings.  Color values are
 entered as a six-digit hexadecimal codes.
 
 .Color Attributes
-[cols=",",options="header",]
+[cols="m,",options="header",]
 |====================================================================
 |Attribute |Description
 
@@ -218,13 +218,13 @@ Before you begin, identify the six-digit hexadecimal base color values
 for the various elements you are changing. You will be using these in
 your command entries.
 
-*CLI:* Global Setting:
+.Global Settings
 [source,bash]
 ----
 zmprov modifyConfig <attribute-name> [“#HEX_6digit_colorcode”]
 ----
 
-*CLI:* Domain Setting:
+.Domain Settings
 [source,bash]
 ----
 zmprov modifyDomain <domain> <attribute-name> [“#HEX_6digit_colorcode”]
@@ -240,11 +240,17 @@ base colors:
 * Selection color = yellow, #FFFF00
 
 1. Specify the skin colors:
-*CLI:* Log in as a Zimbra user and use parameters to modify the domain:
+Log in as the `zimbra` user and use `zmprov` to modify the domain:
 +
-  zmprov modifyDomain domainexample.com zimbraSkinBackgroundColor "#FF7F50" zimbraSkinSecondaryColor "#ADEAEA" zimbraSkinSelectionColor "#FFFF00"
+[source,bash]
+----
+zmprov modifyDomain example.com \
+ zimbraSkinBackgroundColor "#FF7F50" \
+ zimbraSkinSecondaryColor "#ADEAEA" \
+ zimbraSkinSelectionColor "#FFFF00"
+----
 +
-The quote marks, "", are required so the use of the # sign does not
+The quote marks, `""`, are required so the use of the `#` sign does not
 comment out the text that follows.
 +
 2. Use the zmmailboxdctl command to apply the changes by restarting
@@ -261,7 +267,7 @@ You add the company logo information and URL by modifying these the
 following attributes for logos:
 
 .Logo Settings
-[cols=",",options="header",]
+[cols="m,",options="header",]
 |=======================================================================
 |Attribute |Description
 
@@ -286,7 +292,7 @@ in a subdirectory of `/opt/zimbra/jetty/webapps/zimbra`.
 If the logos are hosted on another machine, enter the full URL when
 identifying the logo.
 
-*CLI:* Use steps in this section to update the logo(s) displayed over a
+Use steps in this section to update the logo(s) displayed over a
 domain:
 
 1.  Change the URL link:
@@ -314,8 +320,7 @@ your logo image file(s) for replacement of the default Zimbra images in
 the user interfaces.
 
 [NOTE]
-_Not currently supported:_ Logo modification for the Zimbra
-Web Client.
+_Not currently supported:_ Logo modification for the Zimbra Web Client.
 
 You can globally replace the {product-name} logo with your
 company's logo by replacing the image files in specific paths, as
@@ -341,8 +346,8 @@ The image displays on white background.
 |Size Requirement: |300 x 65 |600 x 130
 
 |File location: |
-/skins/_base/logos/TouchLonginBanner.png |
-/skins/_base/logos/TouchLonginBanner@2x.png
+`/skins/_base/logos/TouchLonginBanner.png` |
+`/skins/_base/logos/TouchLonginBanner@2x.png`
 
 |=======================================================================
 
@@ -355,8 +360,8 @@ The image displays on white background.
 |Size Requirement: |200 x 45 |400 x 90
 
 |File location: |
-/skins/_base/logos/TouchWatermarkBanner.png |
-/skins/_base/logos/TouchWatermarkBanner@2x.png
+`/skins/_base/logos/TouchWatermarkBanner.png` |
+`/skins/_base/logos/TouchWatermarkBanner@2x.png`
 
 |=======================================================================
 
@@ -369,13 +374,13 @@ The image displays on white background.
 |Size Requirement: |Mobile phone: 57 x 57 |Mobile phone: 114 x 114
 
 |File Location: |
-/img/logo/Icon.png |
-/img/logo/Icon@2x.png
+`/img/logo/Icon.png` |
+`/img/logo/Icon@2x.png`
 
 |Size Requirement: |Tablet: 72 x 72 |Tablet: 144 x 144
 
 |File Location: |
-/img/logo/Icon~ipad.png |
-/img/logo/Icon~iPad@2x.png
+`/img/logo/Icon~ipad.png` |
+`/img/logo/Icon~\iPad@2x.png`
 
 |=======================================================================

--- a/configuration.adoc
+++ b/configuration.adoc
@@ -8,7 +8,7 @@ from either the Administration Console or using the CLI utility.
 
 *Help* is available from the Administration Console about how to perform
 tasks from the Administration Console. If the task is only available from
-the CLI, see <<cli_commands, Zimbra CLI Commands>> for a description of how
+the CLI, see <<cli_commands,Zimbra CLI Commands>> for a description of how
 to use the CLI utility.
 
 == Global Configuration
@@ -24,7 +24,7 @@ global settings.
 
 Admin Console: ::
 To configure global settings, navigate to: +
-*Configure > Global Settings*
+*Home > Configure > Global Settings*
 
 Configured global settings are:
 
@@ -96,7 +96,7 @@ The maximum size of a file that can be uploaded into Briefcase.
 
 [NOTE]
 The maximum message size for an email message and attachments that can be
-sent is configured in the *Global Settings > MTA* page, *Messages* section.
+sent is configured in the *Home > Configure > Global Settings > MTA* page, *Messages* section.
 
 |Admin Help URL +
 Delegated Admin Help URL|
@@ -116,12 +116,13 @@ for individual accounts. When attachment settings are configured in Global
 Settings, the global rule takes precedence over COS and Account settings.
 
 Admin Console: ::
-*Home > Configure > Global Settings > Advanced*
+*Home > Configure > Global Settings > Attachments*
 
 [cols=","]
 image:images/administration_console_email_attachment_rules.png[Attachment Rules] +
-See <<_blocking_email_attachments_by_file_type, Blocking Email Attachments
-by File type>> for information about this section of the screen.
+See
+<<_blocking_email_attachments_by_file_type,Blocking Email Attachments by File type>>
+for information about this section of the screen.
 
 .Global Settings Advanced
 [cols=",",options="header",]
@@ -158,7 +159,7 @@ If you do not want to send a notification to the recipient when messages
 are blocked, you can disable this option.
 
 Admin Console: ::
-*Global Settings > Attachments*
+*Home > Configure > Global Settings > Attachments*
 
 [[mta_configuration]]
 == MTA Configuration
@@ -257,7 +258,8 @@ CLI.
 Use the IMAP and POP pages to enable global access.
 
 Admin Console: ::
-*Home > Configure > Global Settings > IMAP* or *POP*
+*Home > Configure > Global Settings > IMAP* +
+*Home > Configure > Global Settings > POP*
 
 [NOTE]
 When you make changes to the IMAP or POP settings, you must restart
@@ -294,7 +296,8 @@ sharing.
 
 A domain can be renamed and all account, distribution list, alias and
 resource addresses are changed to the new domain name. The CLI utility is
-used to changing the domain name. See <<_renaming_a_domain, Renaming a Domain>>.
+used to changing the domain name.
+See <<_renaming_a_domain,Renaming a Domain>>.
 
 [NOTE]
 Domain settings override global settings.
@@ -412,7 +415,7 @@ Use the *GAL Mode Settings* tool with your domain configuration to define
 the Global Address List.
 
 Admin Console: ::
-*Home > 2 Set up Domain > 1 Create Domain..., GAL Mode Settings*
+*Home > 2 Set up Domain > 1 Create Domain... -> GAL Mode Settings*
 
 image:images/administration_console_gal.png[GAL Mode Settings]
 
@@ -429,7 +432,7 @@ image:images/administration_console_gal.png[GAL Mode Settings]
 configure multiple external LDAP hosts for GAL. All other directory
 services use the Zimbra LDAP service (configuration, mail routing, etc.).
 When you configure an external GAL, you can configure different search
-settings and sync settings.You might want to configure different search
+settings and sync settings. You might want to configure different search
 settings if your LDAP environment is set up to optimize LDAP searching by
 setting up an LDAP cache server, but users also will need to be able to
 sync to the GAL.
@@ -504,11 +507,11 @@ When {product-abbrev} is configured with more than one server, you can add an ad
 GAL sync account for each server.
 
 Admin Console: ::
-*Configure > Domains*
+*Home > Configure > Domains*
 
 . Select the domain to add another GAL sync account.
 
-. In the gear box, select *Configure GAL*.
+. In the *Gear* icon, select *Configure GAL*.
 
 . Click *Add a GAL account*.
 
@@ -535,11 +538,11 @@ To change the account name delete the existing GAL sync account and
 configure a new GAL for the domain.
 
 Admin Console: ::
-*Configure > Domains*
+*Home > Configure > Domains*
 
 . Select the domain where you want to change the GAL sync account name.
 
-. In the gear box, select *Configure GAL* to open the configuration wizard
+. In the *Gear* icon, select *Configure GAL* to open the configuration wizard
 and change the GAL mode to internal. Do not configure any other
 fields. Click *Finish*.
 
@@ -560,7 +563,7 @@ and password information provided when users log in.
 Set the authentication method on a per-domain basis.
 
 Admin Console: ::
-*Home > 2 Set up Domain > 1 Create Domain..., Authentication Mode*
+*Home > 2 Set up Domain > 1 Create Domain... -> Authentication Mode*
 
 .New Domain -- Authentication Mode
 [cols=",a",options="header",]
@@ -595,7 +598,7 @@ user login. Zimbra Web Client users can log in without having to specify
 the domain name as part of their user name.
 
 Admin Console: ::
-*Home > 2 Set up Domain > 1 Create Domain..., Virtual Hosts*
+*Home > 2 Set up Domain > 1 Create Domain... -> Virtual Hosts*
 
 .New Domain -- Virtual Hosts
 [cols=",",options="header",]
@@ -701,7 +704,7 @@ must own the domain name and verify your ownership before you can add it as
 an alias.
 
 Admin Console: ::
-*Configure > Domains*: from the *Gear* icon select, *Add a Domain Alias*.
+*Home > Configure > Domains*, from the *Gear* icon select, *Add a Domain Alias*.
 
 === Enabling Support for Domain Disclaimers
 
@@ -896,7 +899,7 @@ The Notes text box can be used to record details you want to save.
 === Change MTA Server Settings
 
 Admin Console: ::
-*Home > Configure > Servers > _zmhostname_ > MTA*
+*Home > Configure > Servers -> _server_ -> MTA*
 
 The *MTA* page show the following settings:
 
@@ -924,7 +927,7 @@ to specify which specific IP addresses you want a particular server to
 bind to.
 
 Admin Console: ::
-*Home > Configure > Servers > _zmhostname_ > IP Address Bindings*
+*Home > Configure > Servers -> _server_ -> IP Address Bindings*
 
 .IP Address Bindings
 [cols=",",options="header",]
@@ -1053,7 +1056,7 @@ include the certificate subject, issuer, validation days and subject
 alternative name.
 
 Admin Console: ::
-*Home > Certificates > _zmhostname_*
+*Home > Configure > Certificates -> _zmhostname_*
 
 Certificates display for different Zimbra services such as LDAP, mailboxd, MTA and proxy.
 
@@ -1190,7 +1193,7 @@ the DKIM DNS text record.
 record.
 
 . Verify that the public key matches the private key, See the
-<<dkim_identifiers, Identifiers>> table for `-d`, `-s`, and `-x`
+<<dkim_identifiers,Identifiers>> table for `-d`, `-s`, and `-x`
 descriptions.
 +
 --
@@ -1201,12 +1204,12 @@ descriptions.
 
 [[dkim_identifiers]]
 .Identifiers
-[cols=",",options="header",]
+[cols="1m,2",options="header",]
 |====================================================
 |Parameter |Description
-|`-d` |Domain name
-|`-s` |Selector name
-|`-x` |Configuration file name.
+|-d |Domain name
+|-s |Selector name
+|-x |Configuration file name.
 
 |====================================================
 --
@@ -1288,8 +1291,8 @@ requirements.
 . From the *Gear* icon, select *Save* to use your settings.
 +
 --
-.Anti Spam
-[cols=",",options="header",]
+.Anti-Spam
+[cols="1,2",options="header",]
 |=======================================================================
 |Option |Description
 
@@ -1436,7 +1439,7 @@ zmlocalconfig -e postfix_enable_smtpd_policyd=no
 ----
 
 Admin Console: ::
-*Global Settings > MTA*
+*Home > Configure > Global Settings > MTA*
 
 Define the policy restriction.Setting Email Recipient
 RestrictionsRealtimeBlackhole Lists and Realtime Right-Hand Side
@@ -1468,7 +1471,7 @@ As part of recipient restrictions, you can also use the
 `reject_rbl_client <rbl hostname>` option.
 
 Admin Console: ::
-*Home > Configure > Global Settings > MTA*, *DNS Checks*
+*Home > Configure > Global Settings > MTA -> DNS Checks*
 
 Use the DNS tools in MTA configuration to define the restriction lists.
 
@@ -1560,7 +1563,7 @@ requirements.
 . From the *Gear* icon, select *Save* to use your settings.
 
 .Anti Virus
-[cols=",",options="header",]
+[cols="1,2",options="header",]
 |=======================================================================
 |Option |Description
 
@@ -1724,8 +1727,8 @@ You must have a {product-abbrev} license that is enabled for S/MIME.
 === Enable S/MIME Feature
 
 Admin Console: ::
-*Home > Configure > Class of Service*, _COS name_, *Features* page +
-*Home > Manage > Accounts*, _account name_, *Features* page
+*Home > Configure > Class of Service -> _COS_ -> Features* +
+*Home > Manage > Accounts -> _account_ -> Features*
 
 The S/MIME feature can be enabled from either the COS or Account
 FeaturesTab.
@@ -1754,8 +1757,8 @@ Zimbra server to lookup and retrieve certificates from the external LDAP,
 on behalf of the client.
 
 Admin Console: ::
-*Global Settings > S/MIME* +
-*Domains > S/MIME*
+*Home > Configure > Global Settings > S/MIME* +
+*Home > Configure > Domains -> _domain_ -> S/MIME*
 
 You can configure the external LDAP server settings from either the *Global
 Settings > S/MIME* tab or the *Domains > S/MIME* tab.
@@ -1878,7 +1881,7 @@ cron table. From the Administration Console, when you select a server, you
 can manually start a HSM session, monitor HSM sessions, and abort HSM
 sessions that are in progress from the Volumes page.
 
-You can manually start an HSM session from the server's gear icon menu.
+You can manually start an HSM session from the server's *Gear* icon.
 
 When you abort a session and then restart the process, the HSM session
 looks for entries in the primary store that meet the HSM age criteria.  Any
@@ -1932,7 +1935,7 @@ You can configure when email messages should be deleted from an accounts
 folders, and the trash and junk folders by COS or for individual accounts.
 
 .Email Lifetime Options
-[cols=",",options="header",]
+[cols="1,2",options="header",]
 |=======================================================================
 |Email Lifetime Option |Description
 
@@ -1955,7 +1958,7 @@ Default = 30 days.
 === Purging Email Messages
 
 By default, the server purges email messages that have exceeded their
-lifetime every minute.You can change the duration of time that the server
+lifetime every minute. You can change the duration of time that the server
 should "rest" between purging mailboxes.
 
 Use the global Sleep Time setting to define duration, in minutes, between
@@ -1995,7 +1998,7 @@ Use the global Retention Policy page to set global retention or deletion
 policies.
 
 Admin Console: ::
-*Home > Configure > Global Settings*, *Retention Policy* page
+*Home > Configure > Global Settings > Retention Policy*
 
 image:images/GlobalRetentionPolicy.jpg[Global Retention Policy]
 
@@ -2005,7 +2008,7 @@ Use the COS Retention Policy page to set retention or deletion for the
 selected COS.
 
 Admin Console: ::
-*Home > Configure > Class of Service*, _COS name_, *Retention Policy* page
+*Home > Configure > Class of Service -> _COS_ -> Retention Policy*
 
 image:images/COSRetentionPolicy.jpg[COS Retention Policy]
 
@@ -2078,10 +2081,9 @@ zmmailbox -z -m <user@example.com> -A dumpsterDeleteItem <item-ids>
 ----
 
 Admin Console: ::
-*Home > Configure > Class of Service* _COS name_, *Features* page,
-*General Features* section.
+*Home > Configure > Class of Service -> _COS_ -> Features -> General Features*
 
-. Enable (check) the Dumpster folder checkbox.
+. Enable (check) the *Dumpster folder* checkbox.
 . To set *Visibility lifetime in dumpster for end user*, go to the COS's,
 *Advanced* page, *Timeout Policy* section.
 . To set *Retention lifetime in dumpster before purging*, go to the COS's
@@ -2098,17 +2100,13 @@ dumpster. This can be set on a COS or for individual accounts. When *Can
 purge dumpster folder* is enabled, any deletion policies set up on the
 accounts' folders are ignored.
 
-Configure legal hold on a COS account:
+Configure legal hold:
 
 Admin Console: ::
-*Configure > Class of Service > Features* page +
-deselect *Can purge dumpster folder*
+*Home > Configure > Class of Service -> _COS_ -> Features* +
+*Home > Manage > Accounts -> _account_ -> Features*
 
-Configure legal hold on individual accounts:
-
-Admin Console: ::
-*Manage > Accounts*, select the _account_ +
-*Disable* the feature on the *Features* page.
+Deselect *Can purge dumpster folder* on the *Features* page.
 
 == Customized Admin Extensions
 

--- a/cos.adoc
+++ b/cos.adoc
@@ -14,16 +14,12 @@ set of domains.
 You can create and edit the classes of services from the Administration
 Console:
 
-.Admin Console
-****
-*Configure > Class of Service >* _select account:_
-*Manage > Accounts*.
+Admin Console: ::
+*Home > Configure > Class of Service -> _COS_*
 
-****
+== Managing Features and Settings with a COS
 
-== Managing Account Usages with a COS
-
-A default COS is created when Zimbra is installed. You can modify the
+A default COS is created when {product-name} is installed. You can modify the
 default COS and create new ones.
 
 From a COS, you can manage the following functions:
@@ -32,8 +28,8 @@ From a COS, you can manage the following functions:
 
 * Themes and Zimlets that users can access.
 
-* Advanced settings including attachment settings, quotas, and password log
-in policies.
+* Advanced settings including attachment settings, quotas, and
+password login policies.
 
 * Web Client Versions (Advanced, Standard, and Mobile clients).
 
@@ -45,26 +41,27 @@ in policies.
 
 As an example, you could create an Executive COS that is configured to
 enable all features, provide unlimited mailbox quotas, and never purges
-messages. And another General-Employee COS may also be created, which
+messages. Another General-Employee COS may also be created, which
 enables only the mail feature, sets the mailbox quota, and purges messages
 every 60 days. Grouping accounts to a specific COS allows you update or
 change account features in bulk. As such, when the COS is changed, all
 accounts assigned to the COS are changed.
 
 If a COS is not explicitly set for a new account, or if the COS assigned to
-a user no longer exists, the Zimbra default COS is automatically assigned.
+a user no longer exists, the *default* COS is automatically assigned.
 
-You can create a domain COS and have all accounts that are created on that
-domain automatically assigned to this COS. You can create different COSs
-and specify which ones are available for the domain. If a domain does not
-have a COS defined, and you do not specify a COS, the original default COS
-is automatically assigned when an account is created.
+You can create a COS and assign that as a default COS for all
+accounts that are created on that domain. You can create different
+COSs and specify which ones are available for the domain. If a domain
+does not have a COS defined, and you do not specify a COS, the
+original default COS is automatically assigned when an account is
+created.
 
 Some COS settings can be overridden either by global settings or by user
 settings. For example:
 
 * Whether outgoing messages are saved to *Sent* can be changed from the
-Zimbra Web Client in the user’s preferences.
+Zimbra Web Client in the user's preferences.
 
 * Attachment blocking set as a global setting can override the COS setting.
 
@@ -83,11 +80,11 @@ the account.
 
 You can define the initial preferences for saving and viewing messages,
 in the *Preferences* page. You can also select a specific locale for the
-ZWC view. If alocale is not specified, the browser locale is the
+ZWC view. If a locale is not specified, the browser locale is the
 default.
 
 For a description of the features and preferences, see
-<<customizing_accounts, Customizing Accounts>>.
+<<Customizing Accounts>>.
 
 === Disabling Preferences
 
@@ -102,11 +99,11 @@ accounts.
 [[setting_default_time_zone]]
 === Setting Default Time Zone
 
-The default time zone setting displayed in an account’s Preferences folder
+The default time zone setting displayed in an account's Preferences folder
 is used to localize the time for received messages and calendar activities
-in the standard web client.
+in the Standard web client.
 
-When the standard web client is used, the time zone on the computer is not
+When the Standard web client is used, the time zone on the computer is not
 used to set the time a message is received or for calendar
 activities. Rather, the time zone setting in the *Preferences > Calendar
 Options* is used.
@@ -115,7 +112,7 @@ When using the Advanced web client, the time zone setting on the computer
 is used as the time stamp for received messages and for calendar
 activities, not the time zone setting on the *General Information* page.
 
-Because the advanced web client and the standard web client do not use the
+Because the advanced web client and the Standard web client do not use the
 same time zone source to render messages, you might notice that a message
 displayed on multiple clients will be stamped with different times. You can
 avoid this by setting the computer time zone and the web client time zone
@@ -129,8 +126,8 @@ which servers to add to the server pool. Within each pool of servers, a
 random algorithm assigns new mailboxes to any available server.
 
 You can assign an account to a particular mailbox server when you create an
-account in the New Account Wizard, Mail Server field. Uncheck *auto* and
-enter the mailbox server in the Mail Server field.
+account in the New Account Wizard, Server field. Uncheck *auto* and
+enter the mailbox server in the Server field.
 
 == Setting Account Quota
 
@@ -143,24 +140,19 @@ If you set the quota to 0, accounts do not have a quota.
 
 === Viewing Account Quotas
 
-.Admin Console
-****
 To view account quotas for all accounts on a domain:
 
-*Home > Configure > Domains >* _domain_, *Mailbox Quota*.
-****
+Admin Console: ::
+*Home > Configure > Domains -> _domain_ -> Mailbox Quota*
 
 ==== Notifying Users When Maximum Quota is Near
 
 Users can be notified that their mailboxes are nearing their quota. The
 quota percentage can be set and the warning message text can be
-modified: Go to the Quotas container for a specified Class of Service:
+modified: Go to the *Quotas* container for a specified Class of Service:
 
-.Admin Console
-****
-
-*Home > Configure > Class of Service >* _COSname_, *Advanced*, *Quotas* container
-****
+Admin Console: ::
+*Home > Configure > Class of Service -> _COS_ -> Advanced -> Quotas*
 
 When the displayed/configured threshold is reached, a quota warning message
 is sent to the user.
@@ -191,29 +183,23 @@ reached, the quota warning email is sent.
 When a domain quota is set, the effective quota for an account is the
 minimum quota setting of either the domain or account.
 
-.Admin Console
-****
 To configure domain quotas, go to the *Domain Quota Setting* container for
 a specified domain:
 
-*Home > Configure > Domains*,_domain_ *Advanced*, *Domain Quota Setting*
-container
-****
+Admin Console: ::
+*Home > Configure > Domains -> _domain_ -> Advanced -> Domain Quota Setting*
 
 === Managing Excess Quota
 
-You can set how message delivery is handled when a Zimbra user’s mailbox
+You can set how message delivery is handled when a user's mailbox
 exceeds the configured quota. The default behavior is for the MTA to
 temporarily send the message to the deferred queue. When the mailbox has
 sufficient space, the message is delivered. You can change this behavior to
 either have messages bounce back to the sender instead of being sent to the
 deferred queue first or you can configure to send the message to the
-mailbox even if the quota has been exceeded
+mailbox even if the quota has been exceeded.
 
-.CLI
-****
 To bounce messages instead of sending them to the deferred queue:
-
 [source,bash]
 ----
 zmprov mcf zimbraLmtpPermanentFailureWhenOverQuota TRUE
@@ -222,19 +208,18 @@ zmprov mcf zimbraLmtpPermanentFailureWhenOverQuota TRUE
 To send the message to the mailbox even if the quota has been exceeded:
 [source,bash]
 ----
-zmlocalconfig -e zimbraMailAllowReceiveButNotSendWhenOverQuota=TRUE
+zmprov mc {cos-name} zimbraMailAllowReceiveButNotSendWhenOverQuota TRUE
 ----
 
 When this attribute is set to TRUE, a mailbox that exceeds its quota is
 still allowed to receive new mail and calendar invites. This quote bypass
 is only implemented for messages. All other mail items are still affected
-by the quota
-****
+by the quota.
 
 == Managing Passwords
 
 If you use internal authentication, you can quickly change an account's
-password from the Account’s toolbar. The user must be told the new password
+password from the Account's toolbar. The user must be told the new password
 to log on.
 
 [IMPORTANT]
@@ -258,35 +243,30 @@ configure {product-name} to direct users to *your password change
 page* when users change their passwords. You can either set this URL as
 a global setting or a per domain setting.
 
-.CLI
-****
-
 Set the `zimbraChangePasswordURL` attribute to the URL of your password
 change page.
 
-In ZWC. *Change Password* in *Preferences > General* links to this URL,
+In ZWC, *Change Password* in *Preferences > General* links to this URL,
 and when passwords expire, users are sent to this page.
 
 Modifying the password for the domain:
 [source,bash]
 ----
-zmprov md exampledomain.com zimbraChangePasswordURL http://www.mysite.com
+zmprov md example.com zimbraChangePasswordURL https://auth.example.com
 ----
-****
 
 === Configuring a Password Policy
 
 If internal authentication is configured for the domain, you can require
 users to create strong passwords to guard against simple password
-harvest attacks Users can be locked out of their accounts if they fail
+harvest attacks. Users can be locked out of their accounts if they fail
 to sign in after the maximum number of attempts configured.
 
-.Admin Console
-****
 To set password policy, use the *Password* container for a specified
 Class of Service:
 
-*Home > Configure > Class of Service >* _COS name_, *Advanced*, *Password* container
+Admin Console: ::
+*Home > Configure > Class of Service -> _COS_ -> Advanced -> Password*
 
 The password settings that can be configured are listed below.
 
@@ -304,7 +284,7 @@ Configures the password expiration date. Users can change their passwords
 at any time between the minimum and maximum. They must change it when the
 maximum password age is reached.
 
-1+| The following settings require users to add complexity to their
+2+| The following settings require users to add complexity to their
 passwords.
 
 |Minimum upper case characters |
@@ -319,9 +299,18 @@ Non-alphanumeric, for example !, $, #, &, %
 |Minimum numeric characters |
 Base 10 digits 0 - 9
 
+|Minimum numeric characters or punctuation |
+Combined Non-alphanumeric and digits
+
 |Minimum number of unique passwords history|
 Number of unique new passwords that a user must create before an old
 password can be reused.
+
+|Minimum password age (Days)|
+Minimum days between password changes
+
+|Maximum password age (Days)|
+Maximum days between password changes
 
 |Password locked |
 Users cannot change their passwords.  This should be set if authentication is
@@ -335,7 +324,6 @@ When enabled, users can change their password at any time within the
 password age settings from their account Preferences tab.
 
 |=======================================================================
-****
 
 == Managing Login Policies
 
@@ -343,13 +331,12 @@ You can set the maximum number of failed login attempts before the account
 is locked out for the specified lockout time. This type of policy is used
 to prevent password attacks.
 
-.Admin Console
-****
 To set user login policy, use the *Filed Login Policy* container for a
 specified Class of Service:
 
-*Home > Configure > Class of Service >* _COS name_, Advanced*, *Failed
-*Login Policy* container
+Admin Console: ::
+*Home > Configure > Class of Service -> _COS_ -> Advanced -> Failed
+Login Policy*
 
 .Login Policy Options
 [cols="2",options="header",]
@@ -357,7 +344,7 @@ specified Class of Service:
 |Login Policy Options |Description
 
 |Enable failed login lockout|
-This enables “failed login lockout” feature.  You can configure the
+This enables "failed login lockout" feature.  You can configure the
 following settings.
 
 |Number of consecutive failed logins allowed|
@@ -370,44 +357,41 @@ is locked out until the correct password is entered, or the administrator
 manually changes the account status and creates a new password.  The
 default is 1 hour.
 
-|Time window in which the failed logins must occur within to lock the account |
+|Time window in which the failed logins must occur to lock the account |
 Duration of time after which the number of consecutive failed login
-attempts is cleared from the log.  The default is 0, the user can continue
+attempts is cleared from the log.  If this is set to 0, the user can continue
 attempts to authenticate, no matter how many consecutive failed login
-attempts have occurred.
+attempts have occurred. The default is 1 hour.
 
 |=======================================================================
-****
 
 [[about_two_factor_auth]]
 === About 2 Factor Authentication
 
-With the 2 Factor Authentication (FA) feature—new in Release 8.7—you can
-apply additional security policies to COS and/or user accounts to provide
-another layer of authentication during attempts to access the system. This
-feature must be enabled or disabled in the Admin Console, to manage 2FA
-functions applicable to user mailboxes.
+With the 2 Factor Authentication (FA) feature -- introduced in Release
+8.7 -- you can apply additional security policies to COS and/or user
+accounts to provide another layer of authentication during attempts to
+access the system. This feature must be enabled or disabled in the
+Admin Console, to manage 2FA functions applicable to user mailboxes.
 
 image:images/2FADiagram.png[2 Factor Authentication]
 
-See also <<two_factor_auth, Two Facor Authentication>> for practical
-guidelines.
+For more information, see
+https://wiki.zimbra.com/wiki/Zimbra_Two-factor_authentication[2 Factor Authentication].
 
 == Managing Session Timeout Policies
 
 You can set the period of time to allot for user sessions, as based on
 various conditions.
 
-.Admin Console
-****
 To set session timeout policy, use the *Timeout Policy* container for a
 specified Class of Service:
 
-*Home > Configure> Class of Service >* _COS name_, *Advanced*, *Timeout
-Policy* container
+Admin Console: ::
+*Home > Configure> Class of Service -> _COS_ -> Advanced -> Timeout Policy*
 
 .Session Timeout Policy Options
-[cols="2",options="header",]
+[cols="1,2",options="header",]
 |=======================================================================
 |Session Timeout Policy Options |Description
 
@@ -419,8 +403,8 @@ the auth token expires.  The default is 12 hours.
 |Auth token lifetime |
 Sets a browser cookie that contains the ZWC auth token.  User can open ZWC
 without having to log on again until the auth token expires.  The default
-is 2 days.  When it expires, the log in page is displayed and the user must
-log in to continue.
+is 2 days.  When it expires, the login page is displayed and the user must
+log on to continue.
 
 |Session idle lifetime |
 How long a user session remains active, if no activity occurs. Activity
@@ -429,11 +413,9 @@ clicking a button. The default is unlimited.
 
 |=======================================================================
 
-You can manually expire a user’s web client session from the
+You can manually expire a user's web client session from the
 Administration Console Expire Sessions link.  This forces the current session
 of the account to expire immediately.
-
-****
 
 == Managing Default External COS
 

--- a/crontab.adoc
+++ b/crontab.adoc
@@ -8,13 +8,11 @@ Zimbra servers.
 == How to read the crontab
 
 Each entry in a crontab file consists of six fields, specified in the
-following order
-
-=== minute hour day month weekday command
+following order: minute, hour, day, month, weekday, command
 
 The fields are separated by blank spaces or tabs.
 
-[cols=",",options="header",]
+[cols="1,4",options="header",]
 |=======================================================================
 |Field |Description
 
@@ -29,12 +27,12 @@ The fields are separated by blank spaces or tabs.
 
 When an asterisk (*) is displayed, it means all possible values for the
 field. For example, an asterisk in the hour time field would be
-equivalent to “every hour”.
+equivalent to "every hour".
 
 == {product-abbrev} Cron Jobs
 
-You can view the {product-abbrev} crontab by logging on as zimbra and typing `crontab
--l`.
+You can view the {product-abbrev} crontab by logging on as zimbra and typing
+`crontab -l`.
 
 === Scheduled jobs
 The following cron jobs are scheduled to run for {product-abbrev}:
@@ -57,7 +55,7 @@ Status logging job runs every 2 minutes.
 
 Full and increment backups are scheduled to run according to the schedule
 defined by `zmschedulebackup` command. By default the full backup is
-sched-uled for 1:00 a.m., every Saturday. The incremental backups are
+scheduled for 1:00 a.m., every Saturday. The incremental backups are
 scheduled for 1:00 a.m., Sunday through Friday.
 
 By default, backups older then a month are deleted on the first of each
@@ -80,29 +78,29 @@ are put in quarantine. Messages older than seven days are deleted at
 
 The `ANALYZE TABLE` statement is run on all tables in the database to
 update the statistics for all indexes. This is done to make sure that the
-MySQL query opti-mizer picks the correct es when executing SQL
-statements. This script is run 1:30 a.m.on Sunday.
+SQL query optimizer picks the correct indexes when executing SQL
+statements. This script is run 1:30 a.m. on Sunday.
 
 ==== Report on any database inconsistencies
 
-`zmdbintegrityreport` is run weekly to check the MySQL database for
-corruptionand will notify the administrator if any corruption is found.
+`zmdbintegrityreport` is run weekly to check the SQL database for
+corruption and will notify the administrator if any corruption is found.
 When this is run, it may consume a significant amount of I/O. If you find
 that it is an issue, you may want to change the frequency with which
-`zmdbintegrityreport` is run by editing the {product-abbrev} crontab entry.  This report
-runs at 11:00 p.m. Sundays.
+`zmdbintegrityreport` is run by editing the {product-abbrev} crontab entry.
+This report runs at 11:00 p.m. Sundays.
 
 Large sites may opt to disable this by setting:
 [source,bash]
 ----
-zmlocalconfig -e zmdbintegrityre-port_disabled=TRUE
+zmlocalconfig -e zmdbintegrityreport_disabled=TRUE
 ----
 
 If you choose to disable this, it is recommended that the integrity report
 be run by hand during the normal maintenance windows and prior to running
 any {product-abbrev} upgrades.
 
-==== Monitor for multiple mysqld tp prevent corruption
+==== Monitor for multiple mysqld to prevent corruption
 
 A script is executed to see if mysqld process is running to detect cases
 where corruption is likely to be caused. An email is generated if it finds
@@ -112,20 +110,20 @@ more than 1 mysqld process running. The script runs every 5 minutes.
 
 ==== process logs
 
-*zmlogprocess* runs every 10 minutes to parse logs and produce MTA
-metrics(as/av, volume, count, etc).
+`zmlogprocess` runs every 10 minutes to parse logs and produce MTA
+metrics (as/av, volume, count, etc).
 
 ==== Daily reports
 
-When the logger package is installed, a daily mail report is automatically
-sched-uled in the crontab. The report runs every morning at 11:30 and is
-sent to the administrator’s email address.
+When the `logger` package is installed, a daily mail report is automatically
+scheduled in the crontab. The report runs every morning at 11:30 and is
+sent to the administrator's email address.
 
 === Jobs for crontab.mta
 
 ==== Queue logging
 
-The zmqueue report status via the syslog is reviewed. This is logger
+The `zmqueue` report status via the syslog is reviewed. This is logger
 data. The status is updated every 10 minutes.
 
 ==== Spam training
@@ -142,7 +140,7 @@ Zimbra MTA. The job runs at 11:00 p.m.
 
 ==== Spam Bayes auto-expiry
 
-Spam bayes auto-expiry maintains the spam-assassin Bayes database. This
+Spam bayes auto-expiry maintains the spamassassin Bayes database. This
 keeps the database to manageable size ensuring spam processing remains as
 quick as possible. This runs every day at 11:20 p.m.
 
@@ -152,7 +150,7 @@ This job is used to clean up the amavisd temp files. It runs at 5:15
 a.m. and at 8:15 p.m.
 
 == Single Server Crontab -l Example
-.Output of `contab -l`
+.Output of `crontab -l`
 ====
 ----
 # ZIMBRASTART -- DO NOT EDIT ANYTHING BETWEEN THIS LINE AND ZIMBRAEND
@@ -229,13 +227,13 @@ crontab.mta
 #
 # Dspam cleanup
 #
-0 1 * * * [ -d /opt/zimbra/data/dspam/data/z/i/zimbra/zimbra.sig ] && find /opt/ zimbra/dspam/var/dspam/data/z/i/zimbra/zimbra.sig/ -type f -name \*sig -mtime +7 -exec rm {} \; > /dev/null 2>&1
-8 4 * * * [ -f /opt/zimbra/data/dspam/system.log ] && /opt/zimbra/dspam/bin/dspa m_logrotate -a 60 -l /opt/zimbra/data/dspam/system.log
-8 8 * * * [ -f /opt/zimbra/data/dspam/data/z/i/zimbra/zimbra.log ] && /opt/zimbra a/dspam/bin/dspam_logrotate -a 60 -l /opt/zimbra/data/dspam/data/z/i/zimbra/zimbra.log
+0 1 * * * [ -d /opt/zimbra/data/dspam/data/z/i/zimbra/zimbra.sig ] && find /opt/zimbra/dspam/var/dspam/data/z/i/zimbra/zimbra.sig/ -type f -name \*sig -mtime +7 -exec rm {} \; > /dev/null 2>&1
+8 4 * * * [ -f /opt/zimbra/data/dspam/system.log ] && /opt/zimbra/dspam/bin/dspam_logrotate -a 60 -l /opt/zimbra/data/dspam/system.log
+8 8 * * * [ -f /opt/zimbra/data/dspam/data/z/i/zimbra/zimbra.log ] && /opt/zimbra/dspam/bin/dspam_logrotate -a 60 -l /opt/zimbra/data/dspam/data/z/i/zimbra/zimbra.log
 #
 # Spam Bayes auto-expiry
 #
-20 23 * * * /opt/zimbra/libexec/sa-learn -p /opt/zimbra/conf/salocal.cf --dbpath /opt/zimbra/data/amavisd/.spamassassin --siteconfigpath /opt/zimbra/conf/spamas sassin --force-expire --sync > /dev/null 2>&1
+20 23 * * * /opt/zimbra/libexec/sa-learn -p /opt/zimbra/conf/salocal.cf --dbpath /opt/zimbra/data/amavisd/.spamassassin --siteconfigpath /opt/zimbra/conf/spamassassin --force-expire --sync > /dev/null 2>&1
 #
 # Clean up amavisd/tmp
 #

--- a/customizingaccounts.adoc
+++ b/customizingaccounts.adoc
@@ -30,15 +30,14 @@ and described in <<table_email_features,Email Features>>.
 
 [[table_email_features]]
 .Email Features
-[cols=",a",options="header",]
+[cols="1,3a",options="header",]
 |=======================================================================
 |Email Messaging Feature |Description
 
 |Mail |
 Enables the email application.  Enabled by default.
 
-See *COS* _name_ *> Features*, *Major Features* container in the Admin
-Console.
+See *_COS_ > Features -> Major Features* container in the Admin Console.
 
 |Conversations |
 Messages can be grouped into conversations by a common thread.  The default
@@ -48,48 +47,43 @@ thread.
 
 To change the default, update attribute `zimbraMailThreadingAlgorithm` from
 the COS or for individual accounts.
+See <<conversation_threading,changing conversations thread default>>.
 
-See zmprov (Provisioning).  If this feature is enabled, conversation view
-is the default.  You can change the default on the COS Preferences page.
-Users can also change the default.
+If this feature is enabled, conversation view is the default.  You can
+change the default on the COS Preferences page.  Users can also change
+the default.
 
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 |HTML compose |
 Users can compose email messages with an HTML editor.  They can specify
 default font settings as a preference.
 
-See *COS* _name_ > *Preferences*, *Composing Mail* container in the Admin
-Console.
+See *_COS_ > Preferences -> Composing Mail* container in the Admin Console.
 
 |Draft auto save interval |
-Frequency of saving draft messages.The default is every 30 seconds.  Users
+Frequency of saving draft messages. The default is every 30 seconds.  Users
 cannot change the frequency, but they can turn off the save draft feature.
 
-See *COS* _name_ *> Preferences*, *Composing Mail* container in the Admin
-Console.
+See *_COS_ > Preferences -> Composing Mail* container in the Admin Console.
 
 | Mail send later |
 When enabled, users can choose *Send Later* to send a message at a later
 time.  The user configures the data and time for sending.  Messages are
 saved in the Draft folder.
 
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 | Message priority |
 When enabled, users can set the priority of the message.  The recipient
 viewing from ZWC sees the priority flag if it is high or low.
 
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 |Enable Attachment indexing |
 Attachments are indexed.  Indexed attachments can be searched.
 
-See *COS* _name_ *> Advanced*, *Attachment Settings* container in the Admin
-Console.
+See *_COS_ > Advanced -> Attachment Settings* container in the Admin Console.
 
 |Allow the user to specify a forwarding address |
 You can specify a default forwarding address that the user can use.  Users
@@ -99,8 +93,7 @@ You can also specify forwarding addresses that are hidden from the user.  A
 copy of a message sent to the account is immediately forwarded to the
 designated forwarding address.
 
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 |Out of office reply |
 
@@ -110,8 +103,7 @@ seven days, regardless of how many messages that person sends to the
 address.  This setting can be changed in the COS Preferences page, *Out of
 office cache lifetime* field.
 
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 |New mail notification |
 Allows users the option to specify an address to be notified of new mail.
@@ -119,11 +111,10 @@ They can turn this feature on or off and designate an address from their
 account Preferences tab.
 
 [NOTE]
-See zmprov (Provisioning) in Appendix A CLI commands, for information about
-how to change the email template.
+See <<custom_new_mail_notification,Customize the notification email>>
+, for an example of changing the email template.
 
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 |Persona |
 When enabled, users can create additional account names to manage different
@@ -131,12 +122,9 @@ roles.  Account aliases can be selected for the *From* name of messages
 sent from that persona account and a specific signature can be set for the
 persona account.  The number of personas that can be created is
 configurable depending on your requirements.  The minimum is 0, and the
-default is 20.
+default is 20 (zimbraIdentityMaxNumEntries).
 
-You can change this from the CLI: `zmprov mc zimbraIdentityMaxNumEntries`.
-
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 |Maximum length of mail signature |
 The maximum number of characters that can be in a signature.  The default is
@@ -145,43 +133,37 @@ The maximum number of characters that can be in a signature.  The default is
 The number of signatures users can create is configured in
 `zimbraSignatureMaxNumEntries`.
 
-See *COS* _name_ *> Preferences*, *Composing Mail* container in the Admin
-Console.
+See *_COS_ > Preferences -> Composing Mail* container in the Admin Console.
 
 |Advanced search |
 Allows users to build a complex search by date, domain, status, tags, size,
 attachment, Zimlets, and folders.
 
-See *COS* _name_ *> Features*, *Search Features* container in the Admin
-Console.
+See *_COS_ > Features -> Search Features* container in the Admin Console.
 
 |Saved searches |
 Users can save a search that they have previously executed or built.
 
-See *COS* _name_ *> Features*, *Search Features* container in the Admin
-Console.
+See *_COS_ > Features -> Search Features* container in the Admin Console.
 
 |Initial search preference |
 When enabled, the default search mailbox can be changed.
 
-See *COS* _name_ *> Features*, *General Options* container in the Admin
-Console.
+See *_COS_ > Features -> General Options* container in the Admin Console.
 
 |External POP access |
-When enabled, users can retrieve their POP accounts’ email messages
+When enabled, users can retrieve their POP accounts' email messages
 directly from their ZWC account.  They add the external account address to
 their account settings.
 
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 |External IMAP Access|
-When enabled, users can retrieve their IMAP accounts’ email messages
+When enabled, users can retrieve their IMAP accounts' email messages
 directly from their ZWC account.  They can add the external account address
 to their account settings.
 
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 |Aliases for this account|
 You can create an aliases for the account.  Users cannot change this.
@@ -193,62 +175,55 @@ email message matches the conditions of a filter rule, the corresponding
 actions associated with that rule are applied.
 
 [NOTE]
-Spam check on a received message is completed before users’ mail filters
+Spam check on a received message is completed before users' mail filters
 are run.  Message identified as spam are moved to the junk folder.  To
 avoid having mail incorrectly marked as spam, users can create a spam
 whitelist from the Preferences Mail folder to identify email addresses that
 should not be marked as spam.
 
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 |Flagging |
 Users can create flags and assign them to messages, contacts, and files in
 Briefcase folders.
 
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 |Enable keyboard shortcuts |
 Users can use keyboard shortcuts within their mailbox.  The shortcut list
 can be printed from the Preferences Shortcuts folder.
 
-See *COS* _name_ *> Preferences*, *General Options* container in the Admin
-Console.
+See *_COS_ > Preferences -> General Options* container in the Admin Console.
 
 |Global Address List (GAL) access |
 Users can access the company directory to find names for their email
 messages.
 
-See *COS* _name_ *> Features*, *General Features* container in the Admin
-Console.
+See *_COS_ > Features -> General Features* container in the Admin Console.
 
 |Autocomplete from GAL |
 When enabled, users enter a few letters in their compose header and names
-listed in the GAL are displayed ranked by usage.  See also
-<<autocomplete_ranks_names,Autocomplete Ranks Names>>.
+listed in the GAL are displayed ranked by usage.
+See also <<autocomplete_ranks_names,Autocomplete Ranks Names>>.
 
-See *COS* _name_ *> Features*, *General Features* container in the Admin
-Console.
+See *_COS_ > Features -> General Features* container in the Admin Console.
 
 |Offline support for Advanced (Ajax) client |
 When enabled, users can use the offline mode to access their data without
-network connectivity when using the Zimbra Web Client.  See also
-<<offline_mode,Offline Mode>>.
+network connectivity when using the Zimbra Web Client.
+See also <<offline_mode,Offline Mode>>.
 
-See *COS* _name_ *> Features*, *General Features* container in the Admin
-Console.
+See *_COS_ > Features -> General Features* container in the Admin Console.
 
 |IMAP access |
 Users can use third party mail applications to access their mailbox using
 the IMAP protocol.
 
-You can set the polling interval from the *COS/Account Advanced* page,
+You can set the polling interval from the COS or Account *Advanced* page,
 *Data Source > IMAP* polling interval section.  The polling interval is not
 set by default.
 
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 |POP3 access |
 
@@ -258,19 +233,18 @@ messages and attachments are saved on the Zimbra server.
 
 Users can configure from their *Preferences > Mail* page
 
-* How messages are download
+* How messages are downloaded.
 
 * Whether to include their junk messages.  Junk messages are downloaded to
   their Inbox.
 
 * How to delete messages from their POP account.
 
-You can set the polling interval from the *COS/Account Advanced* page,
+You can set the polling interval from the COS or Account *Advanced* page,
 *Data Source > POP3* polling interval section.  The polling interval is not
 set by default.
 
-See *COS* _name_ *> Features*, *Mail Features* container in the Admin
-Console.
+See *_COS_ > Features -> Mail Features* container in the Admin Console.
 
 |=======================================================================
 
@@ -326,7 +300,7 @@ CLI `zmprov` for accounts and COS.  The attributes are
 ** Whether to automatically append a signature to outgoing messages.
 ** Preferences for how messages that are replied to or forwarded are composed.
 
-==== Using Import and Export to Save User’s Data
+==== Using Import and Export to Save User's Data
 
 The *Preferences Import/Export* page lets users export all of their account
 data, including mail, contacts, calendar, and tasks.  They can export
@@ -336,7 +310,7 @@ other location.
 The account data is saved as a tar-gzipped (tgz) archive file so that it
 can be imported to restore their account.  Individual contacts are saved as
 .csv files, and individual calendar files are saved as .ics files.  The
-data are copied, not removed from the user’s account.
+data are copied, not removed from the user's account.
 
 The exported account data file can be viewed with an archive program such
 as WinRAR archiver.  Any of these files can be imported into their account
@@ -349,15 +323,14 @@ Features* page, *General Features* section.
 
 Users can subscribe to Websites that provide RSS and podcast feeds and
 receive updated information directly to their mailboxes.  The maximum
-number of feeds that can be returned is 50.  RSS feeds count against users’
+number of feeds that can be returned is 50.  RSS feeds count against users'
 account quota.
 
 The default is to update the RSS data every 12 hours.  Users can
 right-click on an RSS feed folder to manually load new feed.
 
 You can change the polling interval from the Administration Console the
-Class of Server or Account Advanced page, Data Source>RSS polling
-interval section.
+COS or Account *Advanced* page, *Data Source > RSS polling interval* section.
 
 == Address Book Features
 
@@ -368,14 +341,13 @@ can import contacts into their Address Book.
 [IMPORTANT]
 --
 To allow users to share their mail folders, address books, and calendars,
-enable Sharing on the Features page:
+enable Sharing on the *General Features* container:
 
-*Home > Configure > Class of Service*,_COSname_,*Features*, *General
-Features* container
+*Home > Configure > Class of Service -> _COS_ -> Features -> General Features*
 --
 
 .Address Book Features
-[cols=",,",options="header",]
+[cols="1,2,1",options="header",]
 |=======================================================================
 |Feature |Description |COS/Account Tabs
 
@@ -394,11 +366,11 @@ Advanced
 Users can modify the following Address Book preferences from their account
 *Preferences Address Book* page.
 
-.Admin Console
-****
 To set default behavior:
 
-*Home > COS* or *Accounts > Preferences* page.
+Admin Console: ::
+*Home > Configure > Class of Service -> _COS_ -> Preferences* +
+*Home > Manage > Accounts -> _account_ -> Preferences*
 
 * Enable auto adding of contacts to automatically add contacts to their
 Emailed Contact list when they send an email to a new address.
@@ -408,8 +380,6 @@ picker to look up names.
 
 * Enable the options to include the GAL addresses and names in shared
 address books when using autocomplete to address a message.
-
-****
 
 == Calendar Features
 
@@ -422,15 +392,14 @@ Client.  They can also use search for appointments in their calendars.
 [IMPORTANT]
 --
 To allow users to share their calendars, address books,
-and Briefcase files, enable Sharing in the Features page:
-
-*Home > Configure > Class of Service*, _COS name_, *Features*, *General
- Features* container
+and Briefcase files, enable Sharing in the *General Features* container.
 --
 
-Table 20: Calendar Features
+Admin Console: ::
+*Home > Configure > Class of Service -> _COS_ -> Features -> General Features*
 
-[cols=",a,",options="header",]
+.Calendar Features
+[cols="1,2a,1",options="header",]
 |=======================================================================
 |Calendar Feature |Description |COS/Account Tabs
 
@@ -449,12 +418,7 @@ Features
 Calendars can be nested within {product-name} folders like Mail,
 Contact, and Calendar folders.  The administrator creates a nested list of
 calendars using CLI.  A nested calendar grouping can be imported through
-migration as well.  The CLI command to define the grouping is
-
-[source,bash]
-zmmailbox -z -m user1 cf -V appointment /<Calendar Name>/<sub-calendar name>
-
-This creates a calendar nested under the Calendar Name folder.  |
+migration as well. See example below. |
 
 |Time zone |
 Sets the time zone to use for Calendar scheduling.  Domain admins set this
@@ -462,7 +426,7 @@ in the Accounts, General Information page.  | Preferences
 
 |Forward calendar invitation to specific addresses |
 
-You can specify email addresses to forward a user’s calendar invitations.
+You can specify email addresses to forward a user's calendar invitations.
 Users can also specify forwarding address from the Preferences Calendar
 folder.
 
@@ -472,29 +436,30 @@ Accounts Forwarding
 
 |=======================================================================
 
+
+Create a calendar nested under the "Calendar Name" folder:
+[source,bash]
+----
+zmmailbox -z -m user1 cf -V appointment "/Calendar Name/Sub Calendar"
+----
+
 === Troubleshooting Calendar Appointment Problems
 
-.CLI
-****
 Use the `zmcalchk` command to check for discrepancy between different
-users’ calendars for the same meeting, and send an email notification
+users' calendars for the same meeting, and send an email notification
 regarding the discrepancies.
 
 You can also use this command to notify the organizer and/or all attendees
 when an appointment is out of sync.
-****
 
 === Changing Remote Calendar Update Interval
 
 Remote calendars are updated every 12 hours, by default.  The frequency can
 be modified at the Admin Console.
 
-.Admin Console
-****
-To modify the frequency of calendar updates:
-
-*Home > Class of Service* or *Account Advanced* page, *Data Source > Calendar polling interval*
-****
+To modify the frequency of calendar updates in the Admin Console go to
+the desired COS or Account
+*Advanced* page, *Data Source > Calendar polling interval* field.
 
 === Disabling Attendee Edits to Appointments
 
@@ -504,13 +469,10 @@ changes overwrite the attendees edits.  You can modify the COS attribute
 `zimbraPrefCalendarApptAllowAtendeeEdit` to prevent attendees from editing
 appointments in their calendar.
 
-.CLI
-****
 [source,bash]
 ----
-zmprov mc <cosname> zimbraPrefCalendarApptAllowAtendeeEdit=FALSE
+zmprov mc <cosname> zimbraPrefCalendarApptAllowAtendeeEdit FALSE
 ----
-****
 
 === Setting Other User Calendar Preferences
 
@@ -518,15 +480,15 @@ Users can modify the Calendar preferences listed in the Calendar
 Preference table.  You can set the default behavior in the COS or
 Accounts Preferences page.
 
-[cols=",a",options="header",]
+[cols="1,2a",options="header",]
 |=======================================================================
 |Calendar Preference |Description
 
 |Time zone |
-Time zone displayed in the user’s Preferences.  See
-<<setting_default_time_zone,Setting Default Time Zone>>.  If the time zone
-is configured in the COS, the time zone configured in the domain is
-ignored.
+Time zone displayed in the user's Preferences.
+See <<setting_default_time_zone,Setting Default Time Zone>>.
+If the time zone is configured in the COS, the time zone configured in
+the domain is ignored.
 
 |Number of minutes before an appoitment to show reminder |
 Sets the minutes before the meeting to send a reminder notice.
@@ -536,7 +498,7 @@ Sets the minutes before the meeting to send a reminder notice.
 Sets the default view.  Options are Day, Work Week, 7-Day Week, Month, List, or Schedule.
 
 | First day of the week |
-Sets the default first day of a user’s work week.
+Sets the default first day of a user's work week.
 
 |Default appointment visibility |
 Options are Public or Private.  Sets the default visibility options on the
@@ -545,17 +507,17 @@ new appointment page.
 The default is Public, appointments details can be viewed by others.
 
 When the default is Private, all incoming calendar invites are marked as
-private on the user’s calendar and details are hidden.
+private on the user's calendar and details are hidden.
 
 
 |Use iCal delegation model for shared calendars for CalDAV |
 
-Apple iCal can be configured to access users’ calendars using the CalDAV
-protocol.  When enabled, shared calendars are displayed in users’ iCal
-account’s Delegation tab and they can delegate access to their calendars.
+Apple iCal can be configured to access users' calendars using the CalDAV
+protocol.  When enabled, shared calendars are displayed in users' iCal
+account's Delegation tab and they can delegate access to their calendars.
 
-For automatic polling, the polling interval can be set up in the
-*COS/Account Advanced* page, *Data Source > CalDAV polling interval* field.
+For automatic polling, the polling interval can be set up in the COS or Account
+*Advanced* page, *Data Source > CalDAV polling interval* field.
 
 |Enable past due reminders |
 Users log into the ZWC, the reminder notifications for the last two weeks
@@ -579,7 +541,7 @@ rules by enabling this option.
 
 |Automatically add forwarded invites to calendar |
 Invites that have been forward to users are automatically added to the
-forwarded recipient’s calendar.
+forwarded recipient's calendar.
 
 |Flash browser title on appointment reminder |
 When appointment reminders pop up, the browser flashes until the user
@@ -596,7 +558,7 @@ auto-reply message is sent to those users to let them know they do not have
 permission to invite the user.
 
 |Automatically add appointments when invited |
-When enabled, appointments are automatically added to user’s default
+When enabled, appointments are automatically added to user's default
 calendar and declined appointments display on the ZWC calendar in a faded
 view.
 
@@ -631,12 +593,11 @@ completion.
 To allow users to share their Task lists, enable Sharing in the Features
 page.  Task lists can be shared with individuals, groups, and the public.
 
-.Admin Console
-****
 To enable or disable the Tasks feature:
 
-*Home > COS* or *Accounts > Preferences* page.
-****
+Admin Console: ::
+*Home > Configure > Class of Service -> _COS_ -> Features* +
+*Home > Manage > Accounts -> _account_ -> Features*
 
 == Zimbra Web Client User Interface Themes
 
@@ -644,7 +605,7 @@ The appearance of the Zimbra Web Client user interface can be changed.  A
 number of Zimbra themes are included with {product-abbrev}, and you can
 create others.  You can select a theme to be the default and the themes
 that users can select to customize their user experience.  To develop
-themes, see <<color_and_logo_management,Color and Logo Management>>.
+themes, see <<Color and Logo Management>>.
 
 The following theme usage options can be configured either from COS or
 by individual accounts.
@@ -672,48 +633,37 @@ user accounts and/or class of service.
 In the Wizard setup for a new user account, you will find settings for
 2FA with other *Advanced* options.
 
-.Admin Console
-****
-*Home* page, *3.  Add Accounts > 1.  Add Account >* _Next_ until *Advanced*,
-scroll down to *Two Factor Authentication*
+Admin Console: ::
+*Home -> 3 Add Accounts -> 1. Add Account* +
+ -- _Next_ until *Advanced*, scroll down to *Two Factor Authentication*
 
 image::images/User_NewAcct_2FASettings.png[New Account Two Factor Authentication]
 
-See <<two_factor_authentication_parameters, Two Factor Authentication
-Parameters>> for parameter descriptions.
-****
+See <<two_factor_authentication_parameters,Two Factor Authentication Parameters>>
+for parameter descriptions.
 
 === 2FA for Existing User Account
 
 For an existing user account, you can apply 2FA settings from the
 *Advanced* options.
 
-.Admin Console
-****
+Admin Console: ::
 *Home > Manage > Accounts*
 
-.  Locate the editable configurations for the account:
-+
---
-Select an Account from the table, and select *Edit* from the *Gear*
-icon.  The *General Information* screen is now displayed.
---
+Locate the *Two Factor Authentication* container within the editable
+configurations for an account:
 
-.  Locate the *Two Factor Authentication* container:
+. Select an _account_ from the list of accounts.
+. Select *Edit* from the *Gear* icon.
 +
---
-Select *Advanced* from the left panel alongside the *General Information*
-screen.
-
-At the screen, scroll down to the *Two Factor Authentication*
-container.
---
+--  The *General Information* for the _account_ is now displayed.
+. Select *Advanced* from the left panel.
+. Scroll down to the *Two Factor Authentication* container in the main panel.
 
 image::images/User_EditAcct_2FASettings.png[Edit Account Two Factor Authentication]
 
-See <<two_factor_authentication_parameters, Two Factor Authentication
-Parameters>> for parameter descriptions.
-****
+See <<two_factor_authentication_parameters,Two Factor Authentication Parameters>>
+for parameter descriptions.
 
 === 2FA for Class of Service
 
@@ -723,19 +673,17 @@ with other Advanced features.
 To apply 2FA to a class of service, use the *Two Factor Authentication*
 container to set parameters.
 
-.Admin Console
-****
-*Home > Configure > Class of Service >* _COSname_ *> Advanced > Two Factor Authentication*
+Admin Console: ::
+*Home > Configure > Class of Service -> _COS_ -> Advanced -> Two Factor Authentication*
 
 image::images/COS_2FAContainer.png[Class of Service Two Factor Authentication]
 
-See <<two_factor_authentication_parameters, Two Factor Authentication
-Parameters>> for parameter descriptions.
-****
+See <<two_factor_authentication_parameters,Two Factor Authentication Parameters>>
+for parameter descriptions.
 
 [[two_factor_authentication_parameters]]
 .Two Factor Authentication Parameters
-[cols=",",options="header",]
+[cols="1,2",options="header",]
 |=======================================================================
 |Parameters |Description
 
@@ -772,10 +720,10 @@ A users specifies the type of access permissions to give the grantee.  A
 users can share with internal users who can be given complete manager
 access, external guests who must use a password to view the folder content,
 as well as public access so that anyone who has the URL can view the
-folder’s content.
+folder's content.
 
 When internal users share a mail folder, a copy of the shared folder is
-put in the grantee’s folder list on the Overview pane.  Users can manage
+put in the grantee's folder list on the Overview pane.  Users can manage
 their shared folders from their ZWC Preferences Sharing page.
 
 === Configure SMS Notification
@@ -788,7 +736,7 @@ by default.
 SMS notification can be configured by domain, COS or for individual
 accounts.  SMS notification set in a COS overrides SMS notifications set on
 a domain.  In the Administration Console, this is set on the domain, COS or
-account’s Feature page.
+account's Feature page.
 
 Users select a region and a carrier when setting up their SMS alert.  The
 list of SMS/email gateways is in *ZmSMS.properties*.  You can customize
@@ -801,7 +749,7 @@ specific account.  The global setting takes precedence over COS and account
 Settings.  You can select from four options.
 
 .Attachment Viewing Features
-[cols=",a,",options="header",]
+[cols="1,2a,1",options="header",]
 |=======================================================================
 |Feature Name |Description |COS/Account Tabs
 
@@ -867,11 +815,8 @@ marked as spelling errors during a ZWC spell check, you can update the COS
 or domain attribute `zimbraPrefSpellIgnoreWord` with the words that should
 be ignored when spell check is run.
 
-.CLI
-****
 To configure words to ignore for a domain:
 [source,bash]
 ----
-zmprov md domainexample.com +zimbraPrefSpellIgnoreWord <word> +zimbraPrefSpellIgnoreWord <word2>
+zmprov md example.com +zimbraPrefSpellIgnoreWord <word> +zimbraPrefSpellIgnoreWord <word2>
 ----
-****

--- a/delegatedadmin.adoc
+++ b/delegatedadmin.adoc
@@ -11,7 +11,7 @@ domains.
 
 Two frequently used delegated administrator roles, domain administrator and
 distribution list administrator, are already defined. You can add
-administrators to these pre-defined roles with no other configuration
+administrators to these predefined roles with no other configuration
 necessary.
 
 == Target Types for Granting Administrative Rights
@@ -26,8 +26,8 @@ type of access control entries you can grant on the target.
 When selecting a target type for a target consider the following:
 
 * Target. Which specific target are you granting rights? For example, if
-the target type you select is “domain”, which domain do you mean? You
-specify a specific domain’s name (Target Name = example.com). Access
+the target type you select is "domain", which domain do you mean? You
+specify a specific domain's name (Target Name = example.com). Access
 Control Entries (ACE) are granted on that target. An ACE is stored in an
 LDAP attribute on the target entry.
 
@@ -43,9 +43,9 @@ granted rights are effective. For example, the right to set the password is
 applicable only to accounts and calendar resources, but if this right is
 included in the domain targets list of rights, it is effective for all
 accounts or calendar resource in the domain.
-+
+
 .Targets for rights
-[cols=",",options="header",]
+[cols="1,3",options="header",]
 |=======================================================================
 |Target Type |Description of Target Scope
 
@@ -67,8 +67,7 @@ and calendar resources that are direct or indirect members of this
 distribution list.
 
 |Domain |
-
-Applicable to a specific domain, not to any sub- domains.
+Applicable to a specific domain, not to any sub-domains.
 
 Sub-domains must be explicitly marked as targets.
 
@@ -97,18 +96,19 @@ Zimlet entry
 == Rights
 
 Rights are the functions that a delegated administrator can or cannot
-perform on a named target. Right can be either system-defined or attribute.
+perform on a named target. A right is either system-defined or granted
+at the attribute level.
 
 === System-defined rights
 
 Types of system defined rights include:
 
-* Preset rights (*preset*). For example, createAccount creates an account;
-renameDomain, renames the domain.
+* Preset rights (*preset*). For example, `createAccount` creates an account;
+`renameDomain`, renames the domain.
 +
 Preset rights are associated with a fixed target type. For example,
-createAccount is a right only on a domain; renameAccount is a right on an
-account; see Server is a right on a server
+`createAccount` is a right only on a domain; `renameAccount` is a right on an
+account; `getServer` is a right on a server
 +
 No other rights are required to administer that action on the target.
 +
@@ -130,8 +130,8 @@ and view an attribute value. For example, the `modifyAccount` right allows
 the domain administrator to modify all attributes of the account.
 
 * Get attribute rights (`getAttrs`) let the domain administrator view an
-attribute value. For example, the getAccount right shows all the attributes
-for a user’s account.
+attribute value. For example, the `getAccount` right shows all the attributes
+for a user's account.
 
 The specific attribute being granted is configured on the target and the
 type of permission, read (get) or write (set), is specified.
@@ -143,7 +143,7 @@ grant.
 ==== Combo Rights
 
 Combo rights can be assigned to any target type and can include preset
-rights and attribute rights.You can use combo right to grant multiple
+rights and attribute rights. You can use combo right to grant multiple
 attribute rights quickly on targets.
 
 ==== Negative Rights
@@ -162,7 +162,7 @@ the target and sub-targets on which the right is granted.
 An admin group is granted domain administrator rights, including the right
 to create accounts on Domain1. AdminA is in this admin group, but you want
 AdminA to have all domain administrator rights, except the right to create
-accounts. You would grant a negative *createAccount* right to AdminA on the
+accounts. You would grant a negative `createAccount` right to AdminA on the
 target Domain1.
 
 For grants on the same level, negative rights always take precedence.  For
@@ -174,8 +174,8 @@ any account in this domain because the negative right takes precedence.
 For grants on different levels, the most specific grant takes
 precedence. For example, AdminA is granted the negative right to view
 accounts in GroupDistributionList1, which User1 is a member. AdminA is also
-granted the positive right to view account directly on User1’s account. In
-this case, AdminA can view User1’s account as the grant on the account
+granted the positive right to view account directly on User1's account. In
+this case, AdminA can view User1's account as the grant on the account
 target is more specific than the grant on the distribution list.
 
 === Using the Rights List
@@ -195,13 +195,9 @@ are listed.
 * For the other system rights, a list of attributes associated with the
 right are listed
 
-.CLI
-****
-*Viewing Combo Rights*
-
 You can use `zmprov` commands to view combo rights.
 
-* Direct sub rights of a combo right
+* Direct sub-rights of a combo right
 +
 [source,bash]
 ----
@@ -220,7 +216,7 @@ zmprov gr adminConsoleDLRights -e
 You can use `zmprov` commands to view system defined rights for a specific
 topic:
 
-.`zmprov` Commands
+.Viewing Combo Rights with zmprov
 [cols="a,a",options="header",]
 |=======================================================================
 |To View This |Use This `zmprov` Command
@@ -293,7 +289,6 @@ zmprov gar -t zimlet
 ----
 
 |=======================================================================
-****
 
 == Implementing Delegated Administration
 
@@ -317,7 +312,7 @@ account using the Administrator Wizard.
 modify rights to an existing delegated administrator or administrator group
 account.
 
-* Add, modify and delete rights directly in a target’s Access Control List
+* Add, modify and delete rights directly in a target's Access Control List
 page.
 
 === Administrator Groups and Administrators
@@ -334,7 +329,7 @@ which flags it as a delegated administrator DL. After the admin group
 administrator is created and configured with rights and admin views, you
 add administrator user accounts to the admin group.
 
-.. *Admin Account* is a user account that has Administrator enabled onthe
+.. *Admin Account* is a user account that has Administrator enabled on the
 account.
 
 . Configure the admin views for the account. You select the views from the
@@ -363,24 +358,23 @@ rights, modify rights or delete rights on existing administrator accounts.
 
 When you want to add a specific grantee or specific rights on a target you
 can edit the target directly. Each target has an ACL page which lists the
-granted ACLs. You can add, edit or delete the target’s grants.  The
+granted ACLs. You can add, edit or delete the target's grants.  The
 administration account (grantee) is updated to reflect the change.
 
 == Revoking Rights
 
 Global administrators can revoke any rights granted to an administrator.
 
-.Admin Console
-****
+Admin Console: ::
+*Home > Manage > Accounts*
 
-Open the administrator account and click *Configure Grants*.
+Open the desired administrator account and click *Configure Grants*.
 
-. Select the right to revoke and click *Delete*.
+. Select the _right_ to revoke and click *Delete*.
 . When the dialog asks if are sure, click *Yes*.
 
 Delegated administrators can revoke rights if the right was created with
 the *Can Grant the right to other admins* enabled.
-****
 
 === Temporarily Revoke Delegated Admin Rights
 
@@ -402,16 +396,16 @@ automatically. You can assign administrator accounts to these groups.
 
 === Domain Administration Group
 
-The `zimbradomainadmins delegated` admin group grants all the rights
+The `zimbradomainadmins` delegated admin group grants all the rights
 necessary to support {product-name} domain administration for
 accounts, aliases, distribution lists and resources.
 
-Administrators who are part of the qzimbradomainadmins` group can create
+Administrators who are part of the `zimbradomainadmins` group can create
 and manage accounts including setting the account quota, aliases,
 distribution lists, and resources accounts in their domain.
 
 When domain administrators log onto the Administration Console, only the
-functions they are authorized to manage are displayed on the console’s
+functions they are authorized to manage are displayed on the console's
 Navigation pane.
 
 ==== Create Link from Zimbra Web Client Account to Admin Console
@@ -421,18 +415,15 @@ Console. To facilitate easy log in, when a delegated administrator account
 is created, their ZWC account can have a link to the Administration
 Console.
 
-.CLI
-****
-The link is created from the zmprov CLI
+The link is created from the `zmprov` CLI
 [source,bash]
 ----
-zmprov md <server.domainexample.com> zimbraWebClientAdminReference <https:// server.domainexample.com:7071/>
+zmprov md {server.example.com} zimbraWebClientAdminReference {https://server.example.com:7071/}
 ----
-****
 
 === Distribution List Administration Group
 
-The `zimbradladmin delegated` admin group grants all the rights necessary
+The `zimbradladmin` delegated admin group grants all the rights necessary
 to log on to the Administration Console and manage distribution lists.
 
 Administrators who are part of this group can
@@ -450,7 +441,7 @@ the rights to manage individual domains to the administrator account or
 administrator group.
 
 For example, to set up domanadministrator1@example.com to manage
-domainexample1 and domainexample2.com. Create a new administrator account
+domainexample1.com and domainexample2.com. Create a new administrator account
 on one of the domains to be managed.
 
 . Create the administrator account on one of the domains to be managed
@@ -467,7 +458,7 @@ grants associated with the views you select.
 +
 * On the Configure Grants page, click *Add*
 * Select the target type as *domain*
-* Enter the target’s domain name (domainexample2.com)
+* Enter the target's domain name (domainexample2.com)
 * For Right Type, select System Defined Right
 * For Right Name type, adminConsoleAccountRights. *Is Positive Right*
 should be selected.
@@ -492,36 +483,36 @@ rights, add the user to the list and make that user an administrator.
 
 . Create a new distribution list:
 +
-* *Check Admin Group*
+* Check *Admin Group*
 * Add the user who will be the administrator as a member of the DL.
-* *Go to the Admin Views page and check Distribution List View* so theadmin
+* Go to the *Admin Views* page and check *Distribution List View* so the admin
 can view the distribution list.
 * Click *Save*.
 
 . In the *Configure Grants* page, add the following rights.
 +
 .Rights
-[cols="4",options="header",]
+[cols="1m,1,1,1",options="header",]
 |=======================================================================
 |Right Name |Target Type |Target |Right Type
 4+|The following right let the administrator manage distribution lists.
 
-|`listdistributionlist` |dl |DL email address |SD Right
+|listDistributionList |dl |DL email address |SD Right
 
-|`adddistributionlist alias` |dl |DL email address |SD Right
+|addDistributionListAlias |dl |DL email address |SD Right
 
-|`adddistributionlist member` |dl |DL email address |SD Right
+|addDistributionListMember |dl |DL email address |SD Right
 
-|`modifyDistributionlist` |dl |DL email address |SD Right
+|modifyDistributionList |dl |DL email address |SD Right
 
-|`getdistributionlist membership` |dl |DL email address |SD Right
+|getDistributionListMembership |dl |DL email address |SD Right
 
-|`RemoveDistributionlistmember` |dl |DL email address |SD Right
+|removeDistributionListMember |dl |DL email address |SD Right
 
 4+|This domain right displays user account list that the administrator can
 select from to add to a distribution list.
 
-|`listAccount` |domain |DL email address |SD Right
+|listAccount |domain |DL email address |SD Right
 
 |=======================================================================
 
@@ -541,11 +532,11 @@ account name.
 you have chosen. For Change Password rights, do not configure these
 grants. Select *Skip*. Click *Add* to add the following right:
 +
-[cols="4",options="header",]
+[cols="1m,1,1,1",options="header",]
 |=======================================================================
 |Right Name |Target Type |Target |Right Type
 
-|`setAccountPassword` |domain |domain address |SD Right
+|setAccountPassword |domain |domain name |SD Right
 
 |=======================================================================
 
@@ -554,12 +545,12 @@ grants. Select *Skip*. Click *Add* to add the following right:
 View Mail access right can be granted on accounts, domains, and
 distribution lists.
 
-[cols=",,,a",options="header",]
+[cols="1m,1,1,1a",options="header",]
 |=======================================================================
 |Right Name |Target Type |Target |Right Type
 
-|`adminLoginAs` |
-*Either*: account, domain, dl|
+|adminLoginAs |
+account, domain, dl|
 account, domain, or distribution list address|
 SD Right footnote:[To deny the View Mail right on the target, check the box for *Is
 Negative Right (Deny)*]
@@ -580,24 +571,22 @@ account or domain administrator admin group.
 Add the System Defined Rights to each COS in the domain.
 
 .System Defined Rights for COS
-[cols="4",options="header",]
+[cols="1m,1,1,1",options="header",]
 |=======================================================================
 |Right Name |Target Type |Target |Right Type
 
-|`listCos` |cos |COS name |SD Right
+|listCos |cos |COS name |SD Right
 
-|`getCos` |cos |COS name |SD Right
+|getCos |cos |COS name |SD Right
 
-|`assignCos` |cos |COS name |SD Right
+|assignCos |cos |COS name |SD Right
 
-4+|This domain right displays the COS information in the user account’s
+4+|This domain right displays the COS information in the user account's
 General Information page.
 
-|`zimbraCOSId` |domain |domain address |
-Attribute Right
-
-Verb: *Write*
-
+|zimbraCOSId |domain |domain name |
+Attribute Right +
+Verb: *Write* +
 AR Target: *account*
 
 |=======================================================================
@@ -613,11 +602,11 @@ cross mailbox search request.
 The Archiving and Discovery feature must be installed for this feature to
 work.
 
-[cols=",,,",options="header",]
+[cols="1m,1,1,1",options="header",]
 |=======================================================================
 |Right Name |Target Type |Target |Right Type
 
-|`adminConsoleCrossMailboxSearchRights` |
+|adminConsoleCrossMailboxSearchRights |
 (combo) |
 server name where cross mailbox searches can be run |
 SD Right
@@ -629,13 +618,13 @@ accounts so that the admin can create the target mailbox to receive the
 search results. If you do not want this role to have the ability to create
 accounts, grant the following negative right as well.
 
-[cols=",,,a",options="header",]
+[cols="1m,1,1,1a",options="header",]
 |=======================================================================
 |Right Name |Target Type |Target |Right Type
 
-|`CreateAccount` |
+|CreateAccount |
 domain |
-domain address |
+domain name |
 SD Right footnote:[To deny the Create Account right on the target, check the box for *Is Negative Right (Deny)*]
 
 |=======================================================================
@@ -643,11 +632,11 @@ SD Right footnote:[To deny the Create Account right on the target, check the box
 If you want this admin to also view the target mailbox with the results of
 the cross mailbox search, grant the right to view that mailbox only.
 
-[cols=",,,a",options="header",]
+[cols="1m,1,1,1a",options="header",]
 |=======================================================================
 |Right Name |Target Type |Target |Right Type
 
-|`adminLoginAs` |
+|adminLoginAs |
 account |
 cross mailbox search target account name |
 SD Right footnote:[To deny the View Mail right on the target, check the box for *Is Negative Right (Deny)*]
@@ -659,18 +648,18 @@ SD Right footnote:[To deny the View Mail right on the target, check the box for 
 This role creates a delegated administrator role that can create, deploy
 and view Zimlets.
 
-[cols=",,,",options="header",]
+[cols="1m,1,1,1",options="header",]
 |=======================================================================
 |Right Name |Target Type |Target |Right Type
 
-|`adminConsoleZimletRights` |
+|adminConsoleZimletRights |
 server, domain |
-server name or domain address |
+server name or domain name |
 SD Right
 
-|`adminConsoleAccountsZimletsTabRights` |
+|adminConsoleAccountsZimletsTabRights |
 server, domain |
-server name or domain address |
+server name or domain name |
 SD Right
 
 |=======================================================================
@@ -680,13 +669,13 @@ SD Right
 This role creates a delegated administrator that can create and manage
 resources.
 
-[cols=",,,",options="header",]
+[cols="1m,1,1,1",options="header",]
 |=======================================================================
 |Right Name |Target Type |Target |Right Type
 
-|`adminConsoleResourceRights` |
+|adminConsoleResourceRights |
 combo |
-server name or domain address |
+server name or domain name |
 SD Right
 
 |=======================================================================
@@ -697,13 +686,13 @@ This role creates a delegated administrator that can access all the
 searches saved in the Administration Console Navigation pane, Search
 section.
 
-[cols=",,,",options="header",]
+[cols="1m,1,1,1",options="header",]
 |=======================================================================
 |Right Name |Target Type |Target |Right Type
 
-|`adminConsoleSavedSearchRights` |
+|adminConsoleSavedSearchRights |
 combo |
-server name or domain address |
+server name or domain name |
 SD Right
 
 |=======================================================================
@@ -714,11 +703,11 @@ This role creates a delegated administrator that can access the Server
 Status page. In addition to granting this right, you must also select the
 Admin View, *Global Server Status View*.
 
-[cols=",,,",options="header",]
+[cols="1m,1,1,1",options="header",]
 |=======================================================================
 |Right Name |Target Type |Target |Right Type
 
-|`adminConsoleServerStatusRights` |
+|adminConsoleServerStatusRights |
 global ||
 SD Right
 

--- a/introduction.adoc
+++ b/introduction.adoc
@@ -50,5 +50,5 @@ Let us know what you like about the product and what you would like to
 see in the product. Post your ideas to the Zimbra Forum.
 
 If you encounter problems with this software, go to
-http://bugzilla.zimbra.com to submit a bug report. Make sure to provide
+https://bugzilla.zimbra.com to submit a bug report. Make sure to provide
 enough detail so that the bug can be easily duplicated.

--- a/ldap.adoc
+++ b/ldap.adoc
@@ -4,11 +4,11 @@
 
 LDAP directory services provide a centralized repository for information
 about users and devices that are authorized to use your Zimbra service.
-The central repository used for Zimbra’s LDAP data is the OpenLDAP
+The central repository used for Zimbra's LDAP data is the OpenLDAP
 directory server.
 
 [NOTE]
-{product-name} supports integration with Microsoft’s Active Directory
+{product-name} supports integration with Microsoft's Active Directory
 Server.  Contact support for information on specific directory
 implementation scenarios.
 
@@ -53,7 +53,7 @@ entry are determined by the _object classes_ associated with that entry.
 The values of the object class attributes determine the schema rules the
 entry must follow.
 
-An entry’s object class that determines what kind of entry it is, is called
+An entry's object class that determines what kind of entry it is, is called
 a structural object class and cannot be changed.  Other object classes are
 called auxiliary and may be added to or deleted from the entry.
 
@@ -73,7 +73,7 @@ The Zimbra LDAP schema extends the generic schema included with OpenLDAP
 software.  It is designed to coexist with existing directory installations.
 
 All attributes and object classes specifically created for {product-name}
-are prefaced by "`zimbra,`" such as `zimbraAccount` object class or
+are prefaced by "`zimbra`", such as `zimbraAccount` object class or
 `zimbraAttachmentsBlocked` attribute.
 
 The following schema files are included in the OpenLDAP implementation:
@@ -92,7 +92,7 @@ You cannot modify the Zimbra schema.
 
 === {product-name} Objects
 
-[cols="25,50a,25s",options="header",]
+[cols="1,2a,1s",options="header",]
 |=======================================================================
 |Object |Description |Object class
 
@@ -162,23 +162,23 @@ additional attributes on the *zimbraCalendarResource* object class.
 |zimbraCalendarResource
 
 |Identity |
-Represents a persona of a user.  A persona contains the user’s identity
+Represents a persona of a user.  A persona contains the user's identity
 such as display name and a link to the signature entry used for outgoing
 emails.  A user can create multiple personas.  Identity entries are created
-under the user’s LDAP entry in the DIT.  |zimbraIdentity
+under the user's LDAP entry in the DIT.  |zimbraIdentity
 
 |Data Source|
 Represents an external mail source of a user.  Two examples of data source
 are POP3 and IMAP.  A data source contains the POP3/IMAP server name, port,
-and password for the user’s external email account.  The data source also
+and password for the user's external email account.  The data source also
 contains persona information, including the display name and a link to the
 signature entry for outgoing email messages sent on behalf of the external
-account.  Data Source entries are created under the user’s LDAP entry in
+account.  Data Source entries are created under the user's LDAP entry in
 the DIT.  |zimbraDataSource
 
 |Signature |
-Represents a user’s signature.  A user can create multiple signatures.
-Signature entries are created under the user’s LDAP entry in the DIT.
+Represents a user's signature.  A user can create multiple signatures.
+Signature entries are created under the user's LDAP entry in the DIT.
 |zimbraSignature
 
 |=======================================================================
@@ -201,16 +201,16 @@ The default is FALSE.
 
 The internal authentication method uses the Zimbra schema running on the
 OpenLDAP directory server.  For accounts stored in the OpenLDAP server, the
-`userPassword` attribute stores a salted-SHA1 (SSHA) digest of the user’s
-password.  The user’s provided password is computed into the SSHA digest
+`userPassword` attribute stores a salted-SHA512 (SSHA512) digest of the user's
+password.  The user's provided password is computed into the SSHA digest
 and then compared to the stored value.
 
 === External LDAP and External AD Authentication Mechanism
 
 External LDAP and external Active Directory authentication can be used if
 the email environment uses another LDAP server or Microsoft Active
-Directory for authentication and Zimbra- LDAP for all other
-{product-name}-related transactions.  This requires that users exist in
+Directory for authentication and Zimbra LDAP for all other
+{product-name} related transactions.  This requires that users exist in
 both OpenLDAP and in the external LDAP server.
 
 The external authentication methods attempt to bind to the specified LDAP
@@ -230,14 +230,14 @@ For example:
     ldap://server1:3268
     ldap://exch1.acme.com
 +
-If it is an SSL connection, use `ldaps:` instead of `ldap*:`.  The SSL
+If it is an SSL connection, use `ldaps:` instead of `ldap:`.  The SSL
 certificate used by the server must be configured as a trusted certificate.
 
 * `zimbraAuthLdapBindDn` attribute is a format string used to determine
   which DN to use when binding to the external directory server.
 +
 During the authentication process, the user name starts out in the
-format: *user@domain.com*
+format: *user@example.com*
 +
 The user name might need to be transformed into a valid LDAP bind `DN`
 (distinguished name) in the external directory.  In the case of Active
@@ -258,21 +258,18 @@ register the custom authentication handler.
 ==== Preparing a domain for custom auth
 
 To enable a domain for custom auth, set the domain attribute,
-*zimbraAuthMet to custom:\{registered-custom-auth-handler-name}*.
+*zimbraAuthMech to custom:\{registered-custom-auth-handler-name}*.
 
-.CLI
-****
-In the following example, “sample” is the name under which custom
+In the following example, "sample" is the name under which custom
 authentication is registered.
 
 .Enable a domain for custom authentication
-============================================================
+====
 [source, bash]
 ----
 zmprov modifydomain {domain|id} zimbraAuthMech custom:sample
 ----
-============================================================
-****
+====
 
 ==== Register a custom authentication handler
 
@@ -291,14 +288,14 @@ in the init method of the extension.
 Definitions:
 +
 ** *handlerName* is the name under which this custom auth handler
-    isregistered to Zimbra’s authentication infrastructure.  This name is
-    set in the domain’s zimbraAuthMech attribute of the domain.
+    isregistered to Zimbra's authentication infrastructure.  This name is
+    set in the domain's zimbraAuthMech attribute of the domain.
 ** *handler* is the object on which the authenticate method is invoked
     forthis custom auth handler.  The object has to be an instance of
     `ZimbraCustomAuth` (or subclasses of it).
 
 .Registering a custom authentication handler
-===================================================================
+====
 [source, java]
 ----
 public class SampleExtensionCustomAuth implements ZimbraExtension {
@@ -313,7 +310,7 @@ public class SampleExtensionCustomAuth implements ZimbraExtension {
 ...
 }
 ----
-===================================================================
+====
 
 ==== How Custom Authentication Works
 
@@ -333,17 +330,17 @@ All attributes of the account can be retrieved from the account object.
 Kerberos5 Authentication Mechanism authenticates users against an external
 Kerberos server.
 
-1.  Set the domain attribute `zimbraAuthMech` to kerberos5.
+1.  Set the domain attribute `zimbraAuthMech` to `kerberos5`.
 2.  Set the domain attribute `zimbraAuthKerberos5Realm` to the Kerberos5
     realm in which users in this domain are created in the Kerberos
     database.
     When users log in with an email password and the domain,
-    `zimbraAuthMech` is set to kerberos5, the server constructs the
+    `zimbraAuthMech` is set to `kerberos5`, the server constructs the
     Kerberos5 principal by
     `\{localpart-of-the-email}@\{value-of-zimbraAuthKerberos5Realm}` and
     uses that to authenticate to the kerberos5 server.
 
-To specify Kerberos5 for an individual account set the account’s
+To specify Kerberos5 for an individual account set the account's
 `zimbraForeignPrincipal` as `kerberos5:\{kerberos5-principal}`.  For
 example: kerberos5:user1@MYREALM.COM.
 
@@ -358,15 +355,13 @@ For each {product-name} domain you can configure GAL to use:
 
 * External LDAP server
 * {product-name} internal LDAP server
-* Both external LDAP server and OpenLDAP in GAL searches
+* Both external LDAP server and {product-name} LDAP in GAL searches
 
 The {product-name} Web Client can search the GAL.  When the user searches
 for a name, that name is turned into an LDAP search filter similar to the
 following example, where the string `%s` is the name the user is searching
 for.
 
-.CLI
-****
 .Searching the GAL
 ====
 [source]
@@ -377,17 +372,17 @@ for.
   (zimbraMailAddress = %s*)
 ----
 ====
-****
 
 === GAL Attributes in {product-name}
 
-The <<attributes_mapped_to_zimbra_collaboration_contact, Attributes Mapped
-to {product-name} Contact>> table maps generic GAL search attributes to
-their {product-name} contact fields.
+The
+<<attributes_mapped_to_zimbra_collaboration_contact,Attributes Mapped to {product-name} Contact>>
+table maps generic GAL search attributes to their {product-name}
+contact fields.
 
 LDAP attributes are mapped to GAL entry fields.  For example, the LDAP
-attribute displayName and cn can be mapped to GAL entry field fullName.
-The mapping is configured in the zimbraGalLdapAttrMap attribute.
+attribute `displayName` and `cn` can be mapped to GAL entry field `fullName`.
+The mapping is configured in the `zimbraGalLdapAttrMap` attribute.
 
 [[attributes_mapped_to_zimbra_collaboration_contact]]
 .Attributes Mapped to {product-name} Contact
@@ -449,8 +444,6 @@ When you add or change theme (skin) property files and locale resource
 files for {product-abbrev} on a server, you must flush the cache to make
 the new content available.
 
-.CLI
-****
 .To flush skins:
 [source, bash]
 ----
@@ -462,7 +455,6 @@ zmprov flushCache skin
 ----
 zmprov flushCache locale
 ----
-****
 
 === Flush Accounts, Groups, COS, Domains, and Servers
 
@@ -474,8 +466,6 @@ after a period of time if the attributes are cached.
 The default {product-abbrev} setting to update the server is 15 minutes.
 The caching period is configured on local config key.
 
-.CLI
-****
 .To change the setting:
 [source, bash]
 ----
@@ -485,9 +475,8 @@ zmlocalconfig ldap_cache_<object>_maxage
 .To enable changes immediately:
 [source, bash]
 ----
-zmprov flushCache [account|cos|domain|group|server] [name|id]
+zmprov flushCache {account|cos|domain|group|server|...} [name|id]...
 ----
-****
 
 If you do not specify a name or ID along with the type, all entries in
 cache for that type are flushed and the cache is reloaded.
@@ -513,8 +502,6 @@ settings that are inherited from global config are only read once at server
 startup, for example port or number of processing threads.  Modifying these
 types of attributes requires a server restart.
 
-.CLI
-****
 To flush the cache for global config changes on all servers:
 
 1.  Modify the setting on the local server
@@ -524,17 +511,18 @@ To flush the cache for global config changes on all servers:
 zmprov mcf zimbraImapClearTextLoginEnabled TRUE
 ----
 +
-The change is only effective on the server
-*zimbra_zmprov_default_soap_server, port zimbra_admin-service_port*.
+The change is performed via the server identified by the localconfig keys
+`zimbra_zmprov_default_soap_server` and `zimbra_admin_service_port`.
 
-2.  Flush the global config cache on all other servers, `zmprov flushCache`
-must be issued on all servers, one at a time.
+2.  To flush the global config cache on all other servers, `zmprov flushCache`
+must be issued on all servers, one at a time (or use `zmprov flushCache -a`).
 +
 For example:
 +
 [source, bash]
 ----
-zmprov –s server-2 flushcache config zmprov –s server-3 flushcache config
+zmprov –s server2 flushCache config
+zmprov –s server3 flushCache config
 ----
 
 3.  To determine if the action requires a restart
@@ -545,4 +533,3 @@ zmprov desc -a <attributename>
 ----
 +
 The `requiresRestart` value is added to the output if a restart is required.
-****

--- a/legal.adoc
+++ b/legal.adoc
@@ -8,11 +8,11 @@ image:https://i.creativecommons.org/l/by-sa/4.0/88x31.png[CC BY-SA] Synacor, Inc
 This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
 International License unless another license agreement between you and
 Synacor, Inc. provides otherwise. To view a copy of this license, visit
-http://creativecommons.org/licenses/by-sa/4.0 or send a letter to Creative
+https://creativecommons.org/licenses/by-sa/4.0 or send a letter to Creative
 Commons, PO Box 1866, Mountain View, CA 94042, USA.
 
 Synacor, Inc., 2016 +
 40 La Riviere Drive, Suite 300 +
 Buffalo, New York 14202
 
-http://www.synacor.com
+https://www.synacor.com

--- a/legalrequests.adoc
+++ b/legalrequests.adoc
@@ -26,68 +26,60 @@ complete message.
 
 === Setting Up Legal Intercept
 
-.CLI
-****
 Specify the intercept address where the intercepted messages are sent.
 
 * If enabling intercept by COS:
 +
 [source,bash]
 ----
-zmprov mc <cosname> zimbraInterceptAddress <account@intercept_example.gov>
+zmprov mc <cosname> zimbraInterceptAddress <account@intercept.example.com>
 ----
 
 * If enabling intercept for an account:
 +
 [source,bash]
 ----
-zmprov ma <accountname@example.com> zimbraInterceptAddress <account@intercept_example.gov>
+zmprov ma <accountname@example.com> zimbraInterceptAddress <account@intercept.example.com>
 ----
 
 If you are going to use the default intercept message template and From
 address (postmaster@<youraddress.com>), legal intercept is set up.
-****
 
 === Setting Up Legal Intercept to Forward Message Header
 
-.CLI
-****
 To forward the header information, not the complete message for an account:
 [source,bash]
 ----
-zmprov mc <accountname@example.com> zimbraInterceptSendHeadersOnly TRUE
+zmprov ma <accountname@example.com> zimbraInterceptSendHeadersOnly TRUE
 ----
-****
 
 === Modifying the Intercept Cover Email Message
 
 An email message is automatically created to forward copies of the
 intercepted messages as attachments. The default message includes:
 
-* *From* address is Postmaster@<address.com>
+* *From* address is "`postmaster@<example.com>`"
 
-* *Subject* line "`Intercept message for <account@address.com
+* *Subject* line "`Intercept message for <account@example.com>
 <interceptedmessage subject>`"
 
-* *Message* "`Intercept message for <account@address.com>.Operation=<type
-of message>, folder=<foldername>, folder ID=<#>`".
+* *Message* "`Intercept message for <account@example.com>. +
+Operation=<type of message>, folder=<foldername>, folder ID=<#>`".
 
 The cover email message can be modified. Use the following parameters to
 modify the email message.
 
-[cols=",",options=""]
+[cols="s,",options=""]
 |=======================================================================
-|*ACCOUNT_DOMAIN*  |Domain of the account being intercepted.
-|*ACCOUNT_ADDRESS* |Address being intercepted
-|*MESSAGE_SUBJECT* |Subject of the message being intercepted.
-|*OPERATION*       |Operation that the user is performing, "`add message`", "`send message`", or "`save draft`".
-|*FOLDER_NAME*     |Name of the folder to which the message was saved.
-|*FOLDER_ID*       |ID of the folder to which the message was saved.
-|*NEWLINE*         |Used for formatting multi-line message bodies.
+|ACCOUNT_DOMAIN  |Domain of the account being intercepted.
+|ACCOUNT_ADDRESS |Address being intercepted
+|MESSAGE_SUBJECT |Subject of the message being intercepted.
+|OPERATION       |Operation that the user is performing, "`add message`", "`send message`", or "`save draft`".
+|FOLDER_NAME     |Name of the folder to which the message was saved.
+|FOLDER_ID       |ID of the folder to which the message was saved.
+|NEWLINE         |Used for formatting multi-line message bodies.
 |=======================================================================
 
-.CLI
-****
 Use steps in this section to change the from name, the subject line, or
 text in the message body:
 
@@ -95,30 +87,31 @@ text in the message body:
 +
 [source,bash]
 ----
-zmprov mc <accountname@example.com> zimbraInterceptFrom <newname@example.com>
+zmprov ma <accountname@example.com> zimbraInterceptFrom '<newname@example.com>'
 ----
 
 * To change the text of the *Subject* line:
 +
 [source,bash]
 ----
-zmprov mc <accountname@example.com> zimbraInterceptSubject <Intercepted message subject text> parameter <text> parameter
+zmprov ma <accountname@example.com> zimbraInterceptSubject \
+ '<Intercepted message subject text> parameter <text> parameter'
 ----
 
-* To change the text in the message body:
+* To change the text in the *message body*:
 +
 [source,bash]
 ----
-zmprov mc <accountname@example.com> zimbraInterceptBody <Intercepted message text> parameter <text> parameter
+zmprov ma <accountname@example.com> zimbraInterceptBody \
+ '<Intercepted message text> parameter <text> parameter'
 ----
 
 [NOTE]
-To modify by account, type `zmprov ma`.
-****
+To modify by COS, type `zmprov mc {cosname} ...`.
 
 == Creating Mailbox Snapshots for Legal Discovery
 
-You can create a query for the user’s mailbox using the REST URL format to
+You can create a query for the user's mailbox using the REST URL format to
 search for specific types of email messages and attachments and have these
 messages zipped and saved to your computer. This zip file can be forwarded
 to a requesting law enforcement agency.
@@ -146,7 +139,7 @@ account called user1.
 +
 You can use any search operators that are used for searching in
 {product-abbrev}. For example, you can search by folder (in:folder_name),
-by sender’s name (from:<someone>), and you can use multiple search
+by sender's name (from:<someone>), and you can use multiple search
 terms. See the Search Tips wiki page for keyword examples,
 https://wiki.zimbra.com/wiki/Search_Tips.
 

--- a/licensing.adoc
+++ b/licensing.adoc
@@ -51,13 +51,13 @@ need to purchase a subscription or a perpetual license.
 |License Types |Purpose
 
 |Trial |
-Free of charge: Trial license from the Zimbra website (www.zimbra.com). The
+Free of charge: Trial license from the Zimbra website (https://www.zimbra.com). The
 trial license allows you to create up to 50 users. It expires in 60 days.
 
 |Trial extended |
 Free of charge: Allows you to create up to 50 users and is valid for an
 extended period of time. Obtainable from Zimbra Sales by contacting
-sales@zimbra.com or calling 1-650-427-5701.
+sales@zimbra.com or calling 1-972-407-0688.
 
 |Subscription |
 Purchased: Applicable to a specific {product-name} system and encrypted
@@ -108,8 +108,11 @@ account, the license account limit reflects the change
 
 All network edition installations require license activation. New
 installations have a 10 day grace period from the license issue date before
-requiring activation. Your license can be activated by selecting *Configure
-> Global Settings > License > Activate License*.
+requiring activation. Your license can be activated in the Administration Console.
+
+Admin Console: ::
+*Home > Configure > Global Settings > License*, from the *Gear* icon select
+*Activate License*
 
 Upgraded {product-name} versions require an immediate activation to
 maintain network feature functionality.
@@ -119,7 +122,7 @@ maintain network feature functionality.
 Licenses are automatically activated if the {product-name} server has a
 connection to the Internet and can communicate with the Zimbra License
 server. If you are unable to automatically activate your license, see
-<<manual_license_activation, Manual License Activation>>.
+<<manual_license_activation,Manual License Activation>>.
 
 [[manual_license_activation]]
 === Manual License Activation
@@ -185,7 +188,7 @@ of accounts that can be created.
 
 Current license information, including the number of accounts purchased,
 the number of accounts used, and the expiration date, can be viewed from
-*Global Settings > License*.
+*Home > Configure > Global Settings > License*.
 
 == Managing Licenses
 
@@ -195,7 +198,8 @@ License* link on the toolbar activates the license.
 
 Current license information, including the license ID, the issue date,
 expiration date, number of accounts purchased, and the number of accounts
-used can be viewed from *Global Settings > License*.
+used can be viewed from
+*Home > Configure > Global Settings > License*.
 
 === License Information
 
@@ -208,7 +212,9 @@ license.
 
 Current license information, including the license ID, the issue date,
 expiration date, number of accounts purchased, and the number of accounts
-used can be viewed from the *Global Settings > License* page.
+used can be viewed from
+*Home > Configure > Global Settings > License*.
+
 
 When the number of accounts created is equal to the number of accounts
 purchased you will not be able to create new accounts. You can purchase
@@ -234,8 +240,7 @@ functions that are no longer available upon license expiration:
 * Backup/Restore
 * Zimbra Mobile (ActiveSync)
 * Zimbra Touch Client
-* Exchange Web Services (EWS)
-** EWS is a separately licensed add-on
+* Exchange Web Services (EWS) -- _a separately licensed add-on_
 * High-Fidelity Document Preview
 * Zimbra Connector for Outlook
 * Zimbra Connector for Blackberry
@@ -266,26 +271,24 @@ Administration Console, a reminder notice is displayed.
 
 When you renew or change the Zimbra license, you update {product-name}
 mailbox servers with the new license information. This operation be
-performed from either the Administration Console or the CLI.
+performed from either the CLI or the Administration Console.
 
-.CLI
-****
 [source, bash]
 ----
 zmlicense
 ----
-****
 
-.Admin Console
-****
+Admin Console: ::
+*Home > Configure > Global Settings > License*
+
 Updating a license:
 
 . Save the license on the computer you use to access the Administration
 Console.
 
-. Log on to the Administration Console, go to *Global Settings > License*
-and on the toolbar click *Update License*. The License Installation Wizard
-opens.
+. Log on to the Administration Console, go to
+*Home > Configure > Global Settings > License*, from the *Gear* icon select
+*Update License*. The License Installation Wizard opens.
 
 . Browse to select the license file and click *Next*. The license file is
 now uploaded.
@@ -297,4 +300,3 @@ an immediate activation to maintain network feature functionality.
 
 Your license information is updated automatically. The cached account
 license count is automatically refreshed on each mailbox server.
-****

--- a/mailboxserver.adoc
+++ b/mailboxserver.adoc
@@ -39,25 +39,26 @@ delivered or created, the message is saved in the current message volume.
 
 To manage your email storage resources, you can configure storage
 volumes for older messages by implementing a Hierarchical Storage
-Management (HSM) policy. See <<managing_configuration, Managing Configuration>>.
+Management (HSM) policy.
+See <<managing_configuration,Managing Configuration>>.
 
 === Data Store
 
-The Data Store is a MariaDB database where internal mailbox IDs are
+The Data Store is a SQL database where internal mailbox IDs are
 linked with user accounts. All the message metadata including tags,
 conversations, and pointers indicate where the messages are stored in
-the file system. The MariaDB database files are located in
+the file system. The SQL database files are located in
 `/opt/zimbra/db`.
 
 Each account (mailbox) resides only on one server. Each server has its
 own standalone data store containing data for the mailboxes on that
 server.
 
-* The data store maps the mailbox IDs to the users’ OpenLDAP
-accounts.The primary identifier within the {product-name} database
+* The data store maps the mailbox IDs to the users' LDAP
+accounts. The primary identifier within the {product-name} database
 is the mailbox ID, rather than a user name or account name. The mailbox
 ID is only unique within a single mailbox server.
-* Metadata including user’s set of tag definitions, folders, contacts,
+* Metadata including user's set of tag definitions, folders, contacts,
 calendar appointments, tasks, Briefcase folders, and filter rules are in
 the data store database.
 * Information about each mail message, including whether it is read or
@@ -79,7 +80,7 @@ image::images/Tokenization.jpg[Index Store]
 The process is as follows:
 
 1.  The Zimbra MTA routes the incoming email to the mailbox server that
-contains the account’s mailbox.
+contains the account's mailbox.
 2.  The mailbox server parses the message, including the header, the
 body, and all readable file attachments such as PDF files or Microsoft
 Word documents, in order to tokenize the words.
@@ -119,9 +120,9 @@ The Web Application Server Split functionality provides an option to
 separate the mailstore services (mail server) and the user interface
 services (web client server).
 
-For example, a web client server running ‘zimbra,zimbraAdmin’ webapps
+For example, a web client server running 'zimbra,zimbraAdmin' webapps
 serving the static UI content like html/css pages, and mail server
-running ‘service’ webapp serving all the SOAP requests. These servers
+running 'service' webapp serving all the SOAP requests. These servers
 are running in split mode.
 
 The Web Application Server Split benefits include:
@@ -149,8 +150,9 @@ every {product-name} server and performs both backup and restore
 functions. You do not have to stop the {product-name} server in order
 to run the backup process. The backup manager can be used to restore a
 single user, rather than having to restore the entire system in the event
-that one user’s mailbox becomes corrupted. Full and incremental backups are
-in `/opt/zimbra/backup`. See <<backup_and_restore, Backup and Restore>>.
+that one user's mailbox becomes corrupted. Full and incremental backups are
+in `/opt/zimbra/backup`.
+See <<backup_and_restore,Backup and Restore>>.
 
 Each Zimbra mailbox server generates redo logs that contain current and
 archived transactions processed by the message store server since the
@@ -166,8 +168,8 @@ components with one or more mailbox servers. Each of the components may
 generate its own logging output. Local logs are in `/opt/zimbra/log`.
 
 Selected {product-name} log messages generate SNMP traps, which you
-can capture using any SNMP monitoring software. See
-<<monitoring_zcs_servers, Monitoring {product-abbrev} Servers>>.
+can capture using any SNMP monitoring software.
+See <<monitoring_zcs_servers,Monitoring {product-abbrev} Servers>>.
 
 [NOTE]
 System logs, redo logs, and backup sessions should be on separate disks to

--- a/managingaccounts.adoc
+++ b/managingaccounts.adoc
@@ -3,17 +3,15 @@
 
 == Status of User Accounts
 
-.Admin Console
-****
+Admin Console: ::
+*Home > Manage > Accounts*
 
 The status of an account determines whether a user can log in and
-receivemail.  The account status is displayed on the *Accounts Content*
+receivemail.  The account status is displayed on the *Accounts*
 pane of the Administration Console.
-****
-
 
 .Status - User Accounts
-[cols=",",options="header",]
+[cols="1,5",options="header",]
 |=======================================================================
 |Status |Description
 
@@ -54,35 +52,33 @@ The administrator can remove the locked out status at any time.
 
 == Deleting an Account
 
-.Admin Console
-****
+Admin Console: ::
+*Home > Manage > Accounts*
 
 You can delete accounts from the Administration Console.  This removes
-theaccount from the server, deletes the messages in the message store, and
+the account from the server, deletes the messages in the message store, and
 changes the number of accounts used against your license.
-****
 
 [TIP]
 Before you delete an account, run a full backup of that account to save
-the account information.  See also the <<backup_and_restore,Backup and Restore>>.
+the account information.  See also <<backup_and_restore,Backup and Restore>>.
 
 == Viewing an Accounts Mailbox
 
 You can view a selected account’s mailbox content, including all folders,
 calendar entries, and tags from the Administration Console.
 
-.Admin Console
-****
-Select an account and from the gear icon, select *View Mail*.  The user’s
-ZWC account opens in a new browser window.
-****
+Admin Console: ::
+*Home > Manage > Accounts -> _account_*
 
+Select an _account_, from the *Gear* icon select *View Mail*.  The user's
+ZWC account opens in a new browser window.
 
 This feature can be used to assist users who are having trouble with
 their mail account as you and the account user can be logged on to the
 account at the same time.
 
-Any View Mail action to access an account is logged to the _audit.log_
+Any View Mail action to access an account is logged to the `audit.log`
 file.
 
 == Using an Email Alias
@@ -110,48 +106,48 @@ automatically manages adding and deleting members in the list.  For more
 information about dynamic distribution lists, see
 <<using_dynamic_distribution_lists,Using Dynamic Distribution Lists>>.
 
-You can see which distribution lists a user is a member of from the user’s
-account Member of page.  When a Zimbra user’s email address is added to a
-distribution list, the user’s account Member Of page is updated with the
+You can see which distribution lists a user is a member of from the user's
+account Member of page.  When a Zimbra user's email address is added to a
+distribution list, the user's account Member Of page is updated with the
 distribution list name.  When a distribution list is deleted, the
-distribution list name is automatically removed from the account’s Member
+distribution list name is automatically removed from the account's Member
 Of page.
 
 === Setting Subscription Policies for Distribution Lists
 
-Subscription policies can be set up to manage a distribution list’s
+Subscription policies can be set up to manage a distribution list's
 membership.  Owners of the list manage the subscription policy from the
 Properties page of a distribution list.
 
-[cols=",a",options="header",]
+[cols="1,3a",options="header",]
 |=======================================================================
 |Distribution Option |Description
 
 |New Subscription Requests |
 
-* *Automatically accept*. Membership is open to anyone who subscribes.
+* *Automatically accept* -- Membership is open to anyone who subscribes.
 
-* *Require list owner approval*.  To subscribe, users send an email to the
+* *Require list owner approval* --  To subscribe, users send an email to the
 owner of the distribution list and the owner replies to this email request.
 
-* *Automatically reject*. No one can be added to this distribution list.
+* *Automatically reject* -- No one can be added to this distribution list.
 
 |Unsubscription Requests |
 
-* *Automatically accept*.  Anyone can remove their name from the list.
+* *Automatically accept* --  Anyone can remove their name from the list.
 
-* *Require list owner approval*. To be removed from the distribution list,
+* *Require list owner approval* -- To be removed from the distribution list,
 users send an email to the owner.  The owner must accept the email request
 to remove the name.
 
-* *Automatically reject.* Users cannot remove themselves from the list.
+* *Automatically reject* -- Users cannot remove themselves from the list.
 
 |=======================================================================
 
 === Management Options for Owners of Distribution Lists
 
 You can add owners to distribution lists and they manage the list from
-their ZWC account’s Address Book, Distribution List folder.  Owners of a
+their ZWC account's Address Book, Distribution List folder.  Owners of a
 list can right click a distribution list and click the *Edit Group* link to
 edit a list.
 
@@ -168,13 +164,12 @@ owners can configure include:
 
 === Creating a Distribution List
 
-.Admin Console
-****
 Use steps in this section to create a distribution list:
 
+Admin Console: ::
 *Home > Manage > Distribution Lists*
 
-. At the *Gear* icon, click *New*.
+. From the *Gear* icon, click *New*.
 
 . On the *Members* page, add the distribution list name.  Do not use
 spaces.  The other fields are optional.
@@ -188,7 +183,7 @@ section, type a complete mail address.
 . Click *Next* to configure the *Properties* page.
 +
 .Distribution Properties Options
-[cols=",",options="header",]
+[cols="1,3a",options="header",]
 |=======================================================================
 |Distribution Properties Options |Description
 
@@ -218,7 +213,6 @@ Select from:
 * Require list owner approval
 * Automatically reject
 
-
 |Unsubscription Requests |
 Select from:
 
@@ -240,7 +234,6 @@ email addresses in the *Owners* page.
 
 . Click *Finish*.  The distribution list is enabled and the URL is
 created.
-****
 
 === Managing Access to Distribution Lists
 
@@ -258,12 +251,12 @@ grant.
 You can grant the right on individual distribution lists and configure
 specific users that are allowed to access the distribution list.
 
-You can restrict access to a distribution list from the CLI `zmprov grant
-rights` (`grr`) command.
+You can restrict access to a distribution list from the CLI
+`zmprov grantRight` (`grr`) command.
 
 [NOTE]
-For more information about how granting rights works, see Delegated
-Administration.
+For more information about how granting rights works, 
+see <<Delegated Administration>>.
 
 ==== Who Can View Members of a Distribution List
 
@@ -273,8 +266,6 @@ Users can click on this to expand the distribution list.  A list of the
 addresses in the distribution list is displayed.  Users can select
 individual addresses from the expanded list.
 
-.CLI
-****
 Restricting who can view addresses in a distribution list to
 individuals or to a domain:
 --
@@ -300,7 +291,6 @@ zmprov grr domain <domain_name> dom <example.com> viewDistList
 zmprov grr dl <dll_name@example.com> usr <user1@example.com>
 ----
 --
-****
 
 ==== Who Can Send to a Distribution List
 
@@ -312,10 +302,9 @@ stating that they are not authorized to send messages to the recipient
 distribution list.
 
 [NOTE]
-The *Milter Server* must be enabled from *Global Settings > MTA*.
+The *Milter Server* must be enabled from
+*Home > Configure > Global Settings > MTA*.
 
-.CLI
-****
 Restricting who can send messages to a distribution list to individuals or
 to a domain:
 
@@ -334,10 +323,7 @@ distribution lists.
 ----
 zmprov grr domain <domain_name> dom <example.com> sendToDistList
 ----
-****
 
-.CLI
-****
 Restricting access and to remove the restriction to individual distribution
 lists for different user types.
 
@@ -438,7 +424,6 @@ Revoke access
 ----
 zmprov rvr dl <dlname@example.com> gst <someone@foo.com> "" sendToDistList
 ----
-****
 
 ==== Enabling View of Distribution List Members for AD Accounts
 
@@ -446,10 +431,8 @@ To view Active Directory distribution list members in messages or in the
 address book, the GAL group handler for Active Directory must be configured
 in the {product-abbrev} GALsync account for each Active Directory.
 
-.CLI
-****
 Use steps in this section to update the GALsync account for each Active
-Directory.This configuration requires that you know the GALsync account
+Directory. This configuration requires that you know the GALsync account
 name and all data sources on that GALsync account.
 
 . Display the Zimbra ID of the GAL sync account:
@@ -463,7 +446,7 @@ To find the name:
 +
 [source,bash]
 ----
-zmprov ga {zimbraId-of-the-GAL-sync-account} | grep "# name"
+zmprov ga {zimbraId-of-the-GAL-sync-account} name
 ----
 
 . Display data sources for the GALsync account:
@@ -477,9 +460,9 @@ zmprov gds {gal-sync-account-name-for-the-domain}
 +
 [source,bash]
 ----
-zmprov mds {gal-sync-account-name-for-the-domain} {AD-data-source-name} zimbraGalLdapGroupHandlerClass com.zimbra.cs.gal.ADGalGroupHandler
+zmprov mds {gal-sync-account-name-for-the-domain} {AD-data-source-name} \
+ zimbraGalLdapGroupHandlerClass com.zimbra.cs.gal.ADGalGroupHandler
 ----
-****
 
 [[using_dynamic_distribution_lists]]
 == Using Dynamic Distribution Lists
@@ -488,7 +471,7 @@ Dynamic distribution lists automatically manage the membership.  Users are
 added and removed from the distribution list automatically.  When you
 create a dynamic distribution list, a member URL is specified.  This member
 URL is used to identify who should be members of the list.  You can view
-this URL from the Administration Console distribution list’s Properties
+this URL from the Administration Console distribution list's Properties
 page.
 
 You can create dynamic distribution lists from the Administration Console
@@ -511,11 +494,10 @@ the new rule.
 You can create a dynamic distribution list with the admin console or with
 the CLI, as described in this section.
 
-.Admin Console
-****
+Admin Console: ::
 *Home > Manage > Distribution Lists*.
 
-. In the *Gear* icon, click *New*.
+. From the *Gear* icon, click *New*.
 
 . On the *Members* page, add the dynamic distribution list name.  Do not
 use spaces.  Do not add members to the list.
@@ -523,7 +505,7 @@ use spaces.  Do not add members to the list.
 . Click *Next* to configure the *Properties* page.
 +
 .Dynamic Distribution Lists Options
-[cols=",a",options="header",]
+[cols="1,4a",options="header",]
 |=======================================================================
 |Option |Description
 
@@ -577,8 +559,8 @@ ldap:///??sub?(&(objectClass=zimbraAccount)(ZimbraAccountStatus=active))
 
 .All users with the title manager
 ====
-The title is taken from the account’s *Contact Information Job Title*
-field.  In this example, this field would be set to “Manager”.
+The title is taken from the account's *Contact Information Job Title*
+field.  In this example, this field would be set to "Manager".
 ----
 ldap:///??sub?(&(objectClass=zimbraAccount)(title=Manager))
 ----
@@ -610,59 +592,57 @@ If you use the CLI to modify a dynamic distribution list originally created
 on the Administration Console, you must set `zimbraIsACLGroup` *FALSE* for
 that dynamic distribution list.
 
-****
+---
 
-.CLI
-****
-Use the `zmprov` command to manage dynamic distribution lists.  In the
+Use the CLI `zmprov` command to manage dynamic distribution lists.  In the
 command, `ldap:///??sub?` is the URL.  You can add any combination of
 filters to this to create different types of dynamic distribution lists.
 
-
-*Creating a dynamic distribution list of all new and existing accounts*
-
+. Creating a dynamic distribution list of all new and existing accounts
++
 All users, GAL account names, and spam/ham account names are included.
 When user accounts are deleted, they are removed from the list.
-
++
 [source,bash]
 ----
-zmprov cddl <all@domain.com> memberURL 'ldap:///??sub?(objectClass=zimbraAccount)' zimbraIsACLGroup FALSE
+zmprov cddl <all@domain.com> zimbraIsACLGroup FALSE \
+  memberURL 'ldap:///??sub?(objectClass=zimbraAccount)'
 ----
 
-*Creating a COS and Assign Users*
-
+. Creating a COS and Assign Users
++
 If you create COSs and assign users to the COS based on specific criteria,
 such as all managers, you can quickly modify a dynamic distribution list to
 be used for a specific COS.
-
-Examples of creating dynamic distribution lists for specific user types:
-
++
 .A dynamic distribution list that includes all users that have active accounts in a specific COS
 ====
 [source,bash]
 ----
-zmprov cddl <allusers@domain.com> memberURL 'ldap:///??sub?(&(objectClass-zimbraAccount) (zimbraCOSId=513e02e-9abc-4acf-863a-6dccf38252e3) (zimbraAccountStatus=active) )' zimbraIsACLGroup FALSE
+zmprov cddl <allusers@domain.com>  zimbraIsACLGroup FALSE \
+  memberURL 'ldap:///??sub?(&(objectClass-zimbraAccount) (zimbraCOSId=513e02e-9abc-4acf-863a-6dccf38252e3) (zimbraAccountStatus=active))'
 ----
 ====
-
++
 .A dynamic distribution list that includes all users based on job titles
 ====
 To use this, the account's Contact Information *Job Title* field must
 include the title.  In this example it would be set to "Manager".
 [source,bash]
 ----
-zmprov cddl <allmanagers@domain.com> memberURL 'ldap:///??sub?(&(objectClass-zimbraAccount) (zimbraCOSId=513e02e-9abc-4acf-863a-6dccf38252e3) (title=Manager) )' zimbraIsACLGroup FALSE
+zmprov cddl <allmanagers@domain.com> zimbraIsACLGroup FALSE' \
+  memberURL ldap:///??sub?(&(objectClass-zimbraAccount) (zimbraCOSId=513e02e-9abc-4acf-863a-6dccf38252e3) (title=Manager))'
 ----
 ====
-
++
 .A dynamic distribution list for all delegated administrators
 ====
 [source,bash]
 ----
-zmprov cddl <alldelegatedadmins@domain.com> memberURL 'ldap:///??sub?(&(objectClass-zimbraAccount) (zimbraCOSId=513e02e-9abc-4acf-863a-6dccf38252e3) (zimbraIsDelegatedADminAccount=TRUE) )' zimbraIsACLGroup FALSE
+zmprov cddl <alldelegatedadmins@domain.com> zimbraIsACLGroup FALSE \
+  memberURL 'ldap:///??sub?(&(objectClass-zimbraAccount) (zimbraCOSId=513e02e-9abc-4acf-863a-6dccf38252e3) (zimbraIsDelegatedADminAccount=TRUE))'
 ----
 ====
-****
 
 == Moving a Mailbox
 
@@ -670,7 +650,7 @@ Mailboxes can be moved between Zimbra servers that share the same LDAP
 server.
 
 You can move a mailbox from either the Administration Console or use the
-CLI command - `zmmboxmove` - to reposition a mailbox from one server to
+CLI command `zmmboxmove` to reposition a mailbox from one server to
 another, without taking down the servers.
 
 The destination server manages the mailbox move process.  The move runs in
@@ -715,18 +695,15 @@ search indexes, blobs, and HSM blobs when mailboxes are moved.  The
 following configuration options can be set on either the exporting server
 or the destination server:
 
-* `zimbraMailboxMoveSkipSearchIndex`
-+
+* `zimbraMailboxMoveSkipSearchIndex` --
 If you do not include the search index data, the mailbox will have to be
 reindexed after the move.
 
-* `zimbraMailboxMoveSkipBlobs`
-+
+* `zimbraMailboxMoveSkipBlobs` --
 Blobs associated with the mailbox, including primary and secondary
 volumes (HSM) are excluded.
 
-* `zimbraMailboxMoveSkipHsmBlobs`
-+
+* `zimbraMailboxMoveSkipHsmBlobs` --
 This is useful when HSM blobs already exist for the mailbox being moved.
 Set this if `zimbraMailboxMoveSkipBlobs` is not configured, but you want to
 skip blobs on HSM volumes.

--- a/mobile.adoc
+++ b/mobile.adoc
@@ -8,15 +8,15 @@ the mobile device and an account on the mailbox server.
 [NOTE]
 
 Zimbra also has the Touch Client available. For more information, go to
-www.zimbra.com for the latest revision of this guide and see the Zimbra Web
+https://www.zimbra.com for the latest revision of this guide and see the Zimbra Web
 Client User Guide.
 
 The ActiveSync protocol is used to configure and sync the Zimbra mailbox
-server with the native client that is used on a user’s device.
+server with the native client that is used on a user's device.
 
 Zimbra Mobile is compatible with iPhone, iPod Touch, Windows Mobile 5
 (WM5), and 6 (WM6) devices, and many other phones that support the
-ActiveSync™ protocol.
+ActiveSync protocol.
 
 == Mobile Device Security Policies
 
@@ -54,33 +54,24 @@ server. Older devices do not respond to security policies.
 You can manage mobile device policies from the Administration Console as a
 Class of Service or for individual accounts.
 
-.Admin Console
-****
-. To set mobile policies from a COS, go to the *Configure > Class of
-Service* and double-click the COS you want to configure.
+Admin Console: ::
+*Home > Configure > Class of Service -> _COS_ -> Mobile Access -> General* +
+*Home > Manage > Accounts -> _account_ -> Mobile Access -> General*
 
-. To enable mobile devices to sync to {product-abbrev}, check *Mobile Access >
-General > Enable Mobile Sync*.
+. To set mobile policies for an Account or COS, open the desired
+object and select *Mobile Access* in the left hand pane.
 
-. Check *Enable Mobile Policy* to set up mobile security policies that
-enforce security rules.
+. To enable mobile devices to sync to {product-abbrev}, check
+*General -> Enable Mobile Sync*.
 
-. If old devices that do not support device security policies can be used,
-check *Allow non-provisionable devices*.
+. To set up mobile security policies that enforce security rules, check
+*General -> Enable Mobile Policy*.
 
-.  If device does not acknowledge all policies that are downloaded, but you
-want to allow the device to download messages, check *Allow partial policy
-enforcement on devices*.
+. Configure other desired settings.
+See <<mobile_device_security_policies,Mobile Device Security Policies>>
+for a description of the settings you can configure.
 
-. The refresh interval for policy refresh on a device is 24 hours. You can
-change this.
-
-. Configure the appropriate policies in the other sections. See
-<<mobile_device_security_policies,Mobile Device Security Policies>> for a
-description of the settings you can configure.
-
-.  Click *Save*.
-****
+. Click *Save*.
 
 [[mobile_device_security_policies]]
 == Mobile Device Security Policies
@@ -88,19 +79,18 @@ description of the settings you can configure.
 The following attributes can be configured from the Administration Console
 to establish mobile policies.
 
-[cols=",",options="header",]
+[cols="1,2",options="header",]
 |=======================================================================
 |Setting |Description
-2+|*General Settings*
+2+^|*General*
 
-|*Enable Mobile Sync* |
+|Enable Mobile Sync |
 In order for mobile devices to sync to {product-name} Server, *Enable
 Mobile Sync* must be checked. Users have two-way, over the air
 synchronization of mail, contacts, and calendar data between mobile devices
 and the Zimbra server.
 
-|*Enable Mobile Policy* |
-
+|Enable Mobile Policy |
 Check this box to set up mobile security policies that enforce security
 rules on compliant mobile devices.  You can enforce general security
 policies including password rules and set up local wipe capability on
@@ -111,192 +101,191 @@ request to the server, mobile devices that are capable of enforcing
 security policies automatically set up the rules you implement and
 immediately enforces them.
 
-|*Allow non-provisionable devices* |
+|Allow non-provisionable devices |
 If this is enabled, old devices that do not support device security policy
 enforcement can still access the server.
 
-|*Allow partial policy enforcement on device* |
+|Allow partial policy enforcement on device |
 If a device does not acknowledges all policies that are downloaded, {product-abbrev}
 still allows the device to continue downloading messages.
 
-|*Refresh Interval (hours)* |
+|Refresh Interval (hours) |
 Specifies the amount of time in minutes before {product-abbrev} enforces the policy
 refresh on the device by sending "449 Retry after Provision" response to
-Sync request.
-
+Sync request. +
 Default is 24 hours.
 
-2+|*Password Settings*
+2+^|*Password Settings*
 
-|*Require password* |
+|Require password |
 User must create a password on the mobile device.
 
-|*Minimum password length* |
+|Minimum password length |
 Minimum number of characters for the password.  Default is 4. The maximum
 length is 16 characters.
 
-|*Require alphanumeric password* |
+|Require alphanumeric password |
 Requires that the password include both numeric and alpha characters.
 
-|*Minimum complex characters required* |
+|Minimum complex characters required |
 Minimum number of complex characters that must be in the password. This is
 any character that is not a letter. Default is 0 (none).
 
-|*Allow simple password* |
+|Allow simple password |
 Simple passwords can be created. A simple device password is a password
 that has a specific pattern, such as 2468, 1111. Not enabled by default.
 
-|*Enable password recovery* |
+|Enable password recovery |
 Device password is stored n the server and can be recovered. Enabled by
 default.
 
-|*Allow device encryption* |
+|Allow device encryption |
 If enabled, device encryption is enabled on the mobile phone. Enabled by
 default
 
-|*Require device encryption* |
+|Require device encryption |
 If enabled, encryption must be implement on the device to synchronize with
 the server. Not enabled by default.
 
-|*Password re-entry required after inactivity (min)* |
+|Password re-entry required after inactivity (min) |
 Length of time the device remains inactive before the password must be
 entered to reactivate the device.  Default is 15 minutes.
 
-|*Failed attempts allowed* |
+|Failed attempts allowed |
 Specifies the number of failed log in attempts to the device before the
 device automatically initiates a local wipe. The device does not need to
 contact the server for this to happen. Default is 4.
 
-|*Expiration (days)* |
+|Expiration (days) |
 Length of time in days that a password can be used.  After this number of
 days, a new password must be created. Default is 0, the password does not
 expire.
 
-|*Passwords stored to prevent reuse* |
+|Passwords stored to prevent reuse |
 Number of unique passwords that a user must create before an old password
 can be used. Default is 8.
 
-2+|*S/MIME Settings*
+2+^|*S/MIME Settings*
 
-|*Enable S/MIME public key encryption and signing* |
+|Enable S/MIME public key encryption and signing |
 In order to use S/MIME encryption on a mobile device this must be
 checked. The S/MIME feature must also be enabled in the COS Features page.
 
-|*Require device to send signed messages* |
+|Require device to send signed messages |
 Device must send signed S/MIME messages. Not enabled by default.
 
-|*Require S/MIME algorithm for signing* |
+|Require S/MIME algorithm for signing |
 
 Algorithm must be used when signing a message. Not enabled by default.
 
-|*Require device to send encrypted messages* |
+|Require device to send encrypted messages |
 Specifies whether S/MIME messages must be encrypted. Not enabled by
 default.
 
-|*Require S/MIME algorithm for encrypting* |
+|Require S/MIME algorithm for encrypting |
 A required algorithm must be used when signing a message. Not enabled by
 default.
 
-|*Algorithm negotiation* |
+|Algorithm negotiation |
 How a messaging application on the device can negotiate the encryption
 algorithm if a recipient's certificate does not support the specified
 encryption algorithm. Select from *Block Negotiation*; *Strong* *Algorithm
 Only*, or *Allow Any Algorithm*. Default is Allow Any Algorithm.
 
-|*Allow S/MIME software certificates* |
+|Allow S/MIME software certificates |
 Allow S/MIME software certificates. Default is to allow.
 
-2+|*Sync Settings*
+2+^|*Sync Settings*
 
-|*Past calendar items sync'd* |
+|Past calendar items sync'd |
 Maximum range of calendar days that can be synchronized to the device.
 Default is two weeks.
 
-|*Past email items sync'd* |
+|Past email items sync'd |
 Maximum number of days of email items to synchronize to the device. Default
 is 3 days.
 
-|*Limit plain text message size (KB)* |
+|Limit plain text message size (KB) |
 Maximum size at which email messages are truncated when synchronized to the
 device. Default is to not set a maximum size.
 
-|*Allow direct push while roaming* |
+|Allow direct push while roaming |
 Mobile device must synchronize manually while roaming. Default is not to.
 
-|*Allow HTML formatted messages* |
+|Allow HTML formatted messages |
 Enables HTML email on the device. If this is disabled, all email is
 converted to plain text before synchronization occurs. Default is to enable
 HTML formatting.
 
-|*Limit HTML message size (KB)* |
+|Limit HTML message size (KB) |
 Maximum size at which HTML-formatted email messages are synchronized to the
 devices. The value is specified in KB. Default is to not set a maximum
 size.
 
-2+|*Device Settings*
+2+^|*Device Settings*
 
-|*Allow removable storage* |
+|Allow removable storage |
 Mobile device can access information stored on a storage card. Default is
 TRUE.
 
-|*Allow camera* |
+|Allow camera |
 Specifies that the camera on the device can be used.  Default is TRUE.
 
-|*Allow Wi-Fi* |
+|Allow Wi-Fi |
 Specifies that wireless Internet access is allowed on the device.  Default
 is TRUE.
 
-|*Allow Infrared* |
+|Allow Infrared |
 Specifies that an infrared connection is allowed on the device. Default is
 TRUE.
 
-|*Allow sharing* |
+|Allow sharing |
 Specifies that the mobile device can be used as a modem to connect a
 computer to the Internet. Default is TRUE.
 
-|*Allow remote desktop* |
+|Allow remote desktop |
 Specifies that the mobile device can initiate a remote desktop
 connection. Default is TRUE.
 
-|*Allow desktop sync* |
+|Allow desktop sync |
 Specifies that the mobile device can synchronize with a desktop computer
 through a cable. Default is TRUE.
 
-|*Allow bluetooth* |
+|Allow bluetooth |
 By default Bluetooth capabilities are allowed on the device. Select from
 *Allow*, *Disable*, *Hands-Free Only*.
 
-2+|*Device Applications*
+2+^|*Device Applications*
 
-|*Allow browser* |
+|Allow browser |
 Microsoft® Pocket Internet Explorer is allowed on the mobile device by
 default. This does not affect third-party browsers.
 
-|*Allow consumer mail* |
+|Allow consumer mail |
 Users can configure a personal email account on the mobile device. This
 parameter does not control access to emails using third-party mobile device
 email programs.
 
-|*Allow POP or IMAP mail* |
+|Allow POP or IMAP mail |
 Users can configure a POP3 or IMAP4 email account on the device. This
 parameter doe not control access by third-party email programs.
 
-|*Allow text messaging* |
+|Allow text messaging |
 Allow users to use text messaging on the device.
 
-|*Allow unsigned applications* |
+|Allow unsigned applications |
 Allows unsigned applications to be used on the device.
 
-|*Allow unsigned install packages* |
+|Allow unsigned install packages |
 Allows unsigned installation packages on the device.
 
-2+|*Approved Application Lists*
+2+^|*Approved Application Lists*
 
-|*Approved Applications* |
+|Approved Applications |
 This setting stores a list of approved applications that can be run on the
 mobile device.
 
-|*Blocked Applications* |
+|Blocked Applications |
 This setting specifies a list of applications that cannot be run.
 
 |=======================================================================
@@ -370,37 +359,38 @@ Mobile sync is enabled either in the COS profiles for the account or on
 individual accounts. In most cases, no additional plug-ins are required.
 
 Users might need to configure the following on their in the mobile device
-to sync to their Zimbra account if they don’t have auto discover.
+to sync to their Zimbra account if they don't have auto discover.
 
-* *Server name (address)*. Enter the fully qualified host name of the
-user’s{product-name} mailbox server.
+* *Server name (address)* -- Enter the fully qualified host name of the
+user's{product-name} mailbox server.
 
-* *User name*. Enter the user’s primary {product-name} account name.
+* *User name* -- Enter the user's primary {product-name} account name.
 
-* *Domain*. Enter the user’s {product-name} domain name (DNS).
+* *Domain* -- Enter the user's {product-name} domain name (DNS).
 
-* *SSL certificate* from the server might have to be added to the device
-astrusted if SSL is used when the certification is self-signed.
+* *SSL certificate* -- the server might have to be added to the device
+as trusted if TLS is used when the certification is self-signed.
 
 Users can sync their {product-abbrev} account to their mobile device. They
 can send email, create appointments, and add contacts to their address
 book.
 
 For details about specific device setup, see the Mobile Device Setup pages
-on the Zimbra Wiki.
+on the https://wiki.zimbra.com[Zimbra Wiki].
 
 === Change Mobile Device Password Policy
 
 If a mobile device is locked by the {product-name} mobile password
 policy, the PIN requirement must be removed to resync the device.
 
-.Admin Console
-****
-Open the user account to be modified.
+Admin Console: ::
+*Home > Manage > Accounts -> _account_ -> Mobile Access*
 
-.  On the *Mobile Access* page, uncheck *Force pin on device*.
+. Open the user account to be modified.
 
-.  After the password policy has been disabled, the user must resync
+. On the *Mobile Access* page, uncheck *Force pin on device*.
+
+. After the password policy has been disabled, the user must resync
 the device:
 +
 * If the device is a WM6 device, the user syncs to the account. After the
@@ -411,8 +401,6 @@ device and *turn off the device PIN.*
 the account. After the sync, instruct the user to go to the
 *Settings > General* properties and *turn off Passcode Lock*.
 
-****
-
 [NOTE]
 If the iPhone/iPod Touch is prior to 3.0, there is an Apple software bug
 that prevents downloading new device policies to take effect. The user must
@@ -420,7 +408,7 @@ delete the {product-name} account from the iPhone/iPod Touch, turn
 the PIN off, and then re-setup sync with the {product-name}. Because
 the password requirement was turned off, a PIN is not asked for.
 
-== User’s Mobile Device Self-Care Features
+== User's Mobile Device Self-Care Features
 
 Users can directly manage the following device functions.
 

--- a/monitoring.adoc
+++ b/monitoring.adoc
@@ -43,51 +43,41 @@ did not configure this when you installed {product-name}, do so now.
 === Enabling Server Statistics
 
 Enable server statistics to show both system- wide and server specific data
-about the inbound message volume, inbound message count, anti-spam/
-antivirus activity and disk usage for messages processed in the last 48
+about the inbound message volume, inbound message count, anti-spam/anti-virus
+activity and disk usage for messages processed in the last 48
 hours, 30 days, 60 days, and the last year.
 
 . On each server, as root, type `/opt/zimbra/libexec/zmsyslogsetup`.  This
-enables the server to display statistics.
+updates the syslog configuration to enable gathering server statistics.
 
-. On the logger monitor host, you must enable *syslog* to log
-statistics from remote machines.
-
-. Edit the /etc/sysconfig/syslog file, add `-r` to the SYSLOGD_OPTIONS
-setting, `SYSLOGD_options="-r -m 0"`
-
-. Stop the syslog daemon.  Type `/etc/init.d/syslogd stop`.
-
-. Start the syslog daemon.  Type `/etc/init.d/syslogd start`.
+. On the logger monitor host, you must configure *syslog* to accept
+syslog messages from remote machines.
+See https://wiki.zimbra.com/wiki/Configuring-Logger-Host for details.
 
 [NOTE]
 These steps are not necessary for a single-node installation.
 
 === Reviewing Server Status
 
-.Admin Console
-****
+Admin Console: ::
+*Home > Monitor*
 
-The *Monitor > Server Status* page lists all servers and services, their
-status,and when the server status was last checked.  The servers include
+The *Server Status* page lists all servers and services, their
+status, and when the server status was last checked.  The servers include
 the MTA, LDAP, and mailbox server.  The services include MTA, LDAP,
 Mailbox, SNMP, Anti-Spam, Anti-Virus, Spell checker, and Logger.
 
-****
-
 To start a server if it is not running, use the `zmcontrol` CLI command.  You
-can stop and start services from the Administration Console,
+can stop and start services from the Administration Console.
 
 === Enabling or Disabling Server Services
 
-.Admin Console
-****
+Admin Console: ::
+*Home > Configure > Servers -> _server_*
 
-Server services are enabled or disabled from the *Configure > Servers*
+Server services are enabled or disabled from the *Servers -> _server_*
 page.  Select *Services* in the Navigation pane and select to enable or
 disable services.
-
-****
 
 === Viewing Server Performance Statistics
 
@@ -104,17 +94,17 @@ mailbox quota details.
 
 The following display system-wide information:
 
-* *Message Count* - counts message transactions.  A transaction is defined
-aseither the SMTP receipt of a message per person (by Postfix) or a LMTP
+* *Message Count* -- counts message transactions.  A transaction is defined
+as either the SMTP receipt of a message per person (by Postfix) or a LMTP
 delivery of it (by mailboxd) per person.  For example, if a message is sent
 to three people, six transactions are displayed.  Three for SMTP to Postfix
 and three for LMTP to mailboxd.  The message count is increased by six.
 
-* *Message Volume* - displays the aggregate size in bytes of transactions
+* *Message Volume* -- displays the aggregate size in bytes of transactions
 sentand received per hour and per day.  Graphs show the total inbound data
 by volume in bytes.
 
-* *Anti-Spam/Anti-Virus Activity* - displays the number of messages that
+* *Anti-Spam/Anti-Virus Activity* -- displays the number of messages that
 werechecked for spam or viruses and the number of messages that were tagged
 as spam or deemed to contain a virus.  The AS/AV count is increased by one
 per message scanned.  One message sent to three people counts as only one
@@ -132,26 +122,23 @@ the number of recipients who received messages.
 
 Server-specific statistics also include the following details:
 
-* *Disk* - for a selected server displays the disk used and the disk
+* *Disk* -- for a selected server displays the disk used and the disk
 spaceavailable.  The information is displayed for the last hour, day,
 month, and year.
 
-* *Session* - displays information about the active Web client,
+* *Session* -- displays information about the active Web client,
 administratorand IMAP sessions.  You can see how many active sessions are
 opened, who is logged on, when the session was created and the last time
 the session was accessed.
 
-* *Mailbox Quota* - displays information about each account sorted
+* *Mailbox Quota* -- displays information about each account sorted
 bymailbox size in descending order.  See
 <<monitoring_mailbox_quotas,Monitoring Mailbox Quotas>>.
 
 === Configuring Logger Mail Reports
 
-The Logger generates a report about mail activity daily at 11:30 p.m.  and
-sends it to the administrator’s email address.
-
-.CLI
-****
+The Logger generates a report about mail activity daily at 11:30 p.m. and
+sends it to the administrator's email address.
 
 You can configure the number of accounts to include in the report.  The
 default is 25 sender and 25 recipient accounts.
@@ -169,7 +156,6 @@ zmlocalconfig -e zimbra_mtareport_max_recipients=<number>
 ----
 zmlocalconfig -e zimbra_mtareport_max_senders=<number>
 ----
-****
 
 == Configuring Disk Space Notifications
 
@@ -179,9 +165,7 @@ email notification is sent to the administrator account when disk space is
 low.  The default is to send a warning alert when the threshold reaches 85%
 and a critical alert when the threshold reaches 95%.
 
-.CLI
-****
-You can change these values.  Use zmlocalconfig to configure the
+You can change these values.  Use `zmlocalconfig` to configure the
 disk warning thresholds.
 
 * Warning alerts
@@ -201,57 +185,56 @@ zmdisklog_critical_threshold
 When starting services with zmcontrol, if the threshold is exceeded, a
 warning is displayed before the services are started.  You should clean up
 your disk to free up space.
-****
 
 == Monitoring Servers
 
-The {product-name} server collects many performance-related
+The {product-name} server collects many performance related
 statistics that can help you diagnose problems and load issues.
 
-.Admin Console
-****
-The *Monitor > Advanced Statistics* page includes advanced graphing
-optionsthat lets you generate various charts based on statistical
-information for the CPU, IO, mailboxd, MTA queue, MySQL and other
+Admin Console: ::
+*Home > Monitor > Advanced Statistics*
+
+The *Advanced Statistics* page includes advanced graphing
+options that lets you generate various charts based on statistical
+information for the CPU, IO, mailboxd, MTA queue, MariaDB and other
 components.
 
 To chart the graphics in Advanced Statistics, select one of these groups
 and then select from the list of specific counters for the type of
 information to display.
-****
 
 The information covers a wide array of data:
 
-* *cpu.csv*: CPU utilization.  This group contains counters to keep track
+* *cpu.csv* -- CPU utilization.  This group contains counters to keep track
 ofCPU usage (iowait, idle, system, user, time etc.).  CPU information can
 be tracked both at the server level and the process level.
 
-* *df.csv:* Captures disk usage.  Disk utilization is tracked for each
+* *df.csv* -- Captures disk usage.  Disk utilization is tracked for each
 diskpartition.
 
-* *fd.csv*: file descriptor count.  Keeps track of system file descriptor
+* *fd.csv* -- file descriptor count.  Keeps track of system file descriptor
 usageover time.  This is primarily used to track down "out-of-file
 descriptor" errors.
 
-* *mailboxd.csv*: {product-name} server and JVM statistics.
+* *mailboxd.csv* -- {product-name} server and JVM statistics.
 Mailboxdstores almost all of its statistics here.  Interesting numbers to
 keep track of are heap_used, heap_free, imap_conn, soap_sessions,
 pop_conn, db_conn_count.
 
-* *mtaqueue.csv*: Postfix queue.  This measures the mail queue size
+* *mtaqueue.csv* -- Postfix queue.  This measures the mail queue size
 innumber of messages and the size in bytes.
 
-* *proc.csv*: Process statistics for Zimbra processes.  For example
-mailboxd/java, MySQL, OpenLDAP, etc.)
+* *proc.csv* -- Process statistics for Zimbra processes.  For example
+mailboxd/java, MariaDB, OpenLDAP, etc.)
 
-* *soap.csv*: SOAP request processing time.
+* *soap.csv* -- SOAP request processing time.
 
-* *threads.csv*: JVM thread counts.  Counts the number of threads with
+* *threads.csv* -- JVM thread counts.  Counts the number of threads with
 acommon name prefix.
 
-* *vm.csv*: Linux VM statistics (from the vmstat command).
+* *vm.csv* -- Linux VM statistics (from the vmstat command).
 
-* *io-x.csv* and *io.csv* store data from the `iostat(1)` command (io-x.csv
+* *io-x.csv* and *io.csv* -- store data from the `iostat(1)` command (`io-x.csv`
 with `iostat -x`).
 
 == Configuring Denial of Service Filter Parameters
@@ -275,18 +258,22 @@ to see if the DoSFilter was applied.
 
 .`sync.log` entry showing the DoSFilter
 ====
-
+[source,subs="quotes"]
+----
 2013-01-15 15:52:20,426 WARN [qtp1635701107-91:https://x.x.x.x/
-Microsoft-Server-ActiveSync?User=zsupport2&DeviceId=Appl5ddddd3NR&DeviceType=iPhone&Cmd=FolderSync][name=zsupport2@domain.com;mid=64;ip=71.194.89.54;Cmd=FolderSync;DeviceID=Appl5K0113UN3NR;Version=12.1;] sync - *Service exception com.zimbra.common.service.ServiceException: error while proxying request to target server: HTTP/1.1 503 Service Unavailable*
-ExceptionId:qtp1635701107-91:https://10.10.0.54:443/Microsoft-Server-ActiveSync?User=zsupport2&DeviceId=Appl5K0113UN3NR&DeviceType=iPhone&Cmd=FolderSync:1358286740426:c5ca7f36bb0a038f Code:service.PROXY_ERROR Arg:(url, STR,"http://mail.domain.com:80/ service/soap/SyncRequest"
-
+Microsoft-Server-ActiveSync?User=zsupport2&DeviceId=Appl5ddddd3NR&DeviceType=iPhone&Cmd=FolderSync][name=zsupport2@domain.com;mid=64;ip=10.1.2.3;Cmd=FolderSync;DeviceID=Appl5K0113UN3NR;Version=12.1;] sync - *Service exception com.zimbra.common.service.ServiceException: error while proxying request to target server: HTTP/1.1 503 Service Unavailable*
+ExceptionId:qtp1635701107-91:https://10.10.0.54:443/Microsoft-Server-ActiveSync?User=zsupport2&DeviceId=Appl5K0113UN3NR&DeviceType=iPhone&Cmd=FolderSync:1358286740426:c5ca7f36bb0a038f Code:service.PROXY_ERROR Arg:(url, STR,"http://mail.domain.com:80/service/soap/SyncRequest"
+----
 ====
 
 * `/opt/zimbra/log/zmmailboxd.out`
 
 .`zmmailboxd.out` entry showing the DoSFilter
 ====
+[source,subs="quotes"]
+----
 2013-01-15 15:57:32.537:WARN:oejs.*DoSFilter:DOS ALERT*:ip=127.0.1.1,session=null,user=null
+----
 ====
 
 === Customizing DoSFilter Configuration
@@ -299,7 +286,7 @@ override the global settings.
 You can modify these settings, but the default configuration is
 recommended.
 
-[cols=",a",options="header",]
+[cols="2,3a",options="header",]
 |=======================================================================
 |Attribute |Description
 
@@ -315,7 +302,7 @@ considered.  The default is -1.
 
 [source,bash]
 ----
-zmprov mcf zimbraHttpDosFilterDelayMillis [x]
+zmprov mcf zimbraHttpDosFilterDelayMillis {x}
 ----
 
 |*DoSFilter Maximum Requests Per Second* +
@@ -326,11 +313,11 @@ excess of this are throttled.  The default is 30 and the minimum is 1.
 
 [source,bash]
 ----
-zmprov mcf zimbraHttpDosFilterMaxRequestsPerSec [X]
+zmprov mcf zimbraHttpDosFilterMaxRequestsPerSec {x}
 ----
 
 |*DoSFilter IP Addresses Whitelist* +
-`zmprov mcf zimbraHttpThrottleSafeIPs [x.x.x.x,192.168.x.x]` |
+`zmprov mcf zimbraHttpThrottleSafeIPs {x.x.x.x,192.168.x.x}` |
 
 IP addresses to ignore when applying the DosFilter.  This attribute does
 not have a default value, however the following loopback IPs are
@@ -343,7 +330,7 @@ The IP addresses should be comma separated.
 
 [source,bash]
 ----
-zmprov mcf zimbraHttpThrottleSafeIPs [addresses]
+zmprov mcf zimbraHttpThrottleSafeIPs {addresses}
 ----
 
 |=======================================================================
@@ -359,19 +346,14 @@ zmmailboxdctl restart
 
 === Tuning Considerations for {product-abbrev} 8.0.3 and later
 
-* *{product-abbrev} Member Servers*: {product-abbrev} servers under the control of a single
+* *{product-abbrev} Member Servers* -- {product-abbrev} servers under the control of a single
 masterLDAP server are automatically whitelisted by IP address.  These hosts
 are discovered using a *GetAllServersRequest*.  Type as `zmprov gas`.
 
-* *External Provisioning Hosts/SOAP API*: External provisioning hosts can
+* *External Provisioning Hosts/SOAP API* -- External provisioning hosts can
 beadded to the IP whitelist to ensure that the DoSFilter does not block
 some requests.  For example, a mailbox reindex might make several calls per
 second that can trigger the DoSFilter.
-
-[NOTE]
-For {product-abbrev} servers at 8.0.0 to 8.0.2, see the Denial of Service workaround
-located at
-http://www.zimbra.com/forums/announcements/60397-zcs-dosfilter-workaround-zcs-8-0-1-8-0-2-a.html.
 
 == Working with Mail Queues
 
@@ -403,12 +385,12 @@ The *corrupt* queue stores damaged unreadable messages.
 
 === Change the Bounce Queue Lifetime
 
-* The MTA server’s bounce queue lifetime is set for five days.  To change
+* The MTA server's bounce queue lifetime is set for five days.  To change
 the default queue lifetime setting
 +
 [source,bash]
 ----
-zmlocalconfig -e bounce_queue_lifetime=[#]
+zmlocalconfig -e bounce_queue_lifetime={#}
 ----
 
 * To permanently have messages bounced back to the sender, instead of being
@@ -459,8 +441,11 @@ Administration Console.
 
 === Viewing Mail Queues
 
+Admin Console: ::
+*Home > Monitor > Mail Queues*
+
 If you are having problems with mail delivery, you can view the mail queues
-from the Administration Console - *Monitor > Mail Queues* page - to see if
+from the *Mail Queues* page in the Administration Console to see if
 you can fix the mail delivery problem.  When you open mail queues, the
 content of the deferred, incoming, active, hold, and corrupt queues at that
 point in time can be viewed.  You can view the number of messages and where
@@ -506,22 +491,22 @@ Deferred, Incoming and Active queues.
 == Monitoring Mailbox Quotas
 
 Mailbox quotas apply to email messages, attachments, calendar appointments,
-and tasks in a user’s account.  When an account quota is reached, all mail
+and tasks in a user's account.  When an account quota is reached, all mail
 messages are rejected.  Users must delete mail from their account to get
 below their quota limit - this includes emptying their Trash, or you can
 increase their quota.
 
 === Viewing Quota
 
-You can check mailbox quotas for individual accounts from Server Statistics
+You can check mailbox quotas for individual accounts from *Server Statistics*
 on the Administration Console.  Mailbox Quota gives you an instant view of
 the Mailbox Size and Quota Used information for each account.
 
-.Admin Console
-****
-*Monitor > Server Statistics* page.
+Admin Console: ::
+*Home > Monitor > Server Statistics*
 
-. Select the server for which you want to view statistics.
+// begin list
+. Select the *_server_* for which you want to view statistics.
 
 . In the Navigation pane, select *Mailbox Quota*.  The Mailbox Quota page
 displays with the following information:
@@ -529,7 +514,6 @@ displays with the following information:
 are configured either in the COS or by account.
 * Mailbox Size column shows the disk space used.
 * Quota Used column shows what percentage of quota is used.
-****
 
 === Increase or Decrease Quota
 
@@ -537,14 +521,14 @@ From a COS or Account, you can configure a quota threshold that, when
 reached, sends a message alerting users that they are about to reach their
 mailbox quota.
 
-.Admin Console
-****
-*Configure > Class of Service > Advanced* page.
+Admin Console: ::
+*Home > Configure > Class of Service -> _COS_ -> Advanced* +
+*Home > Manage > Accounts -> _account_ -> Advanced*
 
+// list
 . Scroll down to the Quota section.
 . Modify the quota settings.
 . Click *Save*.
-****
 
 == Viewing MobileSync Statistics
 
@@ -558,24 +542,24 @@ To protect against dictionary-based and distributed attacks, you can
 configure the `zmauditwatch`.  The script attempts to detect more advanced
 attacks by looking at where the authentication failures are coming from and
 how frequently they are happening for all accounts on a Zimbra mailbox
-server and sends an email alert to the administrator’s mailbox.
+server and sends an email alert to the administrator's mailbox.
 
 The types of authentication failures checked include:
 
-* *IP/Account hash check*.  The default is to send an email alert if
+* *IP/Account hash check* -- The default is to send an email alert if
 10authenticating failures from an IP/account combination occur within a 60
 second window.
 
-* *Account check*.  The default is to send an email alert if 15
+* *Account check* -- The default is to send an email alert if 15
 authenticationfailures from any IP address occur within a 60 second window.
 This check attempts to detect a distributed hijack based attack on a single
 account.
 
-* *IP check*.  The default is to send an email alert if 20 authentication
+* *IP check* -- The default is to send an email alert if 20 authentication
 failuresto any account occur within a 60 second window.  This check
 attempts to detect a single host based attack across multiple accounts.
 
-* *Total authentication failure check*.  The default is to send an email
+* *Total authentication failure check* -- The default is to send an email
 alert if1000 auth failures from any IP address to any account occurs within
 60 seconds.  The default should be modified to be 1% of the active accounts
 on the mailbox server.
@@ -602,47 +586,47 @@ are used for analysis and troubleshooting.
 Local logs containing Zimbra activity are in the `/opt/zimbra/log`
 directory.
 
-* *audit.log*.  This log contains authentication activity of users
+* *audit.log* -- This log contains authentication activity of users
 andadministrators and login failures.  In addition, it logs admin activity
 to be able to track configuration changes.
 
-* *clamd.log*.  This log contains activity from the antivirus application
+* *clamd.log* -- This log contains activity from the anti-virus application
 clamd.
 
-* *freshclam.log*.  This log contains log information related to the
+* *freshclam.log* -- This log contains log information related to the
 updating ofthe clamd virus definitions.
 
-* *mailbox.log*.  This log is a mailboxd log4j server log containing the
+* *mailbox.log* -- This log is a mailboxd log4j server log containing the
 logs from the mailbox server.  This includes the mailbox store, LMTP
 server, IMAP and POP servers, and Index server.
 
-* *myslow.log*.  This slow query log consists of all SQL statements from
+* *myslow.log* -- This slow query log consists of all SQL statements from
 themailbox server that took more then `long_query_time` seconds to execute.
 +
 [NOTE]
 `long_query_time` is defined in `/opt/zimbra/conf/my.cnf`.
 
-* *spamtrain.log*.  This log contains output from `zmtrainsa` during
+* *spamtrain.log* -- This log contains output from `zmtrainsa` during
 regularly scheduled executions from the cron.
 
-* *sync.log*.  This log contains information about {product-name}
+* *sync.log* -- This log contains information about {product-name}
 mobilesync operations.
 
 Other logs include:
 
-* */opt/zimbra/jetty/logs/*.  This is where Jetty-specific activity is
+* */opt/zimbra/jetty/logs/* -- This is where Jetty-specific activity is
 logged.
 
-* */opt/zimbra/db/data*.  `<hostname>.err`.  This is the message store
+* */opt/zimbra/db/data/<hostname>.err* -- This is the message store
 database error log.
 
-* */opt/zimbra/logger/db/data.* `<hostname>.err`.  This is the Logger
+* */opt/zimbra/logger/db/data/<hostname>.err* -- This is the Logger
 database error log.
 
 {product-name} activity logged to System syslog
 
-* */var/log/zimbra.log.* The Zimbra syslog details the activities of the
-ZimbraMTA (Postfix, amavisd, antispam, antivirus), Logger, Authentication
+* */var/log/zimbra.log* -- The Zimbra syslog details the activities of the
+ZimbraMTA (Postfix, amavisd, anti-spam, anti-virus), Logger, Authentication
 (cyrus-sasl), and Directory (OpenLDAP).  By default LDAP activity is logged
 to `zimbra.log`.
 
@@ -664,7 +648,7 @@ globally or by server:
 
 [source,bash]
 ----
-zmprov mcf zimbraLogToSysLog True
+zmprov mcf zimbraLogToSysLog TRUE
 ----
 
 === Using log4j to Configure Logging
@@ -673,7 +657,7 @@ The {product-name} server uses `log4j`, a Java logging package as the
 log manager.  By default, the {product-name} server has `log4j`
 configured to log to the local file system.  You can configure `log4j` to
 direct output to another location.  Go to the
-http://logging.apache.org/log4j/2.x/[Log4j website] for information about
+https://logging.apache.org/log4j/2.x/[Log4j website] for information about
 using `log4j`.
 
 {product-abbrev} does not check the log4j changes.  To remove all account loggers and
@@ -695,7 +679,7 @@ example, to see debug details for POP activity, you would type
 
 The following categories are predefined in `log4j`:
 
-[cols=",",options="",]
+[cols="2m,3",options="",]
 |====================================================
 |zimbra.account |Account operations
 |zimbra.acl |ACL operations
@@ -733,13 +717,13 @@ The following categories are predefined in `log4j`:
 Changes to the log level take affect immediately.
 
 .Logging Events
-[cols=",,,,",options="header",]
+[cols="1s,1,1,1,6",options="header",]
 |=======================================================================
 |Level |Local? |Syslog |SNMP Trap |When Used
 
 |FATAL |Y |Y |Y |
 Designates very severe error events that the application to abort or impact
-a large number of users.  For example, being unable to contact the MySQL
+a large number of users.  For example, being unable to contact the MariaDB
 database.
 
 |ERROR |Y |Y |N |
@@ -751,7 +735,7 @@ corrupt index or being unable to delete a message from a mailbox.
 Designates potentially harmful situations but are usually recoverable or
 can be ignored.  For example, user log in failed.
 
-|INFO* |Y |N |N* |
+|INFO |Y |N |N |
 Designates information messages that highlight the progress of the
 application, basic transaction-level logging.  For example, server
 start-ups, mailbox creation/deletion, account creation.
@@ -767,14 +751,15 @@ generate traps.
 === Protocol Trace
 
 Protocol trace is available in the following logging categories:
-
-* zimbra.smtp
-* zimbra.lmtp
-* zimbra.soap
-* zimbra.imap
-* zimbra.imap-client
-* zimbra.pop
-* zimbra.pop-client
+----
+zimbra.smtp
+zimbra.lmtp
+zimbra.soap
+zimbra.imap
+zimbra.imap-client
+zimbra.pop
+zimbra.pop-client
+----
 
 === Reviewing mailbox.log Records
 
@@ -795,7 +780,7 @@ messages for unrelated accounts.  See <<command_line_utilities,Command-Line
 Utilities>>, the `zmprov` miscellaneous section.
 
 *Reading records in the log* The example below is a record showing that
-onJune 25, 2007, the zimbra server with an IP address of 127.0.0.1 was in
+on June 25, 2007, the zimbra server with an IP address of 127.0.0.1 was in
 the process of deleting backups that were created on Monday, June 18, 2007
 at 8 seconds after midnight Pacific Daylight Time (PDT) or older than that
 date.
@@ -815,12 +800,14 @@ signals that some type of error was detected.
 
 .Handler Exception
 ====
-007-06-25 00:00:10,379 INFO [btpool0-1064] [name=nriers@example.com;
-mid=228;ip=72.255.38.207;ua=zimbra Desktop/0.38;] SoapEngine - *handler exception*
+[source,subs="quotes"]
+----
+007-06-25 00:00:10,379 INFO [btpool0-1064] [name=nriers@example.com;mid=228;ip=10.2.3.4;ua=zimbra Desktop/0.38;] SoapEngine - *handler exception*
+----
 ====
 
 Sometimes a stack trace is displayed after the exceptions notification.  A
-stack trace reports the threads and monitors in the zimbra’s *mailboxd*
+stack trace reports the threads and monitors in the zimbra's *mailboxd*
 service.  This information aids in debugging, because the trace shows where
 the error occurred.  The last few entries in the stack often indicate the
 origin of the problem.  When the *caused by* descriptor is included in the
@@ -829,41 +816,28 @@ was caused by 501, bad address syntax.
 
 .Stack Trace
 ====
-com.example.cs.mailbox.MailServiceException: *Invalid address*: Jon R at
-com.example.cs.mailbox.*MailServiceException.internal_SEND_FAILURE*
+[source,subs="quotes"]
+----
+com.example.cs.mailbox.MailServiceException: *Invalid address*: Jon R
+at com.example.cs.mailbox.*MailServiceException.internal_SEND_FAILURE* (MailServiceException.java:412)
+at com.example.cs.mailbox.*MailServiceException.SEND_ABORTED_ADDRESS_FAILURE* MailServiceException.java:416)
+...
+at org.mortbay.thread.BoundedThreadPool$PoolThread.run(BoundedThreadPool.java:442)
 
-(MailServiceException.java:412)
-
-at
-com.example.cs.mailbox.*MailServiceException.SEND_ABORTED_ADDRESS_FAILURE*
-MailServiceException.java:416) +
-. +
-. +
-. +
-at org.mortbay.thread.BoundedThreadPool$PoolThread.run(BoundedThread
-Pool.java:442)
-
-*Caused by* :
-com.example.cs.mailbox.MailSender$SafeSendFailedException:501 Bad
-address syntax
-
-; chained exception is: com.sun.mail.smtp.SMTPAddressFailedException:
-501 Bad address syntax at
-com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:1196) at
-com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:584) at
-javax.mail.Transport.send0(Transport.java:169)
-
-at javax.mail.Transport.send(Transport.java:98) at
-
-com.example.cs.mailbox.MailSender.sendMessage(MailSender.java:409) at
-com.example.cs.mailbox.MailSender.sendMimeMessage(MailSender.java:26 2)
-
-&#8230;  30 more
+*Caused by*: com.example.cs.mailbox.MailSender$SafeSendFailedException: 501 Bad address syntax; chained exception is: com.sun.mail.smtp.SMTPAddressFailedException: 501 Bad address syntax
+at com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:1196)
+at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:584)
+at javax.mail.Transport.send0(Transport.java:169)
+at javax.mail.Transport.send(Transport.java:98)
+at com.example.cs.mailbox.MailSender.sendMessage(MailSender.java:409)
+at com.example.cs.mailbox.MailSender.sendMimeMessage(MailSender.java:262)
+... 30 more
+----
 ====
 
 ==== Mailbox log files
 
-The mailbox.log files rotate daily.  The mailbox log files are saved in
+The `mailbox.log` files rotate daily.  The mailbox log files are saved in
 `/opt/zimbra/log`.  Previous `mailbox.log` file names include the date the
 file was made.  The log without a date is the current log file.  You can
 back up and remove these files.
@@ -872,7 +846,6 @@ back up and remove these files.
 
 To review the `mailbox.log` for errors, search for the email address or the
 service that is experiencing the problem.  Also, search for WARN or ERROR
-
 log levels, read the text of the message.  When you find the error, review
 the records, tracing the events that happened before the problem was
 recorded.
@@ -885,15 +858,20 @@ out-of-memory error on June 17, 2007.
 
 .Startup message
 ====
+[source,subs="quotes"]
+----
 2007-06-25 01:56:18,725 INFO [main] [] soap - Servlet SoapServlet starting up
+----
 ====
 
 Look for errors before the startup message.
 
 .Error message
 ====
-2007-06-17 20:11:34,194 FATAL [btpool0-3335]
-[name=samd@example.com;aname=abcadmin@example.com;mid=142;ip=66.92.25.194;ua=zimbraConnectorForBES/5.0.207;] system - handler exception java.lang.OutOfMemoryError: PermGen space
+[source,subs="quotes"]
+----
+2007-06-17 20:11:34,194 FATAL [btpool0-3335] [name=samd@example.com;aname=abcadmin@example.com;mid=142;ip=10.3.4.5;ua=zimbraConnectorForBES/5.0.207;] system - handler exception java.lang.OutOfMemoryError: PermGen space
+----
 ====
 
 ==== Mail Delivery Problem
@@ -904,57 +882,54 @@ rejected as the address must be a fully-qualified address.
 
 .Mail delivery problem
 ====
+[source,subs="quotes"]
+----
 2007-06-25 10:47:43,008 INFO [*LmtpServer*-250]
-[name=bigen@example.com;mid=30;msgid=<1291804360.35481182793659172.J
-avaMail.root@dogfood.example.com>;] *lmtp - rejecting message*
-*bigen@example.com: exception occurred*
-
-com.zimbra.cs.mailbox.MailServiceException: redirect to too failed +
-at com.zimbra.cs.mailbox.MailServiceException.internal_SEND_FAILURE (MailServiceException.java:412) +
-at com.zimbra.cs.mailbox.MailServiceException.SEND_FAILURE(MailServiceException.java:424) +
-at com.zimbra.cs.filter.zimbraMailAdapter.executeActions(zimbraMailAdapter.java:286) +
-at org.apache.jsieve.SieveFactory.evaluate(SieveFactory.java:151) +
-at com.zimbra.cs.filter.RuleManager.applyRules(RuleManager.java:177) +
-at com.zimbra.cs.lmtpserver.zimbraLmtpBackend.deliverMessageToLocal Mailboxes(zimbraLmtpBackend.java:325) +
-at com.zimbra.cs.lmtpserver.zimbraLmtpBackend.deliver(zimbraLmtpBackend.java:140) +
-at com.zimbra.cs.lmtpserver.LmtpHandler.doDATA(LmtpHandler.java:441) +
-at com.zimbra.cs.lmtpserver.LmtpHandler.processCommand(LmtpHandler.java:205) +
-at com.zimbra.cs.tcpserver.ProtocolHandler.processConnection(ProtocolHandler.java:231) +
-at com.zimbra.cs.tcpserver.ProtocolHandler.run(ProtocolHandler.java:198) +
-at EDU.oswego.cs.dl.util.concurrent.PooledExecutor$Worker.run(Unknown Source) +
-at java.lang.Thread.run(Thread.java:619) +
+[name=bigen@example.com;mid=30;msgid=<1291804360.35481182793659172.JavaMail.root@example.com>;] *lmtp - rejecting message bigen@example.com: exception occurred*
+com.zimbra.cs.mailbox.MailServiceException: redirect to too failed
+at com.zimbra.cs.mailbox.MailServiceException.internal_SEND_FAILURE (MailServiceException.java:412)
+at com.zimbra.cs.mailbox.MailServiceException.SEND_FAILURE(MailServiceException.java:424)
+at com.zimbra.cs.filter.zimbraMailAdapter.executeActions(zimbraMailAdapter.java:286)
+at org.apache.jsieve.SieveFactory.evaluate(SieveFactory.java:151)
+at com.zimbra.cs.filter.RuleManager.applyRules(RuleManager.java:177)
+at com.zimbra.cs.lmtpserver.zimbraLmtpBackend.deliverMessageToLocalMailboxes(zimbraLmtpBackend.java:325)
+at com.zimbra.cs.lmtpserver.zimbraLmtpBackend.deliver(zimbraLmtpBackend.java:140)
+at com.zimbra.cs.lmtpserver.LmtpHandler.doDATA(LmtpHandler.java:441)
+at com.zimbra.cs.lmtpserver.LmtpHandler.processCommand(LmtpHandler.java:205)
+at com.zimbra.cs.tcpserver.ProtocolHandler.processConnection(ProtocolHandler.java:231)
+at com.zimbra.cs.tcpserver.ProtocolHandler.run(ProtocolHandler.java:198)
+at EDU.oswego.cs.dl.util.concurrent.PooledExecutor$Worker.run(Unknown Source)
+at java.lang.Thread.run(Thread.java:619)
 
 *Caused by:*
-com.zimbra.cs.mailbox.MailSender$SafeSendFailedException:504 <too>: +
-Recipient address rejected: need fully-qualified address ; +
-chained exception is: com.sun.mail.smtp.SMTPAddressFailedException: 504 <too>: +
-Recipient address rejected: need fully-qualified address
-
-at com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:1196) +
-at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:584) +
-at javax.mail.Transport.send0(Transport.java:169) +
-at javax.mail.Transport.send(Transport.java:120) +
-at com.zimbra.cs.filter.zimbraMailAdapter.executeActions(zimbraMailAdapter.java:281) +
-
-&#8230; 10 more
+com.zimbra.cs.mailbox.MailSender$SafeSendFailedException: 504 <too>: Recipient address rejected: need fully-qualified address ;
+chained exception is: com.sun.mail.smtp.SMTPAddressFailedException: 504 <too>: Recipient address rejected: need fully-qualified address
+at com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:1196)
+at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:584)
+at javax.mail.Transport.send0(Transport.java:169)
+at javax.mail.Transport.send(Transport.java:120)
+at com.zimbra.cs.filter.zimbraMailAdapter.executeActions(zimbraMailAdapter.java:281)
+... 10 more
+----
 ====
 
 ==== Account Error - Login error
 
 `mailbox.log` logs any successful or unsuccessful login attempts from IMAP,
 POP3 or ZWC.  When you are looking for a login error, start by looking for
-"Auth."  This example shows that someone from IP address 10.10.131.10 was
+"Auth."  This example shows that someone from IP address 10.4.5.6 was
 trying to log in as admin on the Zimbra Web Client, using Firefox in a
 Windows OS.  Permission was denied because it was not an admin account.
 
 .Account Error - Login error
 ====
-2007-06-25 09:16:11,483 INFO [btpool0-251]
-[ip=10.10.131.10;ua=zimbraWebClient - FFX.X (Win);] SoapEngine - *handler exception*
-
-com.zimbra.common.service.ServiceException: permission denied: not an admin account +
-at com.zimbra.common.service.ServiceException.PERM_DENIED(ServiceException.java:205) +
+[source,subs="quotes"]
+----
+2007-06-25 09:16:11,483 INFO [btpool0-251] [ip=10.4.5.6;ua=zimbraWebClient - FFX.X (Win);] SoapEngine - *handler exception*
+com.zimbra.common.service.ServiceException: permission denied: not an admin account
+at com.zimbra.common.service.ServiceException.PERM_DENIED(ServiceException.java:205)
 at com.zimbra.cs.service.admin.*Auth*.handle(*Auth*.java:103)
+----
 ====
 
 ==== Account Errors - IMAP or POP related
@@ -965,15 +940,16 @@ occurred while trying to connect siress@example.com.
 
 .Account Error - IMAP error
 ====
-mailbox.log.2007-06-19:2007-06-19 15:33:56,832 FATAL [*ImapServer*-2444]
-[name=sires@example.com;ip=127.0.0.1;] system - Fatal error occurred
-while handling connection
+[source,subs="quotes"]
+----
+mailbox.log.2007-06-19:2007-06-19 15:33:56,832 FATAL [*ImapServer*-2444] [name=sires@example.com;ip=127.0.0.1;] system - Fatal error occurred while handling connection
+----
 ====
 
 == Reading a Message Header
 
 Each email message includes a header that shows the path of an email from
-its origin to destination.  This information is used to trace a message’s
+its origin to destination.  This information is used to trace a message's
 route when there is a problem with the message.  The Zimbra email message
 header can be viewed from the Zimbra Web Client Message view.  Right-click
 on a message and select *Show Original*.
@@ -981,20 +957,20 @@ on a message and select *Show Original*.
 
 The following lines are in the message header:
 
-* *Date* - The date and time the message was sent.  When you specify time,
+* *Date* -- The date and time the message was sent.  When you specify time,
 you can specify range by adding start and stop time to search for messages.
 
-* *From* - The name of the sender and the email address
+* *From* -- The name of the sender and the email address
 
-* *To* - The name of the recipient and the email address.  Indicates
+* *To* -- The name of the recipient and the email address.  Indicates
 primary recipients.
 
-* *Message-ID* - Unique number used for tracing mail routing
+* *Message-ID* -- Unique number used for tracing mail routing
 
-* *In-Reply-To* - Message ID of the message that is a reply to.  Used to
+* *In-Reply-To* -- Message ID of the message that is a reply to.  Used to
 linkrelated messages together.
 
-* *Received: from* - The name and IP address the message was sent from.The
+* *Received: from* -- The name and IP address the message was sent from. The
 header displays Received: from information from the MTA to the LMTP and
 from the local host.
 
@@ -1026,13 +1002,10 @@ messages that are not indexed, searches may not find all results.
 Run a sanity check on a specific mailbox index using the `zmprov
 verifyIndex` command.
 
-.CLI
-****
 [source,bash]
 ----
 zmprov verifyIndex <user@example.com>
 ----
-****
 
 If problems are detected, a failure status is returned and a repair can
 be performed on the index.
@@ -1041,13 +1014,10 @@ be performed on the index.
 
 Use the `reIndexMailbox` command to repair and reindex a corrupt index.
 
-.CLI
-****
 [source,bash]
 ----
 zmprov reIndexMailbox <user@example.com> start
 ----
-****
 
 This returns a status of _started_.
 
@@ -1081,8 +1051,8 @@ alert system.
 
 The MariaDB database is automatically checked weekly to verify the health
 of the database.  This check takes about an hour.  If any errors are found,
-a report is sent to the administrator’s account.  The report name that runs
-the MySQL check is *zmbintegrityreport,* and the crontab is automatically
+a report is sent to the administrator's account.  The report name that runs
+the MariaDB check is *zmbintegrityreport,* and the crontab is automatically
 configured to run this report once a week.
 
 [NOTE]
@@ -1097,7 +1067,7 @@ the frequency with which zmbintegrityreport is run.  See
 When {product-name} is installed, the {product-name} software update
 utility is automatically configured to check for the latest {product-name}
 version once a day and if there is an update, to send notification to the
-address that is configured in the Administration Console’s *Server
+address that is configured in the Administration Console's *Server
 Updates*.
 
 The dates and times {product-name} checked for updates is saved to the
@@ -1108,23 +1078,23 @@ available*.
 
 You can configure the following:
 
-* *Server that checks for updates*.  Available servers are listed and only
+* *Server that checks for updates* -- Available servers are listed and only
 one server is configured.  The selected server checks for updates and the
 result of the update response from www.zimbra.com is stored in LDAP.
 
-* *Check for updates every x*.  The default is to check once a day.  You
+* *Check for updates every x* -- The default is to check once a day.  You
 can change the frequency interval to check every x hours, minutes, or
 seconds.  A cron job is configured to check for new updates.  If the
 frequency interval is less than 2 hours, the crontab file must be modified.
 
-* *Updates URL*.  This address is the URL that the server connects to
+* *Updates URL* -- This address is the URL that the server connects to
 when checking for updates.  When a {product-name} server checks for
 updates, it transmits its version, platform, and build number to Zimbra.
 Normally, this URL is not changed.
 
 * To be notified of updates, check the *Send notification email when
 updates are available* and enter the send to and send from addresses.  The
-default address is the administrator’s address.
+default address is the administrator's address.
 
 * A generic email is created.  The subject and content of the email can be
 changed.
@@ -1140,13 +1110,14 @@ upload the newer ZCO msi file to the {product-abbrev} server from the Administra
 Console.  The file is uploaded to the
 `/opt/zimbra/jetty/webapps/zimbra/downloads` directory.
 
-. Download the new ZCO file to a computer that you can access from the
-Administration Console
-+
-[NOTE]
-*Tools and Migration > Client Upload*.
+Admin Console: ::
+*Home > Tools and Migration > Client Upload*
+
+. Download the new ZCO file to a computer that you can access from
+*Client Upload* in the Administration Console
 
 . Click *Browse* to locate the ZCO file to upload.
+
 . Restart {product-abbrev}:
 +
 [source,bash]
@@ -1163,7 +1134,7 @@ or run
 
 The `downloads/index.html` file is updated with the latest ZCO client
 version.  This new file can be downloaded from the ZCO link on the
-Administration Console *Tools and Migration > Download* page.
+Administration Console *Home > Tools and Migration > Download* page.
 
 [NOTE]
 If you do not restart the server, the ZCO download link on the Zimbra
@@ -1182,7 +1153,6 @@ Subject: Service <service_name> started on <zimbra_host>
 
 Service status change: <zimbra_host> <service> changed from stopped to running
 ----
-
 
 ==== Server Stop Notification Message
 ----
@@ -1232,8 +1202,7 @@ Subject: ZCS: SSL Certificates approaching expiration!
 The Administration Console and CLI Certificate Tools guide provides
 instructions on how to replace you self-signed or commercial certificate.
 
-http://wiki.zimbra.com/
-index.php?title=Administration_Console_and_CLI_Certificate_Tools SSL Certificate expiration checked with $0 on <zimbra_host>.
+https://wiki.zimbra.com/index.php?title=Administration_Console_and_CLI_Certificate_Tools SSL Certificate expiration checked with $0 on <zimbra_host>.
 ----
 
 === Daily report notification
@@ -1250,9 +1219,9 @@ Subject: Daily mail report for <day>
 
 === Database integrity check notification
 
-The MySQL database can be checked by running the zmdbintegrityreport
+The MariaDB database can be checked by running the zmdbintegrityreport
 automatically scheduled in the crontab to run on a weekly basis.  A report
-is sent to the administrator’s mailbox.
+is sent to the administrator's mailbox.
 
 ----
 Subject: Database Integrity check report for <zimbra_host>

--- a/mta.adoc
+++ b/mta.adoc
@@ -11,13 +11,13 @@ configuration to ensure the best results.
 
 The Zimbra MTA server includes the following programs:
 
-[cols="25,75",options="header",]
+[cols="1,3",options="header",]
 |=======================================================================
 |*MTA Server Programs* |*Purpose/Description*
 |Postfix MTA |
 Mail routing, mail relay, and attachment blocking
 
-|Clam AntiVirus |
+|Clam Anti-Virus |
 Scanning email messages and attachments in email messages for viruses
 
 |Spam Assassin |
@@ -81,13 +81,13 @@ filtering might be duplicated between an edge MTA and the Zimbra MTA.
 
 === Postfix Configuration Files
 
-Zimbra modified Postfix files—main.cf and master.cf—specifically to work
+Zimbra modified Postfix files -- main.cf and master.cf -- specifically to work
 with {product-abbrev}:
 
-* *main.cf.* Modified to include the LDAP tables. The `zmconfigd` in
+* *main.cf* -- Modified to include the LDAP tables. The `zmconfigd` in
 the Zimbra MTA pulls data from the Zimbra LDAP and modifies the Postfix
 configuration files.
-* *master.cf.* Modified to use Amavisd-New.
+* *master.cf* -- Modified to use Amavisd-New.
 
 [IMPORTANT]
 Changes made to postfix configuration files will be overwritten with every
@@ -143,22 +143,18 @@ location of the Postfix server in the Zimbra MTA package.
 To use the Administration Console to configure Relay MTA for external
 delivery:
 
-.Admin Console
-****
-*Home> Global Settings> MTA* page, *Network* container.
+Admin Console: ::
+*Home > Configure > Global Settings > MTA -> Network*
 
 [IMPORTANT]
-To prevent mail loops, use caution when setting the
-relay host.
+To prevent mail loops, use caution when setting the relay host.
 
 image::images/sending_non_local_mail_to_different_server.png[MTA Settings]
-
-****
 
 == Anti-Virus and Anti-Spam Protection
 
 The Amavisd-New utility is the interface between the Zimbra MTA and Clam
-AntiVirus (ClamAV) and SpamAssassin scanners.
+Anti-Virus (ClamAV) and SpamAssassin scanners.
 
 === Anti-Virus Protection
 
@@ -172,13 +168,10 @@ updates from ClamAV.
 
 You can change anti-virus settings at the Administration Console.
 
-.Admin Console
-****
-*Home> Configure> Global Settings> AS/AV* page, *Antivirus Settings* container.
+Admin Console: ::
+*Home > Configure > Global Settings > AS/AV -> Anti-virus Settings*
 
 image::images/anti_virus_protection.png[Anti-Virus Protection]
-
-****
 
 [NOTE]
 Updates are obtained via HTTP from the ClamAV website.
@@ -191,8 +184,6 @@ an email, it is scanned using ClamAV prior to sending the message. If
 ClamAV detects a virus, it will block attaching the file to the message.
 By default, scanning is configured for a single node installation.
 
-.CLI
-****
 To enable scanning, using a single node:
 
 [source, bash]
@@ -208,11 +199,10 @@ To enable scanning in a multi-node environment:
 +
 [source, bash]
 ----
-zmprov ms <mta server> zimbraClamAVBindAddress <mta server>
-zmprov mcfzimbraAttachmentsScanURL clam://<mta server>:3310/
+zmprov ms <mta_server> zimbraClamAVBindAddress <mta_server>
+zmprov mcf zimbraAttachmentsScanURL clam://<mta_server>:3310/
 zmprov mcf zimbraAttachmentsScanEnabled TRUE
 ----
-****
 
 === Anti-Spam Protection
 
@@ -222,19 +212,19 @@ database. You can also use the Postscreen function to provide additional
 protection against mail server overload. Both strategies are described
 in the following topics:
 
-* <<spam_assassin_methods, Spam Assassin Methods for Avoiding Spam>>
-* <<postscreen_methods, Postscreen Methods for Avoiding Spam>>
+* <<spam_assassin_methods,Spam Assassin Methods for Avoiding Spam>>
+* <<postscreen_methods,Postscreen Methods for Avoiding Spam>>
 
 [[spam_assassin_methods]]
 ==== Spam Assassin Methods for Avoiding Spam
 
 Usage guidelines are provided in the following topics:
 
-* <<spam_assassin_score, Managing the Spam Assassin Score>>
-* <<training_spam_filter, Training the Spam Filter>>
-* <<config_final_destination_spam, Configuring Final Destination for Spam>>
-* <<setting_up_trusted_netorks, Setting Up Trusted Networks>>
-* <<enabling_milter_server, Enabling a Milter Server>>
+* <<spam_assassin_score,Managing the Spam Assassin Score>>
+* <<training_spam_filter,Training the Spam Filter>>
+* <<config_final_destination_spam,Configuring Final Destination for Spam>>
+* <<setting_up_trusted_netorks,Setting Up Trusted Networks>>
+* <<enabling_milter_server,Enabling a Milter Server>>
 
 [NOTE]
 For information about how to customize SpamAssassin, see
@@ -245,35 +235,29 @@ https:// wiki.zimbra.com/wiki/Anti-spam_strategies.
 aswell as a Bayes database to score messages with a numerical range.
 Zimbra uses a percentage value to determine "`spaminess`" based on a
 SpamAssassin score of 20 as 100%. Any message tagged between 33%-75% is
-considered spam and delivered to the user’s junk folder. Messages tagged
+considered spam and delivered to the user's junk folder. Messages tagged
 above 75% are always considered spam and discarded.
 
 You can change the spam percentage settings, and the subject prefix at
 the Administration Console.
 
-.Admin Console
-****
-*Admin Console: Home> Configure> Global Settings> AS/AV* page, *Spam
-checking Settings* container.
+Admin Console: ::
+*Home > Configure > Global Settings > AS/AV -> Spam checking Settings*
 
 image::images/spam_assassin.png[Spam Assassin Settings]
 
 By default, Zimbra uses the Berkeley DB database for spam training. You
 can also use a MariaDB database.
-****
 
-.CLI
-****
 To use the MariaDB method on the MTA servers:
 [source, bash]
 ----
 zmlocalconfig -e antispam_mariadb_enabled=TRUE
 ----
 When this is enabled, Berkeley DB database is not enabled.
-****
 
 [[training_spam_filter]]
-*Training the Spam Filter:* The effectiveness of the anti-spam filter is
+*Training the Spam Filter* -- The effectiveness of the anti-spam filter is
 dependenton user input to differentiate spam or ham. The SpamAssassin
 filter learns from messages that users specifically mark as spam by
 sending them to their junk folder or not spam by removing them from
@@ -293,7 +277,6 @@ enable spam/ham training on another MTA, as one host should have this
 enabled to run `zmtrainsa --cleanup`.
 
 To set this on a new MTA server:
-
 [source, bash]
 ----
 zmlocalconfig -e zmtrainsa_cleanup_host=TRUE
@@ -310,13 +293,13 @@ get accurate scores. To determine whether to mark messages as spam at least
 200 known spams and 200 known hams must be identified.
 
 [[spamassassin_sa_update_tool]]
-SpamAssassin’s sa-update tool is included with SpamAssassin. This tool
+SpamAssassin's sa-update tool is included with SpamAssassin. This tool
 updates SpamAssassin rules from the SA organization. The tool is
 installed into `/opt/zimbra/common/bin`.
 
 [[config_final_destination_spam]]
-*Configuring Final Destination for Spam:* You can configure Amavis
-behavior tohandle a spam item’s final destination by using the following
+*Configuring Final Destination for Spam* -- You can configure Amavis
+behavior tohandle a spam item's final destination by using the following
 attribute:
 
 `zimbraAmavisFinalSpamDestiny`
@@ -324,8 +307,6 @@ attribute:
 The default is `D_DISCARD` (which will not deliver the email to the
 addressee).
 
-.CLI
-****
 Setting final spam destiny attributes:
 [source, bash]
 ----
@@ -333,30 +314,29 @@ zmprov mcf "zimbraAmavisFinalSpamDestiny" D_PASS
 zmprov ms serverhostname.com D_PASS
 ----
 
-Configurable attribute values are:
+.Configurable attribute values
+[cols="1m,3a",options="header",]
+|====
+|Value | Description
 
-`D_PASS`
-
+|D_PASS |
 Deliver the email to the recipient. The email is likely to be placed in
-the recipient’s junk folder (although some sites disable junk).
+the recipient's junk folder (although some sites disable junk).
 
-`D_BOUNCE`
-
+|D_BOUNCE |
 The email is bounced back to the sender. Because this setting can create
-backscatter—as the “sender” is not the person who actually sent the
-email—it is not advised.
+backscatter -- as the "sender" is not the person who actually sent the
+email -- it is not advised.
 
-`D_REJECT`
-
+|D_REJECT|
 Reject the email. This setting reduces the chance of backscatter:
 
 * If the sender is valid, the MTA will notify this person about the rejection.
 * If the sender is not valid, the associated MTA will discard the email (i.e. email that was sent by a spammer spoofing someone else).
 
-`D_DISCARD`
-
+|D_DISCARD |
 The email is silently discarded (not delivered).
-****
+|====
 
 [[setting_up_trusted_netorks]]
 *Setting Up Trusted Networks:* The {product-abbrev} configuration allows
@@ -368,31 +348,28 @@ setting. The server setting overrides the global setting.
 To use the Administration Console to set up MTA trusted networks as a
 global setting:
 
-.Admin Console
-****
-*Home> Configure> Global Settings> MTA* page, *Network* container.
+Admin Console: ::
+*Home > Configure > Global Settings > MTA -> Network*
 
 image::images/mta_network.png[MTA Trusted Networks]
 
 When using the Administration Console to set up MTA trusted networks on
 a per server basis, first ensure that MTA trusted networks have been set
 up as global settings.
-****
 
-.Admin Console
-****
-*Home> Configure> Servers>* <Edit> *MTA* page, *Network* container.
+Admin Console: ::
+*Home > Configure > Servers -> _server_ -> MTA -> Network*
 
 image::images/mta_network_2.png[MTA Trusted Networks]
 
-Enter the network addresses separated by commas and/or a space. Continue
+Enter the network addresses separated by _commas_ and/or a _space_. Continue
 long lines by starting the next line with space, similar to the
 following examples:
 
-* 127.0.0.0/8, 168.100.189.0/24
-* No commas: 127.0.0.0/8 168.100.189.0/24 10.0.0.0/8 [::1]/128 [fe80::%eth0]/64
-
-****
+----
+127.0.0.0/8, 168.100.189.0/24
+127.0.0.0/8 168.100.189.0/24 10.0.0.0/8 [::1]/128 [fe80::%eth0]/64
+----
 
 [[enabling_milter_server]]
 *Enabling a Milter Server:* Milter server can be enabled to enforce
@@ -407,28 +384,21 @@ Only enable a Milter Server on a server where an MTA is running.
 For global configuration, enable the milter server from the
 Administration Console:
 
-.Admin Console
-****
-*Home> Configure> Global Settings> MTA* page, *Milter Server* container.
+Admin Console: ::
+*Home > Configure > Global Settings > MTA -> Milter Server*
 
 image::images/mta_milter.png[MTA Milter Server]
 
 Use the Administration Console to enable a specific milter server, and
 to set bind addressing for individual servers.
-****
 
-.Admin Console
-****
-*Home> Configure> Servers>* <Edit> *MTA* page, *Milter Server* container.
+Admin Console: ::
+*Home > Configure > Servers -> _server_ -> MTA -> Milter Server*
 
 image::images/mta_milter_2.png[MTA Milter Server]
-****
 
 [[postscreen_methods]]
 ==== Postscreen Methods for Avoiding Spam
-
-[[about_postscreen]]
-*About Postscreen:*
 
 Zimbra Postscreen is the 8.7 enhancement to the {product-name}
 anti-spam strategy, to provide additional protection against mail server
@@ -455,11 +425,12 @@ clients that have passed a number of tests. When an SMTP client IP address
 is whitelisted, Postscreen immediately passes the connection to a Postfix
 SMTP server process. This minimizes the overhead for legitimate mail.
 
-In a typical scenario that uses Postscreen service, it is reasonable to
-expect potentially malicious email entities—such as bots and zombies—to be
-mixed in with friendly candidates in email loads. This concept is
-illustrated in the following diagram, in which undesirable entities are
-depicted in red; good email candidates are green.
+In a typical scenario that uses Postscreen service, it is reasonable
+to expect potentially malicious email entities -- such as bots and
+zombies -- to be mixed in with friendly candidates in email
+loads. This concept is illustrated in the following diagram, in which
+undesirable entities are depicted in red; good email candidates are
+green.
 
 image::images/postscreen.png[Postscreen]
 
@@ -471,10 +442,8 @@ Postscreen security, then allowed to talk directly with the SMTP daemon,
 which scans the Email (as usual) with the AS/AV. By default, all bots or
 zombies are rejected.
 
-.CLI
-****
 Use Zimbra CLI attributes to set parameters for Postscreen operations. For
-any <<postscreen_attributes, Postscreen Attributes>> that provide the
+any <<postscreen_attributes,Postscreen Attributes>> that provide the
 ignore, enforce, or drop instruction, use guidelines as follows:
 
 * _ignore_ -- Ignore this result. Allow other tests to complete. Repeat this
@@ -486,18 +455,17 @@ mailwith a 550 SMTP reply, and log the hello/sender/recipient
 information. Repeat this test with subsequent client connections.
 
 * _drop_ -- Drop the connection immediately with a 521 SMTP reply.
-Repeatthis test with subsequent client connections.
-****
+Repeat this test with subsequent client connections.
 
 [[postscreen_attribtutes]]
 *Postscreen Attributes:*
 
 Go to the `zmprov mcf` prompt (release 8.7+) to use Postscreen commands.
-You can see example usages of these attributes in <<enabling_postscreen,
-Enabling Postscreen>>.
+You can see example usages of these attributes in
+<<enabling_postscreen,Enabling Postscreen>>.
 
-`zimbraMtaPostscreenAccessList`
-
+* `zimbraMtaPostscreenAccessList` -- Default = permit_mynetworks
++
 Postconf postscreen_access_list setting, which is the permanent white/
 blacklist for remote SMTP client IP addresses. Postscreen(8) searches this
 list immediately after a remote SMTP client connects. Specify a comma- or
@@ -505,49 +473,40 @@ whitespace -separated list of commands (in upper or lower case) or lookup
 tables. The search stops upon the first command that fires for the client
 IP address.
 
-Default = permit_mynetworks
-
-`zimbraMtaPostscreenBareNewlineAction`
-
+* `zimbraMtaPostscreenBareNewlineAction` -- Default = ignore
++
 The action that postscreen(8) is to take when a remote SMTP client sends a
-bare newline character, that is, a newline not preceded by carriage return—
+bare newline character, that is, a newline not preceded by carriage return --
 as either ignore, enforce, or drop.
 
-Default = ignore
-
-`zimbraMtaPostscreenBareNewlineEnable`
-
+* `zimbraMtaPostscreenBareNewlineEnable` -- Default = no
++
 Enable (yes) or disable (no) "`bare newline`" SMTP protocol tests in the
 postscreen(8) server. These tests are expensive: a remote SMTP client must
 disconnect after it passes the test, before it can talk to a real Postfix
 SMTP server.
 
-Default = no
-
-`zimbraMtaPostscreenBareNewlineTTL`
-
+* `zimbraMtaPostscreenBareNewlineTTL` -- Default = 30d
++
 The amount of time allowable for postscreen(8) to use the result of a
 successful "`bare newline`" SMTP protocol test. During this time, the client
 IP address is excluded from this test. The default setting is lengthy
 because a remote SMTP client must disconnect after it passes the test,
 before it can talk to a real Postfix SMTP server.
-
++
 Specify a non-zero time value (an integral value plus an optional
 one-letter suffix that specifies the time unit). Time units: s (seconds), m
 (minutes), h (hours), d (days), w (weeks).
 
-Default = 30d
-
-`zimbraMtaPostscreenBlacklistAction`
-
+* `zimbraMtaPostscreenBlacklistAction` -- Default = ignore
++
 The action that postscreen(8) is to take when a remote SMTP client is
 permanently blacklisted with the postscreen_access_list parameter, as
 either ignore, enforce, or drop.
 
-Default = ignore
-
-`zimbraMtaPostscreenCacheCleanupInterval`
-
+* `zimbraMtaPostscreenCacheCleanupInterval` -- Default = 12h
++
+--
 The amount of time allowable between postscreen(8) cache cleanup runs.
 Cache cleanup increases the load on the cache database and should therefore
 not be run frequently. This feature requires that the cache database
@@ -560,39 +519,35 @@ entries that were retained and dropped. A cleanup run is logged as
 stop`, or no requests for `$max_idle` seconds.
 
 Time units: s (seconds), m (minutes), h (hours), d (days), w (weeks).
-Default = 12h
+--
 
-`zimbraMtaPostscreenCacheRetentionTime`
-
+* `zimbraMtaPostscreenCacheRetentionTime` -- Default = 7d
++
 The amount of time that postscreen(8) is allowed to cache an expired
 temporary whitelist entry before it is removed. This prevents clients from
 being logged as "`NEW`" just because their cache entry expired an hour
 ago. It also prevents the cache from filling up with clients that passed
 some deep protocol test once and never came back.
-
++
 Time units: s (seconds), m (minutes), h (hours), d (days), w (weeks).
-Default = 7d
 
-`zimbraMtaPostscreenCommandCountLimit`
-
+* `zimbraMtaPostscreenCommandCountLimit` -- Default = 20
++
 Value to set the limit on the total number of commands per SMTP session for
 postscreen(8)'s built-in SMTP protocol engine. This SMTP engine defers or
 rejects all attempts to deliver mail, therefore there is no need to enforce
 separate limits on the number of junk commands and error commands.
 
-Default = 20
-
-`zimbraMtaPostscreenDnsblAction`
-
+* `zimbraMtaPostscreenDnsblAction` -- Default = ignore
++
 The action that postscreen(8) is to take when a remote SMTP client's
 combined DNSBL score is equal to or greater than a threshold (as defined
 with the `postscreen_dnsbl_sites` and `postscreen_dnsbl_threshold`
 parameters), as either ignore, enforce, or drop.
 
-Default = ignore
-
-`zimbraMtaPostscreenDnsblSites`
-
+* `zimbraMtaPostscreenDnsblSites`
++
+--
 Optional list of DNS white/blacklist domains, filters and weight
 factors. When the list is non-empty, the dnsblog(8) daemon will query
 these domains with the IP addresses of remote SMTP clients, and
@@ -631,147 +586,125 @@ To use example.com as a high-confidence blocklist, and to block mail
 with example.net and example.org only when both agree:
 ----
 postscreen_dnsbl_threshold = 2
-
 postscreen_dnsbl_sites = example.com*2, example.net, example.org
 ----
+
 To filter only DNSBL replies containing 127.0.0.4:
 ----
 postscreen_dnsbl_sites = example.com=127.0.0.4
 ----
+--
 
-`zimbraMtaPostscreenDnsblThreshold`
-
+* `zimbraMtaPostscreenDnsblThreshold` -- Default = 1
++
 Value to define the inclusive lower bound for blocking a remote SMTP
 client, based on its combined DNSBL score as defined with the
 postscreen_dnsbl_sites parameter.
 
-Default = 1
-
-`zimbraMtaPostscreenDnsblTTL`
-
+* `zimbraMtaPostscreenDnsblTTL` -- Default = 1h
++
 The amount of time allowable for postscreen(8) to use the result from a
 successful DNS-based reputation test before a client IP address is required
 to pass that test again.
-
++
 Specify a non-zero time value (an integral value plus an optional
 one-letter suffix that specifies the time unit). Time units: s (seconds), m
 (minutes), h (hours), d (days), w (weeks).
 
-Default = 1h
-
-`zimbraMtaPostscreenDnsblWhitelistThreshold`
-
+* `zimbraMtaPostscreenDnsblWhitelistThreshold` -- Default = 0
++
 Allow a remote SMTP client to skip "`before`" and "`after 220 greeting`"
 protocol tests, based on its combined DNSBL score as defined with the
 `postscreen_dnsbl_sites` parameter.
-
++
 Specify a negative value to enable this feature. When a client passes the
 postscreen_dnsbl_whitelist_threshold without having failed other tests, all
 pending or disabled tests are flagged as completed with a time-to-live
 value equal to `postscreen_dnsbl_ttl`. When a test was already completed, its
 time-to-live value is updated if it was less than `postscreen_dnsbl_ttl`.
 
-Default = 0
-
-`zimbraMtaPostscreenGreetAction`
-
+* `zimbraMtaPostscreenGreetAction` -- Default = ignore
++
 The action that postscreen(8) is to take when a remote SMTP client speaks
 before its turn within the time specified with the `postscreen_greet_wait`
 parameter, as either ignore, enforce, or drop.
 
-Default = ignore
-
-`zimbraMtaPostscreenGreetTTL`
-
+* `zimbraMtaPostscreenGreetTTL` -- Default = 1d
++
 The amount of time allowed for postscreen(8) to use the result from a
 successful PREGREET test. During this time, the client IP address is
 excluded from this test. The default is relatively short, because a good
 client can immediately talk to a real Postfix SMTP server.
-
++
 Specify a non-zero time value (an integral value plus an optional
 one-letter suffix that specifies the time unit). Time units: s (seconds), m
 (minutes), h (hours), d (days), w (weeks).
 
-Default = 1d
-
-`zimbraMtaPostscreenNonSmtpCommandAction`
-
+* `zimbraMtaPostscreenNonSmtpCommandAction` -- Default = drop
++
 The action that postscreen(8) takes when a remote SMTP client sends
 non-SMTP commands as specified with the postscreen_forbidden_ commands
 parameter, as either ignore, enforce, or drop.
 
-Default = drop
-
-`zimbraMtaPostscreenNonSmtpCommandEnable`
-
+* `zimbraMtaPostscreenNonSmtpCommandEnable` -- Default = no
++
 Enable (yes) or disable (no) "non- SMTP command" tests in the postscreen(8)
 server. These tests are expensive: a client must disconnect after it passes
 the test, before it can talk to a real Postfix SMTP server.
 
-Default = no
-
-`zimbraMtaPostscreenNonSmtpCommandTTL`
-
+* `zimbraMtaPostscreenNonSmtpCommandTTL` -- Default = 30d
++
 The amount of time allowable for postscreen(8) to use the result from a
 successful "`non_smtp_command`" SMTP protocol test. During this time, the
 client IP address is excluded from this test. The default is long because a
 client must disconnect after it passes the test, before it can talk to a
 real Postfix SMTP server.
-
++
 Specify a non-zero time value (an integral value plus an optional
 one-letter suffix that specifies the time unit). Time units: s (seconds), m
 (minutes), h (hours), d (days), w (weeks).
 
-Default = 30d
-
-`zimbraMtaPostscreenPipeliningAction`
-
+* `zimbraMtaPostscreenPipeliningAction` -- Default = enforce
++
 The action that postscreen(8) is to take when a remote SMTP client sends
 multiple commands instead of sending one command and waiting for the server
 to respond, as either ignore, enforce, or drop.
 
-Default = enforce
-
-`zimbraMtaPostscreenPipeliningEnable`
-
+* `zimbraMtaPostscreenPipeliningEnable` -- Default = no
++
 Enable (yes) or disable (no) "`pipelining`" SMTP protocol tests in the
 postscreen(8) server. These tests are expensive: a good client must
 disconnect after it passes the test, before it can talk to a real Postfix
 SMTP server.
 
-Default = no
-
-`zimbraMtaPostscreenPipeliningTTL`
-
+* `zimbraMtaPostscreenPipeliningTTL` -- Default = 30d
++
 Time allowable for postscreen(8) to use the result from a successful
 "`pipelining`" SMTP protocol test. During this time, the client IP address is
 excluded from this test. The default is lengthy because a good client must
 disconnect after it passes the test, before it can talk to a real Postfix
 SMTP server.
-
++
 Specify a non-zero time value (an integral value plus an optional
 one-letter suffix that specifies the time unit). Time units: s (seconds), m
 (minutes), h (hours), d (days), w (weeks).
 
-Default = 30d
-
-`zimbraMtaPostscreenWatchdogTimeout`
-
+* `zimbraMtaPostscreenWatchdogTimeout` -- Default = 10s
++
 Time allowable for a postscreen(8) process to respond to a remote SMTP
 client command, or to perform a cache operation, before it is terminated by
 a built-in watchdog timer. This is a safety mechanism that prevents
 postscreen(8) from becoming non-responsive due to a bug in Postfix itself
 or in system software. To avoid false alarms and unnecessary cache
 corruption this limit cannot be set under 10s.
-
++
 Specify a non-zero time value (an integral value plus an optional
 one-letter suffix that specifies the time unit). Time units: s (seconds), m
 (minutes), h (hours), d (days), w (weeks).
 
-Default = 10s
-
-`zimbraMtaPostscreenWhitelistInterfaces`
-
+* `zimbraMtaPostscreenWhitelistInterfaces`
++
+--
 A list of local postscreen(8) server IP addresses where a non-whitelisted
 remote SMTP client can obtain postscreen(8)'s temporary whitelist
 status. This status is required before the client can talk to a Postfix
@@ -813,23 +746,23 @@ Example:
 # Don't whitelist connections to the backup IP address.
 postscreen_whitelist_interfaces = !168.100.189.8, static:all
 ----
+--
 
-`zimbraMtaPostscreenDnsblMinTTL`
-
-The minimum amount of time that postscreen(8) is allowed—resulting from a
-successful DNS -based reputation test—before a client IP address is
+* `zimbraMtaPostscreenDnsblMinTTL` -- Default = 60s
++
+The minimum amount of time that postscreen(8) is allowed -- resulting from a
+successful DNS -based reputation test -- before a client IP address is
 required to pass that test again. If the DNS reply specifies a larger TTL
 value, that value will be used unless it would be larger than
 postscreen_dnsbl_max_ttl.
-
++
 Specify a non-zero time value (an integral value plus an optional
 one-letter suffix that specifies the time unit). Time units: s (seconds), m
 (minutes), h (hours), d (days), w (weeks).
 
-Default = 60s
-
-`zimbraMtaPostscreenDnsblMaxTTL`
-
+* `zimbraMtaPostscreenDnsblMaxTTL` -- Default = postscreen dnsbl ttl
++
+--
 The maximum amount of time allowable for postscreen(8) to use the result
 from a successful DNS-based reputation test before a client IP address is
 required to pass that test again. If the DNS reply specifies a shorter TTL
@@ -840,8 +773,9 @@ Specify a non-zero time value (an integral value plus an optional
 one-letter suffix that specifies the time unit). Time units: s (seconds), m
 (minutes), h (hours), d (days), w (weeks).
 
-Default = postscreen dnsbl ttl. Note that the default seeting is
-backwards-compatible with Postscreen versions earlier than 3.1.
+Note that the default setting is backwards-compatible with Postscreen
+versions earlier than 3.1.
+--
 
 [[enabling_postscreen]]
 *Enabling Postscreen:*
@@ -861,26 +795,26 @@ zmprov mcf zimbraMtaPostscreenCacheCleanupInterval 12h
 zmprov mcf zimbraMtaPostscreenCacheRetentionTime 7d
 zmprov mcf zimbraMtaPostscreenCommandCountLimit 20
 zmprov mcf zimbraMtaPostscreenDnsblAction enforce
-zmprov mcf zimbraMtaPostscreenDnsblSites
-'b.barracudacentral.org=127.0.0.2_7' zimbraMtaPostscreenDnsblSites
-'dnsbl.inps.de=127.0.0.2*7'
-zimbraMtaPostscreenDnsblSites*'zen.spamhaus.org=127.0.0.[10;11]*8'
-zimbraMtaPostscreenDnsblSites *'zen.spamhaus.org=127.0.0.[4..7]*6'
-zimbraMtaPostscreenDnsblSites *'zen.spamhaus.org=127.0.0.3*4'
-zimbraMtaPostscreenDnsblSites *'zen.spamhaus.org=127.0.0.2*3'
-zimbraMtaPostscreenDnsblSites *'list.dnswl.org=127.0.[0..255].0*-2'
-zimbraMtaPostscreenDnsblSites *'list.dnswl.org=127.0.[0..255].1*-3'
-zimbraMtaPostscreenDnsblSites *'list.dnswl.org=127.0.[0..255].2*-4'
-zimbraMtaPostscreenDnsblSites *'list.dnswl.org=127.0.[0..255].3*-5'
-zimbraMtaPostscreenDnsblSites *'bl.mailspike.net=127.0.0.2*5'
-zimbraMtaPostscreenDnsblSites *'bl.mailspike.net=127.0.0.[10;11;12]*4'
-zimbraMtaPostscreenDnsblSites *'wl.mailspike.net=127.0.0.[18;19;20]*-2'
-zimbraMtaPostscreenDnsblSites *'dnsbl.sorbs.net=127.0.0.10*8'
-zimbraMtaPostscreenDnsblSites *'dnsbl.sorbs.net=127.0.0.5*6'
-zimbraMtaPostscreenDnsblSites *'dnsbl.sorbs.net=127.0.0.7*3'
-zimbraMtaPostscreenDnsblSites *'dnsbl.sorbs.net=127.0.0.8*2'
-zimbraMtaPostscreenDnsblSites *'dnsbl.sorbs.net=127.0.0.6*2'
-zimbraMtaPostscreenDnsblSites **'dnsbl.sorbs.net=127.0.0.9*2'
+zmprov mcf \
+  zimbraMtaPostscreenDnsblSites 'b.barracudacentral.org=127.0.0.2_7' \
+  zimbraMtaPostscreenDnsblSites 'dnsbl.inps.de=127.0.0.2*7' \
+  zimbraMtaPostscreenDnsblSites 'zen.spamhaus.org=127.0.0.[10;11]*8' \
+  zimbraMtaPostscreenDnsblSites 'zen.spamhaus.org=127.0.0.[4..7]*6' \
+  zimbraMtaPostscreenDnsblSites 'zen.spamhaus.org=127.0.0.3*4' \
+  zimbraMtaPostscreenDnsblSites 'zen.spamhaus.org=127.0.0.2*3' \
+  zimbraMtaPostscreenDnsblSites 'list.dnswl.org=127.0.[0..255].0*-2' \
+  zimbraMtaPostscreenDnsblSites 'list.dnswl.org=127.0.[0..255].1*-3' \
+  zimbraMtaPostscreenDnsblSites 'list.dnswl.org=127.0.[0..255].2*-4' \
+  zimbraMtaPostscreenDnsblSites 'list.dnswl.org=127.0.[0..255].3*-5' \
+  zimbraMtaPostscreenDnsblSites 'bl.mailspike.net=127.0.0.2*5' \
+  zimbraMtaPostscreenDnsblSites 'bl.mailspike.net=127.0.0.[10;11;12]*4' \
+  zimbraMtaPostscreenDnsblSites 'wl.mailspike.net=127.0.0.[18;19;20]*-2' \
+  zimbraMtaPostscreenDnsblSites 'dnsbl.sorbs.net=127.0.0.10*8' \
+  zimbraMtaPostscreenDnsblSites 'dnsbl.sorbs.net=127.0.0.5*6' \
+  zimbraMtaPostscreenDnsblSites 'dnsbl.sorbs.net=127.0.0.7*3' \
+  zimbraMtaPostscreenDnsblSites 'dnsbl.sorbs.net=127.0.0.8*2' \
+  zimbraMtaPostscreenDnsblSites 'dnsbl.sorbs.net=127.0.0.6*2' \
+  zimbraMtaPostscreenDnsblSites 'dnsbl.sorbs.net=127.0.0.9*2'
 zmprov mcf zimbraMtaPostscreenDnsblTTL 5m
 zmprov mcf zimbraMtaPostscreenDnsblThreshold 8
 zmprov mcf zimbraMtaPostscreenDnsblTimeout 10s
@@ -912,23 +846,15 @@ The following real-world example demonstrates return of a 550 error from
 Postscreen during a test session:
 
 ----
-Mar 1 02:03:26 edge01 postfix/postscreen[23154]: DNSBL rank 28 for
-[112.90.37.251]:20438
+Mar 1 02:03:26 edge01 postfix/postscreen[23154]: DNSBL rank 28 for [112.90.37.251]:20438
 
-Mar 1 02:03:26 edge01 postfix/postscreen[23154]: CONNECT from
-[10.210.0.161]:58010 to [10.210.0.174]:25
+Mar 1 02:03:26 edge01 postfix/postscreen[23154]: CONNECT from [10.210.0.161]:58010 to [10.210.0.174]:25
 
-Mar 1 02:03:26 edge01 postfix/postscreen[23154]: WHITELISTED
-[10.210.0.161]:58010
+Mar 1 02:03:26 edge01 postfix/postscreen[23154]: WHITELISTED [10.210.0.161]:58010
 
-Mar 1 02:03:27 edge01 postfix/postscreen[23154]: NOQUEUE: reject: RCPT
-from [112.90.37.251]:20438: 550 5.7.1 Service unavailable; client
-[112.90.37.251] blocked using zen.spamhaus.org;
-from=<hfxdgdsggfvfg@gmail.com>, to=<support@zimbra.com>, proto=ESMTP,
-helo=<gmail.com>
+Mar 1 02:03:27 edge01 postfix/postscreen[23154]: NOQUEUE: reject: RCPT from [112.90.37.251]:20438: 550 5.7.1 Service unavailable; client [112.90.37.251] blocked using zen.spamhaus.org; from=<hfxdgdsggfvfg@gmail.com>, to=<support@zimbra.com>, proto=ESMTP, helo=<gmail.com>
 
-Mar 1 02:03:27 edge01 postfix/postscreen[23154]: DISCONNECT
-[112.90.37.251]:20438
+Mar 1 02:03:27 edge01 postfix/postscreen[23154]: DISCONNECT [112.90.37.251]:20438
 ----
 
 == Receiving and Sending Mail
@@ -980,5 +906,5 @@ attempts are made for messages in the hold queue.
 The *corrupt* queue stores damaged unreadable messages.
 
 You can monitor the mail queues for delivery problems from the
-Administration Console. See <<monitoring_zcs_servers,Monitoring
-{product-abbrev} Servers>>.
+Administration Console. See
+<<monitoring_zcs_servers,Monitoring {product-abbrev} Servers>>.

--- a/productoverview.adoc
+++ b/productoverview.adoc
@@ -55,10 +55,11 @@ through the browser based web client.
 == Zimbra Components
 
 Zimbra architecture includes open-source integrations using industry
-standard protocols. The third-party software listed in <<table_tps,
-Third-Party Software>> is bundled with Zimbra software and installed as
-part of the installation process. These components have been tested and
-configured to work with the software.
+standard protocols. The third-party software listed in
+<<table_tps,Third-Party Software>>
+is bundled with Zimbra software and installed as part of the
+installation process. These components have been tested and configured
+to work with the software.
 
 [[table_tps]]
 .Third-Party Software
@@ -123,14 +124,14 @@ enabled to run on all systems.
 The components for the mailbox server (including Jetty). The Zimbra mailbox
 server includes the following components:
 
-* *Data store*. A MariaDB database.
+* *Data store* -- A MariaDB database.
 
-* *Message store*. Location of all email messages and file attachments.
+* *Message store* -- Location of all email messages and file attachments.
 
-* *Index store*. Index and search technology is provided through
+* *Index store* -- Index and search technology is provided through
 Lucene. Index files are maintained for each mailbox.
 
-* *Web application services*. The Jetty web application server runs web
+* *Web application services* -- The Jetty web application server runs web
 applications (webapps) on any store server. It provides one or more web
 application services.
 
@@ -197,7 +198,7 @@ and Discovery, contact Zimbra sales.
 
 |=======================================================================
 
-== Mail Flow—Multi-Server Configuration
+== Mail Flow -- Multi-Server Configuration
 
 The configuration for each deployment is dependent on numerous variables
 such as the number of mailboxes, mailbox quotas, performance requirements,
@@ -247,10 +248,11 @@ The directories not listed in the following table are
 libraries used for building the core Zimbra software or
 miscellaneous third-party tools.
 
-.System Directory Tree
+// TODO: update for 8.7 changes with /opt/zimbra/common
+.System Directory Tree under `/opt/zimbra`
 [cols="30m,70",options="header",grid="rows"]
 |=======================================================================
-|`opt/zimbra` File | Description
+|File | Description
 
 |backup/ |
 Backup target contains full and incremental backup data
@@ -372,7 +374,7 @@ book, and task functions.
 |Client Type |Description
 
 |Advanced Web Client |
-includes Ajax capability and offers a full set of web collaboration
+Includes Ajax capability and offers a full set of web collaboration
 features. This web client works best with newer browsers and fast Internet
 connections.
 
@@ -381,11 +383,11 @@ A good option when Internet connections are slow or users prefer HTML-based
 messaging for navigating within their mailbox
 
 |Mobile Client |
-(Native Mail Client): Used to configure and sync the Zimbra mailbox server
+(Native Mail Client) Used to configure and sync the Zimbra mailbox server
 with the native mail client on a mobile device.
 
 |Touch Client |
-(Mobile Web App) provides an experience for touch-capable mobile
+(Mobile Web App) Provides an experience for touch-capable mobile
 devices. Its features are a subset of the features found in the Zimbra Web
 Client, including Mail, Contacts and Calendar.
 
@@ -397,7 +399,7 @@ version.
 
 When users sign in, they view the advanced Zimbra Web Client, unless they
 use the menu on the login screen to change to the standard version.  If ZWC
-detects the screen resolution to be 800 x 600, users are automatically
+detects the screen resolution to be 800x600, users are automatically
 redirected to the standard Zimbra Web Client. Users can still choose the
 advanced ZWC but see a warning message suggesting the use of the standard
 ZWC for better screen view.
@@ -419,7 +421,7 @@ Outlook on a Mac device. To enable EWS client access, see the Class of
 Service section. EWS is a separately licensed add-on feature.
 
 * *Messaging Application Programming Interface (MAPI)* synchronizes
-toMicrosoft Outlook 2016/2013/2010/2007/2003 with full delegate, offline
+to Microsoft Outlook 2016/2013/2010/2007/2003 with full delegate, offline
 access and support for S/MIME. Use the Zimbra Connector for Outlook to
 connect to {product-name} when using Microsoft Outlook on a Windows
 device. To enable MAPI (Microsoft Outlook) Connector, see the Class of
@@ -432,7 +434,7 @@ Authoring and Versioning (CardDAV) clients.
 [[offline_mode]]
 == Offline Mode
 
-Zimbra Offline Mode allows access to data—without network connectivity—
+Zimbra Offline Mode allows access to data -- without network connectivity --
 when using the Zimbra Web Client (ZWC).
 
 For example, if there is no server connectivity or if server connectivity
@@ -452,8 +454,8 @@ following topics:
 
 [NOTE]
 To view current and detailed security news and alerts, please refer to
-https://wiki.zimbra.com[Zimbra Wiki]
-https://wiki.zimbra.com/wiki/SecurityCenter[Security Center].
+https://wiki.zimbra.com/wiki/Security_Center[Security Center] on the
+https://wiki.zimbra.com/[Zimbra Wiki].
 
 === Identity and Access Management
 
@@ -478,16 +480,16 @@ user store: the passwords are stored as salted hash that is compared
 against that of the entered password, for rejection (no match) or
 acceptance (matched). If external directory (LDAP or Active Directory) is
 preferred, the appropriate login credentials can be stored in this external
-LDAP directory. See also <<zimbra_ldap_service, Zimbra LDAP Service>> for
-more details.
+LDAP directory. See also
+<<zimbra_ldap_service,Zimbra LDAP Service>> for more details.
 
 |Two Factor Authentication |
 A second layer of identify security that is configured at the Admin Console
 to enable or disable passcode generation to mobile devices associated with
 {product-name}. When enabled, user or COS accounts must use the generated
 passcode to gain access to their client services. See also
-<<about_two_factor_auth, About 2 Factor Authentication>> and
-<<two_factor_auth, Two Factor Authentication>>.
+<<about_two_factor_auth,About 2 Factor Authentication>> and
+<<two_factor_auth,Two Factor Authentication>>.
 
 |Authorized Access |
 User accounts are defined by various attributes, permission levels, and
@@ -526,7 +528,7 @@ With S/MIME for end-to-end encryption, data stored in a {product-name}
 message store is encrypted until decryption occurs with the appropriate
 private key.
 
-|Anti-virus and Antispam |
+|Anti-virus and Anti-spam |
 Both malware and spam are challenged by the {product-name} native
 functionality and third-party plugins: Amavisd-new, ClamAV, and Spam
 Assassin.

--- a/provisioning.adoc
+++ b/provisioning.adoc
@@ -14,22 +14,21 @@ Before adding a user account, determine which features and access
 privileges should be assigned.  You can either assign a class of service
 (COS) with the features enabled when you create the account or you can
 configure the features for the individual accounts.  For a description of
-the features, see <<class_of_service_and_accounts,Class of Service and
-Accounts>>.
+the features, see
+<<class_of_service_and_accounts,Class of Service and Accounts>>.
 
 If the COS you assign has the correct functionality for the account, you do
 not need to perform any additional configuration.
 
 Creating an account sets up the appropriate entries on the Zimbra LDAP
 directory server.  When the user logs in for the first time or when an
-email is delivered to the user’s account, the mailbox is created on the
+email is delivered to the user's account, the mailbox is created on the
 mailbox server.
 
-.Admin Console
-****
-For basic user account setup:
+Basic user account setup:
 
-*Home > Add Accounts >* click *Add Account*
+Admin Console: ::
+*Home -> 3 Add Accounts -> 1. Add Account*
 
 . In the *Account Name* section, enter the account name and the last
   name as a minimum to configure the account.
@@ -41,7 +40,6 @@ The default COS is assigned to the account.
 You can continue to configure features and functionality for the
 individual account.  Changes you make to the account override the COS
 that is assigned to the account.
-****
 
 == Migrating Accounts and Importing Account Email
 
@@ -50,7 +48,7 @@ Wizard from the Administration Console.  You can import accounts from
 either a generic IMAP server or from another {product-abbrev} server.
 
 [NOTE]
-Only accounts on {product-abbrev} 7.2 or later can be migrated to {product-abbrev} 8.0.
+Only accounts on {product-abbrev} 7.2 or later can be migrated to {product-abbrev} 8.
 
 You can also import account names to provision from an XML file that you
 create.
@@ -78,32 +76,32 @@ accounts you provisioned.
 
 If you running a split domain configuration, you can set the SMTP host and
 port in the wizard.  For more information about split domains, see the wiki
-article about split domains at http://wiki.zimbra.com/wiki/Split_Domain.
+article about split domains at https://wiki.zimbra.com/wiki/Split_Domain.
 
 === Migrating Accounts from a Zimbra Server
 
-.Admin Console
-****
-To migrate accounts from a server running {product-abbrev} 7.2.0 or later to {product-abbrev} 8.0.
+To migrate accounts from a server running {product-abbrev} 7.2 or later to {product-abbrev} 8.
 
-*Home > Add Accounts >* click *Migration and Co-existence.*
+Admin Console: ::
+*Home -> 3 Add Accounts -> 3. Migration and Co-existence*
 
+// list
 . In the *Type of mail server* field, select *{product-name}.*
 
-.  If you are provisioning accounts, select *Yes* to import the account's
+. If you are provisioning accounts, select *Yes* to import the account's
 records.  If you are not going to import the data at this time, in the
 *Would you like to import mail*, select *No*.
 
-.  Click *Next*.
+. Click *Next*.
 
-.  On the *Overview* dialog, Import from another Zimbra LDAP directory is
+. On the *Overview* dialog, Import from another Zimbra LDAP directory is
 selected.  Click *Next*.
 
-.  On the *Bulk provisioning options* page, select whether to generate
+. On the *Bulk provisioning options* page, select whether to generate
 random passwords or to assign the same password for each account.
 +
 .Bulk Provisioning Features
-[cols=",",options="header",]
+[cols="1,2",options="header",]
 |=======================================================================
 |Bulk Provisioning Feature |Description
 
@@ -137,7 +135,7 @@ For split domain configurations, set the SMTP Host name and port.
 the server.
 +
 .Directory Connection Options
-[cols=",a",options="header",]
+[cols="1,2a",options="header",]
 |=======================================================================
 |Directory Connection Options |Description
 
@@ -154,7 +152,7 @@ Enter the maximum number of accounts to import at one time.  The default is
 0, which means that no limits are set.
 
 |Server name, LDAP URL, Port, and Use of SSL |
-* The LDAP URL is entered as `ldap://<ldapdirectory.example.com>`.
+* The LDAP URL is entered as: `ldap://<ldapdirectory.example.com>`
 * The default port is 389, but you can change this.
 * Check SSL if this is used.
 
@@ -168,8 +166,8 @@ Enter the password for the server.
 |LDAP filter |
 In this field enter the LDAP search filter to run.  Here you can define
 search criteria to collect the type of account information you want to
-import.  The default filter in the field is (*objectclass-zimbraAccount*).
-This filter includes the emailaddress, the account ID, and attributes for
+import.  The default filter in the field is (*objectclass=zimbraAccount*).
+This filter includes the email address, the account ID, and attributes for
 the account.
 
 |LDAP search base |
@@ -191,33 +189,30 @@ provisioned on the {product-name} server.
 passwords.  The .csv file is deleted when you close the wizard.  If you do
 not download the file, you cannot access the report later.
 
-****
-
 === Migrating Accounts from Generic IMAP Servers
-
-.Admin Console
-****
 
 Use steps in this section to provision accounts on the Zimbra server.
 
-*Home> Add Accounts >* click *Migration and Co-existence.*
+Admin Console: ::
+*Home -> 3 Add Accounts -> 3. Migration and Co-existence*
 
+// list
 . In the *Type of mail server* field, select *Generic IMAP Server*.
 
-. If you are provisioning accounts, select *Yes* to import the account’s
+. If you are provisioning accounts, select *Yes* to import the account's
 records.  If you are not going to import the data at this time, in the
 Would you like to import mail, select *No*.
 
 . Click *Next*.
 
-.  On the *Overview* dialog, Import from another LDAP directory is
+. On the *Overview* dialog, Import from another LDAP directory is
 selected.  Click *Next*.
 
 . On the *Bulk provisioning options* page, select whether to generate
 random passwords or to assign the same password for each account.
 +
 .Bulk Provisioning Features
-[cols=",",options="header",]
+[cols="1,2",options="header",]
 |=======================================================================
 |Bulk Provisioning Feature |Description
 
@@ -250,7 +245,7 @@ For split domain configurations, set the SMTPHost name and port.
 the server.
 +
 .Directory Connection Options
-[cols=",a",options="header",]
+[cols="1,2a",options="header",]
 |=======================================================================
 |Directory Connection Options |Description
 
@@ -267,7 +262,7 @@ Enter the maximum number of accounts to import at one time.  The default is
 0, which means that no limits are set.
 
 |Server name, LDAP URL, Port, and Use of SSL |
-* The LDAP URL is entered as `ldap://<ldapdirectory.example.com>`.
+* The LDAP URL is entered as: `ldap://<ldapdirectory.example.com>`
 * The default port is 389, but you can change this.
 * Check SSL if this is used.
 
@@ -281,8 +276,8 @@ Enter the password for the server.
 |LDAP filter |
 In this field enter the LDAP search filter to run.  Here you can define
 search criteria to collect the type of account information you want to
-import.  The default filter in the field is (*objectclass-zimbraAccount*).
-This filter includes the emailaddress, the account ID, and attributes for
+import.  The default filter in the field is (*objectclass=zimbraAccount*).
+This filter includes the email address, the account ID, and attributes for
 the account.
 
 |LDAP search base |
@@ -304,21 +299,19 @@ provisioned on the {product-name} server.
 passwords.  The .csv file is deleted when you close the wizard.  If you do
 not download the file, you cannot access the report later.
 
-****
-
 === Migrating Accounts using an XML File
 
-.Admin Console
-****
 Use steps in this section to create an XML file with the account
 information and save it to a computer you can access.
 
-*Home > Add Accounts >* click *Migration and Co-existence.*
+Admin Console: ::
+*Home -> 3 Add Accounts -> 3. Migration and Co-existence*
 
+// list
 . In the *Type of mail server* field, select the type of server your are
 migrating from.
 
-. If you are provisioning accounts, select *Yes* to import the account’s
+. If you are provisioning accounts, select *Yes* to import the account's
 records.  If you are not going to import the data at this time, in the
 Would you like to import mail, select *No*.
 
@@ -341,12 +334,8 @@ server.
 passwords.  The .csv file is deleted when you close the wizard.  If you do
 not download the file, you cannot access the report later.
 
-****
-
 === Importing Email for Selected Accounts
 
-.Admin Console
-****
 Use steps in this section to specify the list of accounts whose mail you
 want to import by either selecting the accounts to import data or by using
 an XML file to select the accounts.
@@ -355,9 +344,11 @@ an XML file to select the accounts.
 Ensure that accounts are provisioned on the {product-abbrev} server before attempting
 this procedure.
 
-*Home > Add Accounts >* click *Migration and Co-existence.*
+Admin Console: ::
+*Home -> 3 Add Accounts -> 3. Migration and Co-existence*
 
-. In the *Typ*e *of mail server* field, select the type of server your are
+// list
+. In the *Type of mail server* field, select the type of server your are
 importing the data from.
 
 . In the *Would you like to import account records* menu, select *No*.
@@ -396,8 +387,6 @@ IMAP host name, port and administrator login information.
 
 . Review the data import options.  If the information is correct, click
 *Next*.
-
-****
 
 === XML File Examples
 
@@ -509,13 +498,13 @@ provisioning methods.
 When an external LDAP authentication mechanism - such as external LDAP
 authentication, preauth, or SPNEGO - is configured for a {product-abbrev} domain, you
 can set up {product-abbrev} to automatically create user accounts on {product-abbrev}.  Primary email
-address and account attributes are mapped from an external directory.You
+address and account attributes are mapped from an external directory. You
 can configure how and when new accounts should be created from the external
 directory data.
 
 Three modes are supported for auto-provisioning configuration.
 
-[cols=",",options="header",]
+[cols="1,5",options="header",]
 |=======================================================================
 |Mode |Description
 
@@ -525,8 +514,8 @@ mode, you configure how often the external directory is polled for new
 users, the maximum number of users to process at each interval, and which
 domains are scheduled for account auto provision on specified servers.
 
-Guidelines are provided in <<eager_mode_configuration,Eager Mode
-Configuration>>.
+Guidelines are provided in
+<<eager_mode_configuration,Eager Mode Configuration>>.
 
 | Lazy |
 If a user logs into ZWC the first time through one of the authentication
@@ -534,8 +523,8 @@ mechanisms supported for auto provisioning, and if the user does not exist
 in the {product-abbrev} directory, a new account is automatically created in {product-abbrev} for
 this user.
 
-Guidelines are provided in <<lazy_mode_configuration,Lazy Mode
-Configuration>>.
+Guidelines are provided in
+<<lazy_mode_configuration,Lazy Mode Configuration>>.
 
 |Manual |
 Auto provisioning does not occurs: instead, the administrator manually
@@ -543,8 +532,8 @@ searches from the configured external auto-provisioning LDAP source and
 selects an entry from the search result to create the corresponding Zimbra
 account for the external entry.
 
-Guidelines are provided in <<manual_mode_configuration,Manual Mode
-Configuration>>.
+Guidelines are provided in
+<<manual_mode_configuration,Manual Mode Configuration>>.
 
 |=======================================================================
 
@@ -553,7 +542,7 @@ alongside the @ symbol) is mapped from a user attribute on the external
 directory that you define in `zimbraAutoProvAccountNameMap`.  Other account
 information, such as first and last name, phone numbers, and address, is
 populated from the attributes mapped from the external directory based on
-`zimbraAutoProvAttrMap`.  You can review the external directory’s
+`zimbraAutoProvAttrMap`.  You can review the external directory's
 attributes to determine those that should be mapped to a Zimbra attribute.
 
 The COS assignment for auto-provisioned accounts is identical to the way
@@ -566,7 +555,7 @@ that are created.
 
 You can configure a *Welcome* email message to be sent to newly created
 accounts.  The subject and body of this email can be configured with
-`AutoProvNotification*` attributes on the domain.
+`AutoProvNotification` attributes on the domain.
 
 === Auto-Provisioning Attributes
 
@@ -575,88 +564,70 @@ to configure auto provisioning of new accounts with an external LDAP
 directory.
 
 `zimbraAutoProvMode`::
-
-    Set auto provision mode as either EAGER, LAZY, and/or MANUAL.  Multiple
-    auto-provisioning modes can be enabled on a domain.
+Set auto provision mode as either EAGER, LAZY, and/or MANUAL.
+Multiple auto-provisioning modes can be enabled on a domain.
 
 `zimbraAutoProvAuthMech`::
-
-    Set type of authentication mechanism - as either LDAP, PREAUTH, KRB^,
-    or SPNEGO - to enable for LAZY mode.  Once a user authenticates via the
-    specified authentication mechanism, and if the user account does not
-    yet exist in the Zimbra directory, an account will be automatically
-    created in the Zimbra directory.
+Set type of authentication mechanism - as either LDAP, PREAUTH, KRB5,
+or SPNEGO - to enable for LAZY mode.  Once a user authenticates via
+the specified authentication mechanism, and if the user account does
+not yet exist in the Zimbra directory, an account will be
+automatically created in the Zimbra directory.
 
 `zimbraAutoProvLdapURL`::
-
-    Set the LDAP URL of the external LDAP source for auto provisioning
+Set the LDAP URL of the external LDAP source for auto provisioning
 
 `zimbraAutoProvLdapStartTlsEnabled`::
-
-    Enable (TRUE) or disable (FALSE) the StartTLS protocol when accessing
-    the external LDAP server for auto provisioning.
-+
+Enable (TRUE) or disable (FALSE) the StartTLS protocol when accessing
+the external LDAP server for auto provisioning. +
 Default = FALSE.
 
 `zimbraAutoProvLdapAdminBindDn`::
-
-    Defines the LDAP search bind DN for auto provisioning.
+Defines the LDAP search bind DN for auto provisioning.
 
 `zimbraAutoProvLdapAdminBindPassword`::
-
-   Set the LDAP search admin bind password for auto provisioning.
+Set the LDAP search admin bind password for auto provisioning.
 
 `zimbraAutoProvLdapSearchBase`::
-
-    Set the LDAP search base for auto provisioning, used in conjunction
-    with zimbra `zimbraAutoProvLdapSearchFilter`.
-+
+Set the LDAP search base for auto provisioning, used in conjunction
+with zimbra `zimbraAutoProvLdapSearchFilter`. +
 If not set, LDAP root DSE will be used.
 
 `zimbraAutoProvLdapSearchFilter`::
-
-    Defines the LDAP search filter template for account auto provisioning.
-    For LAZY mode, either `zimbraAutoProvLdapSearchFilter`
-+
-or
-+
+Defines the LDAP search filter template for account auto provisioning.
+For LAZY mode, either `zimbraAutoProvLdapSearchFilter` or
 `zimbraAutoProvLdapBindDn` must be set.
 +
 If both are set, `zimbraAutoProvLdapSearchFilter` will take precedence.
-See <<auto_provisioning_placeholders,Place Holders>> for supported
+See <<auto_provisioning_placeholders,Placeholders>> for supported
 placeholders.
 
 `zimbraAutoProvLdapBindDn`::
-
-    Defines the LDAP external DN template for account auto provisioning.  For
-    LAZY mode, either `zimbraAutoProvLdapSearchFilter`
-+
-or
-+
+Defines the LDAP external DN template for account auto provisioning.
+For LAZY mode, either `zimbraAutoProvLdapSearchFilter` or
 `zimbraAutoProvLdapBindDn` must be set.
 +
-If both are set, `zimbraAutoProvLdapSearchFilter` will take precedence.
-See <<auto_provisioning_placeholders,Place Holders>> for supported
-placeholders.
+If both are set, `zimbraAutoProvLdapSearchFilter` will take
+precedence.  See <<auto_provisioning_placeholders,Placeholders>> for
+supported placeholders.
 
 `zimbraAutoProvAccountNameMap`::
-
-    Defines the attribute name in the external directory that contains
-    local part of the account name.  This is the name used to create the
-    Zimbra account.  If this is not specified, the local part of the
-    account name is the principal user used to authenticated to Zimbra.
+Defines the attribute name in the external directory that contains
+local part of the account name.  This is the name used to create the
+Zimbra account.  If this is not specified, the local part of the
+account name is the principal user used to authenticated to Zimbra.
 
 `zimbraAutoProvAttrMap`::
-
-    Defines the attribute map for mapping attribute values from the
-    external entry to Zimbra account attributes.  Values are in the format
-    of `{external attribute}={zimbra attribute}`.  If this is not set, no
-    attributes from the external directory are populated in Zimbra account.
+Defines the attribute map for mapping attribute values from the
+external entry to Zimbra account attributes.  Values are in the format
+of `{external attribute}={zimbra attribute}`.  If this is not set, no
+attributes from the external directory are populated in Zimbra
+account.
 +
 [IMPORTANT]
 --
-Invalid mapping configuration will cause the account creation to fail.  Bad
-mapping may be due to conditions such as:
+Invalid mapping configuration will cause the account creation to fail.
+Bad mapping may be due to conditions such as:
 
 * Invalid external attribute name.
 * Invalid Zimbra attribute name.
@@ -667,79 +638,75 @@ attribute=integer).
 --
 
 `zimbraAutoProvNotificationFromAddress`::
-
-    Defines the email address to put in the *From* header for the Welcome
-    email sent to the newly created account.  If not set, no notification
-    email is sent to the newly created account.
+Defines the email address to put in the *From* header for the Welcome
+email sent to the newly created account.  If not set, no notification
+email is sent to the newly created account.
 
 `zimbraAutoProvNotificationSubject`::
-
-    Template used to construct the subject of the notification message sent
-    to the user when the user's account is auto provisioned.
+Template used to construct the subject of the notification message
+sent to the user when the user's account is auto provisioned.
 +
 Supported variables: `${ACCOUNT_ADDRESS}`, `${ACCOUNT_DISPLAY_NAME}`
 
 `zimbraAutoProvNotificationBody`::
-
-    Template used to construct the subject of the notification message sent
-    to the user when the user’s account is auto provisioned.
+Template used to construct the subject of the notification message
+sent to the user when the user's account is auto provisioned.
 +
 Supported variables: `${ACCOUNT_ADDRESS}`, `${ACCOUNT_DISPLAY_NAME}`
 
 `zimbraAutoProvListenerClass`::
-
-    Domain setting to define the class name of auto provision listener.
-    The class must implement the
-    `com.zimbra.cs.account.Account.AutoProvisionListener` interface.  The
-    singleton listener instance is invoked after each account is auto
-    created in Zimbra.  Listener can be pluthe gged in as a server
-    extension to handle tasks like updating the account auto provision
-    status in the external LDAP directory.
+Domain setting to define the class name of auto provision listener.
+The class must implement the
+`com.zimbra.cs.account.Account.AutoProvisionListener` interface.  The
+singleton listener instance is invoked after each account is auto
+created in Zimbra.  Listener can be plugged in as a server
+extension to handle tasks like updating the account auto provision
+status in the external LDAP directory.
 +
-At each eager provision interval, {product-abbrev} does an LDAP search based on the
-value configured in `zimbraAutoProvLdapSearchFilter`.  Returned entries
-from this search are candidates to be auto provisioned in this batch.  The
-`zimbraAutoProvLdapSearchFilter` should include an assertion that will only
-hit entries in the external directory that have not yet been provisioned in
-{product-abbrev}, otherwise it's likely the same entries will be repeated pulled in to
-{product-abbrev}.  After an account is auto provisioned in {product-abbrev},
+At each eager provision interval, {product-abbrev} does an LDAP search
+based on the value configured in `zimbraAutoProvLdapSearchFilter`.
+Returned entries from this search are candidates to be auto
+provisioned in this batch.  The `zimbraAutoProvLdapSearchFilter`
+should include an assertion that will only hit entries in the external
+directory that have not yet been provisioned in {product-abbrev},
+otherwise it's likely the same entries will be repeated pulled in to
+{product-abbrev}.  After an account is auto provisioned in
+{product-abbrev},
 `com.zimbra.cs.account.Account.AutoProvisionListener.postCreate
-(Domain domain, Account acct, String external DN)` will be called by the
-auto provisioning framework.  Customer can implement the
-AutoProvisionListener interface in a {product-abbrev} server extension and get their
-`AutoProvisionListener.postCreate()` get called.  The implementation of
-customer's post Create method can be, for example, setting an attribute
-in the external directory on the account just provisioned in {product-abbrev}.  The
-attribute can be included as a condition in the
-`zimbraAutoProvLdapSearchFilter`, so the entry won't be returned again by
-the LDAP search in the next interval.
+(Domain domain, Account acct, String external DN)` will be called by
+the auto provisioning framework.  Customer can implement the
+AutoProvisionListener interface in a {product-abbrev} server extension
+and get their `AutoProvisionListener.postCreate()` get called.  The
+implementation of customer's post Create method can be, for example,
+setting an attribute in the external directory on the account just
+provisioned in {product-abbrev}.  The attribute can be included as a
+condition in the `zimbraAutoProvLdapSearchFilter`, so the entry won't
+be returned again by the LDAP search in the next interval.
 
 `zimbraAutoProvBatchSize`::
-
-    Domain | Global setting to define the maximum number of accounts to
-    process in each interval for EAGER auto provision.
+Domain | Global setting to define the maximum number of accounts to
+process in each interval for EAGER auto provision.
 
 `zimbraAutoProvScheduledDomains`::
-
-    Server attribute that lists the domains scheduled for EAGER auto
-    provision on this server.  Scheduled domains must have EAGER mode
-    enabled in `zimbraAutoProvMode`.  Multiple domains can be scheduled on a
-    server for EAGER auto provision.  Also, a domain can be scheduled on
-    multiple servers for EAGER auto provision.
+Server attribute that lists the domains scheduled for EAGER auto
+provision on this server.  Scheduled domains must have EAGER mode
+enabled in `zimbraAutoProvMode`.  Multiple domains can be scheduled on
+a server for EAGER auto provision.  Also, a domain can be scheduled on
+multiple servers for EAGER auto provision.
 
 `zimbraAutoProvPollingInterval`::
-
-    Domain | Global setting to define the interval between successive
-    polling and provisioning accounts in EAGER mode.  The actual interval
-    might take longer since it can be affected by two other factors:
-    `zimbraAutoProvBatchSize` and number of domains configured in
-    `zimbraAutoProvScheduledDomains`.
+Domain | Global setting to define the interval between successive
+polling and provisioning accounts in EAGER mode.  The actual interval
+might take longer since it can be affected by two other factors:
+`zimbraAutoProvBatchSize` and number of domains configured in
+`zimbraAutoProvScheduledDomains`.
 +
-At each interval, the auto provision thread iterates through all domains in
-`zimbraAutoProvScheduledDomains` and auto creates accounts up to
-`domain.zimbraAutoProvBatchSize`.  If that process takes longer than
-`zimbraAutoProvPollingInterval` than the next iteration starts immediately
-instead of waiting for `zimbraAutoProvPollingInterval` amount of time.
+At each interval, the auto provision thread iterates through all
+domains in `zimbraAutoProvScheduledDomains` and auto creates accounts
+up to `domain.zimbraAutoProvBatchSize`.  If that process takes longer
+than `zimbraAutoProvPollingInterval` than the next iteration starts
+immediately instead of waiting for `zimbraAutoProvPollingInterval`
+amount of time.
 +
 * If set to 0 when server starts up, the auto provision thread will not
 start.
@@ -748,28 +715,26 @@ provision thread will be shutdown.
 * If changed from 0 to a non-0 value while server is running, the auto
 provision thread will be started.
 
-=== Place holders
+[[auto_provisioning_placeholders]]
+=== Placeholders
 
-Table 22: Place holders for use with auto provisioning attributes
-
-[cols=",,",options="header",]
+.Placeholders for use with auto provisioning attributes
+[cols="1,2,2",options="header",]
 |=======================================================================
 |Tag |Description |Result
 
-|%/n |User name and the @ symbol  |This returns _user1@domain.com_
+|%/n |User name and the @ symbol  |This returns _user1@example.com_
 
 |%u |User name without the @ symbol  |This returns _user1_.
 
-|%d |Domain  |This returns _domain_._com_
+|%d |Domain  |This returns _example.com_
 
-|%D |Domain as dc |This returns _domain,dc=com_
+|%D |Domain as dc |This returns _example,dc=com_
 
 |=======================================================================
 
 [[eager_mode_configuration]]
 === Eager Mode Configuration
-.CLI
-****
 
 With Eager mode, {product-abbrev} polls the external directory for accounts to auto
 provision.  You configure how often the external directory is polled for
@@ -778,26 +743,29 @@ domains to be scheduled for account auto-provisioning on specified servers.
 
 . Log in to the {product-abbrev} server as zimbra and type zmprov at the command
 prompt.
++
+[source,bash]
+----
+zmprov
+----
 
 . Enable EAGER mode on the domain.
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvMode EAGER
+md <example.com> zimbraAutoProvMode EAGER
 ----
 
 . Set the maximum number of accounts to process in each interval
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvBatchSize <#>
+md <example.com> zimbraAutoProvBatchSize <#>
 ----
 
 . Configure the interval (in minutes) between polling and provisioning of
 accounts.  This must be set to a non-0 value for the auto provisioning
-thread to start.
-+
-Default =15 minutes.
+thread to start. Default = 15 minutes.
 +
 [source,bash]
 ----
@@ -811,7 +779,8 @@ A domain can be scheduled on multiple servers.
 +
 [source,bash]
 ----
-ms <server.com> +zimbraAutoProvScheduledDomains <domain1.com> +zimbraAutoProvScheduledDomains <domain2.com>
+ms <server.com> +zimbraAutoProvScheduledDomains <domain1.com> \
+  +zimbraAutoProvScheduledDomains <domain2.com>
 ----
 
 . Configure the external LDAP settings:
@@ -820,7 +789,7 @@ ms <server.com> +zimbraAutoProvScheduledDomains <domain1.com> +zimbraAutoProvSch
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvLdapURL “ldap:// xxx.xxx.xxx.xxx:<port>
+md <example.com> zimbraAutoProvLdapURL "ldap://xxx.xxx.xxx.xxx:<port>"
 ----
 +
 The LDAP port is typically 389.
@@ -829,17 +798,17 @@ The LDAP port is typically 389.
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvLdapStartTlsEnabled TRUE
+md <example.com> zimbraAutoProvLdapStartTlsEnabled TRUE
 ----
 
 .. LDAP admin bind DN for auto provision:
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvLdapAdminBindDn "cn=admin, dc=autoprov, dc=company, dc=com"
+md <example.com> zimbraAutoProvLdapAdminBindDn "cn=admin, dc=autoprov, dc=company, dc=com"
 ----
 
-.. Administrator’s LDAP search bind password for auto provision.
+.. Administrator's LDAP search bind password for auto provision.
 +
 [source,bash]
 ----
@@ -852,10 +821,10 @@ Example using the LDAP search filter:
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvLdapSearchFilter “(uid=<%placeholder>)”
+md <example.com> zimbraAutoProvLdapSearchFilter "(uid=<%placeholder>)"
 ----
 +
-Refer to <<auto_provisioning_placeholders,Place Holders>> for supported
+Refer to <<auto_provisioning_placeholders,Placeholders>> for supported
 placeholders.
 
 ..  LDAP search base for auto provisioning
@@ -866,12 +835,11 @@ LDAP directory root, `rootDSE`, is the starting point.
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvLdapSearchBa
-
-md <domain.com> zimbraAutoProvLdapBindDn <“placeholder1”>
+md <example.com> zimbraAutoProvLdapSearchBase "dc=autoprov,dc=company,dc=com"
+md <example.com> zimbraAutoProvLdapBindDn <"placeholder1">
 ----
 +
-Refer to <<auto_provisioning_placeholders,Place Holders>> for supported
+Refer to <<auto_provisioning_placeholders,Placeholders>> for supported
 placeholders.
 
 . (Optional) Define the attribute name that is mapped to the local part of
@@ -881,7 +849,7 @@ account name is the principal user name used to authenticate to {product-abbrev}
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvAccountNameMap < value>
+md <example.com> zimbraAutoProvAccountNameMap <value>
 ----
 
 . (Optional) Map the attribute values from the external entry to the {product-abbrev}
@@ -898,7 +866,7 @@ description on the {product-abbrev} account, type
 +
 [source,bash]
 ----
-md <domain.com> +zimbraAutoProvAttrMap sn=displayName +zimbraAutoProvAttrMap description=description
+md <example.com> +zimbraAutoProvAttrMap sn=displayName +zimbraAutoProvAttrMap description=description
 ----
 
 . (Optional) If you want to send a Welcome email to new accounts, enter the
@@ -906,7 +874,7 @@ _from_ address of the originator.
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvNotificationFromAddress <name@domain.com>
+md <example.com> zimbraAutoProvNotificationFromAddress <name@example.com>
 ----
 
 .  To exit zmprov, type
@@ -915,11 +883,8 @@ md <domain.com> zimbraAutoProvNotificationFromAddress <name@domain.com>
 ----
 exit
 ----
-****
 
 === Lazy Mode Configuration
-.CLI
-****
 Lazy mode auto provisioning automatically creates a new account after a
 user authenticates from an external authentication mechanisms (LDAP,
 preauth, Kerberos 5, and/or Spnego).
@@ -931,7 +896,7 @@ prompt.
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvMode LAZY
+md <example.com> zimbraAutoProvMode LAZY
 ----
 
 . Select the external authentication mechanism for the LAZY mode: LDAP,
@@ -948,7 +913,7 @@ md <example.com> zimbraAutoProvAuthMech <type> +zimbraAutoProvAuthMech <type2>
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvLdapURL "ldap:// xxx.xxx.xxx.xxx:<port>"
+md <example.com> zimbraAutoProvLdapURL "ldap://xxx.xxx.xxx.xxx:<port>"
 ----
 +
 The LDAP port is usually 389.
@@ -957,7 +922,7 @@ The LDAP port is usually 389.
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvLdapStartTlsEnabled TRUE
+md <example.com> zimbraAutoProvLdapStartTlsEnabled TRUE
 ----
 
 ..  LDAP Admin bind DN for auto provision in the format
@@ -965,12 +930,12 @@ md <domain.com> zimbraAutoProvLdapStartTlsEnabled TRUE
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvLdapAdminBindDn <"bindDN">
+md <example.com> zimbraAutoProvLdapAdminBindDn <"bindDN">
 ----
 +
 For example, `"cn=admin, dc=autoprov, dc=company, dc=com"`
 
-..  Administrator’s LDAP search bind password for auto provision.
+..  Administrator's LDAP search bind password for auto provision.
 +
 [source,bash]
 ----
@@ -984,10 +949,10 @@ Example: using LDAP search filter:
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvLdapSearchFilter <"placeholder">
+md <example.com> zimbraAutoProvLdapSearchFilter <"placeholder">
 ----
 +
-Refer to <<auto_provisioning_placeholders,Place Holders>> for supported
+Refer to <<auto_provisioning_placeholders,Placeholders>> for supported
 placeholders.
 +
 [NOTE]
@@ -1001,7 +966,7 @@ the LDAP directory root, `rootDSE`, is the starting point.
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvLdapSearchBase <"location">
+md <example.com> zimbraAutoProvLdapSearchBase <"location">
 ----
 +
 For example, `"dc=autoprov,dc=company,dc-com"`
@@ -1011,10 +976,11 @@ provisioning.
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvLdapBindDn "uid=%<placeholder1>, %<placeholder2>"
+md <example.com> zimbraAutoProvLdapBindDn "uid=%<placeholder1>, %<placeholder2>"
 ----
 +
-Refer to <<auto_provisioning_placeholders,Place Holders>> for supported placeholders.
+Refer to <<auto_provisioning_placeholders,Placeholders>> for supported
+placeholders.
 
 . (Optional) Identify the attribute name on the external entry that
 contains the local part of the account name to be provisioned in {product-abbrev}.  If
@@ -1023,7 +989,7 @@ user used to authenticate to {product-abbrev}.
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvAccountNameMap <value>
+md <example.com> zimbraAutoProvAccountNameMap <value>
 ----
 
 . (Optional) Map the attribute values from the external entry to the {product-abbrev}
@@ -1037,7 +1003,7 @@ the {product-abbrev} account, type as
 +
 [source,bash]
 ----
-md <domain.com> +zimbraAutoProvAttrMap sn=displayName +zimbraAutoProvAttrMap description=description
+md <example.com> +zimbraAutoProvAttrMap sn=displayName +zimbraAutoProvAttrMap description=description
 ----
 
 . (Optional)  If you want to send a *Welcome* email to new accounts, enter
@@ -1045,16 +1011,13 @@ the _from_ address of the originator.
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvNotificationFromAddress <name@domain.com>
+md <example.com> zimbraAutoProvNotificationFromAddress <name@example.com>
 ----
 
 . Exit zmprov, type `exit`.
-****
 
 === Manual Mode Configuration
 
-.CLI
-****
 Use the Manual Mode setting to disable auto provisioning with an external
 LDAP server.
 
@@ -1065,9 +1028,8 @@ command prompt.
 +
 [source,bash]
 ----
-md <domain.com> zimbraAutoProvMode MANUAL
+md <example.com> zimbraAutoProvMode MANUAL
 ----
-****
 
 == Managing Resources
 
@@ -1114,24 +1076,24 @@ if these are set up.
 
 When the meeting invite is sent, an email is sent to the resource account,
 and, based on the scheduling policy, if the resource is free the meeting is
-automatically entered in the resource’s calendar and the resource is shown
+automatically entered in the resource's calendar and the resource is shown
 as Busy.
 
 === Set Up the Scheduling Policy
 
-The scheduling policy establishes how the resource’s calendar is
+The scheduling policy establishes how the resource's calendar is
 maintained.  The following resource scheduling values can be set up:
 
-* *Auto decline all recurring appointments*.  This value is enabled when
+* *Auto decline all recurring appointments* -- This value is enabled when
 theresource can be scheduled for only one meeting at a time.  No recurring
 appointments can be scheduled for this resource.
 
-* *Auto accept if available, auto-decline on conflict*.  When this option
+* *Auto accept if available, auto-decline on conflict* -- When this option
 isselected, the resource account automatically accepts appointments unless
 the resource is already scheduled.  The free/busy times can be viewed.  You
 can modify the auto-decline rule to accept some meetings that conflict.
 
-* *Manual accept, auto decline on conflict*.  When this option is selected,
+* *Manual accept, auto decline on conflict* -- When this option is selected,
 theresource account automatically declines all appointments that conflict.
 Appointment requests that do not conflict are marked as tentative in the
 resource calendar and must be manually accepted.  If you set this up,
@@ -1139,7 +1101,7 @@ configure the forwarding address so a copy of the invite is sent to the
 account that can manually accept the invitation.  You can modify the
 auto-decline rule to accept some meetings that conflict.
 
-* *Auto accept always*.  The resource account automatically accepts
+* *Auto accept always* -- The resource account automatically accepts
 allappointments that are scheduled.  In this case, free/busy information is
 not maintained, thus more than one meeting could schedule the resource at
 the same time.  Because the resource always accepts the invitation, the
@@ -1147,18 +1109,18 @@ suggested use for this policy would be for a frequently used location off
 premises that you want the location address to be included in the invite to
 attendees.
 
-* *No auto accept or decline*.  The resource account is manually managed.
-Adelegated user must log into the resource account and accept or decline
+* *No auto accept or decline* -- The resource account is manually managed.
+A delegated user must log into the resource account and accept or decline
 all requests.
 
-*Conflict Rules* For accounts that include the auto decline on conflict
-value, youcan set up a threshold, either as a number of conflicts or as a
+*Conflict Rules* -- For accounts that include the auto decline on conflict
+value, you can set up a threshold, either as a number of conflicts or as a
 percentage of all the recurring appointments to partially accept recurring
 appointments.
 
 *Maximum allowed number of conflicts* and/or *Maximum allowed percent of
 conflicts* are configured to allow a recurring resource to be scheduled
-even if itis not available for all the requested recurring appointment
+even if it is not available for all the requested recurring appointment
 dates.
 
 The resource accepts appointments even if there are conflicts until either
@@ -1170,7 +1132,7 @@ series to work, both fields must be set to nonzero values.
 
 You can log on to the resource account and set preferences for the
 resource.  The *Resource Accounts Preference > Calendar* can be configured
-to let users manage the Resource’s Calendar.  You can configure the
+to let users manage the Resource's Calendar.  You can configure the
 following options to manage the resource.
 
 * An address to forward invites.  If the forwarding address was set up when
@@ -1178,7 +1140,7 @@ the account was provisioned, you can change the address
 
 * Who can use this resource.  In the Permissions section, Invites, select
 *Allow only the following internal users to invite me to meetings* and add
-*theappropriate users' email addresses to the list.
+the appropriate users' email addresses to the list.
 
 You can share the resource calendar with a user and give the user Manager
 rights.  Users delegated as Manager have full administrative rights for

--- a/proxy.adoc
+++ b/proxy.adoc
@@ -26,14 +26,14 @@ Benefits for using Zimbra Proxy include:
 * URL Rewriting
 
 For more information, see the wiki page
-http://wiki.zimbra.com/wiki/Zimbra_Proxy_Guide[Zimbra_Proxy_Guide].
+https://wiki.zimbra.com/wiki/Zimbra_Proxy_Guide[Zimbra_Proxy_Guide].
 
 == Zimbra Proxy Components
 
 Zimbra Proxy is designed to provide a HTTP/POP/IMAP proxy that is quick,
 reliable, and scalable. Zimbra Proxy includes the following:
 
-[cols=",",options="header",]
+[cols="1,2",options="header",]
 |=======================================================================
 |Component |Description
 
@@ -82,7 +82,7 @@ connecting directly to {product-name} Mailbox.
 == Changing the Zimbra Proxy Configuration
 
 When Zimbra proxy is configured, the Zimbra proxy config performs keyword
-substitution as necessary with values from the . LDAP configuration and
+substitution as necessary with values from the LDAP configuration and
 localconfig.
 
 If changes are required after the Zimbra Proxy is set up, modify the Zimbra
@@ -177,8 +177,6 @@ master.
 Use steps in this section if your configuration includes a
 separate proxy server.
 
-.CLI
-****
 . On each Zimbra mailbox server that you want to proxy with, enable the
 proxy for IMAP/POP proxy.
 +
@@ -190,21 +188,21 @@ proxy for IMAP/POP proxy.
 This configures the following:
 +
 --
-[cols=",",options="header",]
+[cols="m,",options="header",]
 |====================================================
 |Port Attributes |Setting
 
-|`zimbraImapBindPort` |7143
-|`zimbraImapProxyBindPort` |143
-|`zimbraImapSSLBindPort` |7993
-|`zimbraImapSSLProxyBindPort` |993
-|`zimbraPop3BindPort` |7110
-|`zimbraPop3ProxyBindPort` |110
-|`zimbraPop3SSLBindPort` |7995
-|`zimbraPop3SSLProxyBindPort` |995
-|`zimbralmapCleartextLoginEnabled` |TRUE
-|`zimbraReverseProxyLookupTarget` |TRUE
-|`zimbraPop3CleartextLoginEnabled` |TRUE
+|zimbraImapBindPort |7143
+|zimbraImapProxyBindPort |143
+|zimbraImapSSLBindPort |7993
+|zimbraImapSSLProxyBindPort |993
+|zimbraPop3BindPort |7110
+|zimbraPop3ProxyBindPort |110
+|zimbraPop3SSLBindPort |7995
+|zimbraPop3SSLProxyBindPort |995
+|zimbralmapCleartextLoginEnabled |TRUE
+|zimbraReverseProxyLookupTarget |TRUE
+|zimbraPop3CleartextLoginEnabled |TRUE
 
 |=======================================================================
 --
@@ -215,12 +213,9 @@ This configures the following:
 ----
 zmcontrol restart
 ----
-****
 
 *Set Up the Proxy Node*
 
-.CLI
-****
 On each proxy node that has the proxy service installed, enable the proxy
 for the web.
 [source,bash]
@@ -230,30 +225,27 @@ for the web.
 
 This configures the following:
 
-[cols=",",options="header",]
+[cols="m,",options="header",]
 |====================================================
 |*Port Attribute* |*Setting*
 
-|`zimbraImapBindPort` |7143
-|`zimbraImapProxyBindPort` |143
-|`zimbraImapSSLBindPort` |7993
-|`zimbraImapSSLProxyBindPort` |993
-|`zimbraPop3BindPort` |7110
-|`zimbraPop3ProxyBindPort` |110
-|`zimbraPop3SSLBindPort` |7995
-|`zimbraPop3SSLProxyBindPort` |995
-|`zimbraReverseProxyMailEnabled` |TRUE
+|zimbraImapBindPort |7143
+|zimbraImapProxyBindPort |143
+|zimbraImapSSLBindPort |7993
+|zimbraImapSSLProxyBindPort |993
+|zimbraPop3BindPort |7110
+|zimbraPop3ProxyBindPort |110
+|zimbraPop3SSLBindPort |7995
+|zimbraPop3SSLProxyBindPort |995
+|zimbraReverseProxyMailEnabled |TRUE
 |====================================================
 
-****
 
-*Setting Up a Single Node*
+==== Set Up a Single Node
 
 Use steps in this section if Zimbra proxy is installed with {product-name}
 on the same server.
 
-.CLI
-****
 . Enable the proxy for the web.
 +
 [source,bash]
@@ -264,22 +256,22 @@ on the same server.
 This configures the following:
 +
 --
-[cols=",",options="header",]
+[cols="m,",options="header",]
 |====================================================
 |Port Attribute |Setting
 
-|`zimbraImapBindPort` |7143
-|`zimbraImapProxyBindPort` |143
-|`zimbraImapSSLBindPort` |7993
-|`zimbraImapSSLProxyBindPort` |993
-|`zimbraPop3BindPort` |7110
-|`zimbraPop3ProxyBindPort` |110
-|`zimbraPop3SSLBindPort` |7995
-|`zimbraPop3SSLProxyBindPort` |995
-|`zimbraImapCleartextLoginEnabled` |TRUE
-|`zimbraReverseProxyLookupTarget` |TRUE
-|`zimbraPop3CleartextLoginEnabled` |TRUE
-|`zimbraReverseProxyMailEnabled` |TRUE
+|zimbraImapBindPort |7143
+|zimbraImapProxyBindPort |143
+|zimbraImapSSLBindPort |7993
+|zimbraImapSSLProxyBindPort |993
+|zimbraPop3BindPort |7110
+|zimbraPop3ProxyBindPort |110
+|zimbraPop3SSLBindPort |7995
+|zimbraPop3SSLProxyBindPort |995
+|zimbraImapCleartextLoginEnabled |TRUE
+|zimbraReverseProxyLookupTarget |TRUE
+|zimbraPop3CleartextLoginEnabled |TRUE
+|zimbraReverseProxyMailEnabled |TRUE
 |====================================================
 --
 
@@ -289,7 +281,6 @@ This configures the following:
 ----
 zmcontrol restart
 ----
-****
 
 == Configuring Zimbra HTTP Proxy
 
@@ -297,8 +288,8 @@ Zimbra Proxy can also reverse proxy HTTP requests to the right back-end
 server.
 
 For example, users can use a web browser to connect to the proxy server at
-http://mail.example.com. The connection from users whose mailboxes live on
-mbs1. example.com is proxied to mbs1.example.com by the proxy running on
+https://mail.example.com. The connection from users whose mailboxes live on
+mbs1.example.com is proxied to mbs1.example.com by the proxy running on
 the mail.example.com server, REST and CalDAV clients, Zimbra Connector for
 Outlook, Zimbra Connector for BES, and Zimbra Mobile Sync devices are also
 supported by the proxy.
@@ -307,7 +298,7 @@ supported by the proxy.
 When ZCB is configured in {product-name}, the proxy configuration
 must be changed from the directions here. See the Zimbra wiki article
 Installing Blackberry Enterprise Server in a Zimbra Proxy Environment at
-http://wiki.zimbra.com/wiki/Installing_Blackberry_Enterprise_Server_%28ZCB/BES%29_in_a_Zimbra_Proxy_Environment.
+https://wiki.zimbra.com/wiki/Installing_Blackberry_Enterprise_Server_%28ZCB/BES%29_in_a_Zimbra_Proxy_Environment.
 
 HTTP reverse proxy routes requests as follows:
 
@@ -339,8 +330,6 @@ configured in the LDAP master.
 Use steps in this section if your configuration includes a separate proxy
 server.
 
-.CLI
-****
 . On each Zimbra mailbox server that you want to proxy with, enable the
 proxy for the web.
 +
@@ -352,15 +341,15 @@ proxy for the web.
 This configures the following:
 +
 --
-[cols=",",options="header",]
+[cols="m,",options="header",]
 |====================================================
 |Attribute |Setting
 
-|`zimbraMailReferMode` |reverse-proxied.
-|`zimbraMailPort` |8080 (to avoid port conflicts)
-|`zimbraMailSSLPort` |8443 (to avoid port conflicts)
-|`zimbraReverseProxyLookupTarget` |TRUE
-|`zimbraMailMode` |HTTP
+|zimbraMailReferMode |reverse-proxied.
+|zimbraMailPort |8080 (to avoid port conflicts)
+|zimbraMailSSLPort |8443 (to avoid port conflicts)
+|zimbraReverseProxyLookupTarget |TRUE
+|zimbraMailMode |HTTP
 |====================================================
 --
 
@@ -378,12 +367,9 @@ REST URLs, email, and Briefcase folders.
 ----
 zmprov modifyDomain <domain.com> zimbraPublicServiceHostname <hostname.domain.com>
 ----
-****
 
 *Setting Up Proxy Node*
 
-.CLI
-****
 On each proxy node that has the proxy service installed, enable the proxy
 for the web.
 
@@ -394,33 +380,30 @@ for the web.
 
 This configures the following:
 
-[cols=",",options="header",]
+[cols="m,",options="header",]
 |=================================================================
 |Attribute |Setting
 
-|`zimbraMailReferMode` |
+|zimbraMailReferMode |
 reverse-proxied.
 To set the proxy server mail mode, add the -x option to the command, with
 the specific mode as either http, https, both, redirect, or mixed.
 
-|`zimbraMailProxyPort` |80 (to avoid port conflicts).
-|`zimbraMailSSLProxyPort` |443 (to avoid port conflicts).
-|`zimbraReverseProxyHttpEnabled` |TRUE (to indicate that Web proxy is enabled).
-|`zimbraReverseProxyMailMode` |HTTP (default)
+|zimbraMailProxyPort |80 (to avoid port conflicts).
+|zimbraMailSSLProxyPort |443 (to avoid port conflicts).
+|zimbraReverseProxyHttpEnabled |TRUE (to indicate that Web proxy is enabled).
+|zimbraReverseProxyMailMode |HTTP (default)
 
 |=================================================================
 
 To set the proxy server mail mode, add the `-x` option to the command
 with the specific mode: *http*, *https*, *both*, *redirect*, *mixed*.
-****
 
-*Set Up a Single Node for HTTP Proxy*
+==== Setting Up a Single Node for HTTP Proxy
 
 Use steps in this section if Zimbra proxy is installed along with {product-abbrev} on
 the same server.
 
-.CLI
-****
 . On each zimbra mailbox server that you want to proxy with, enable
 the proxy for the web.
 +
@@ -432,7 +415,7 @@ the proxy for the web.
 This configures the following:
 +
 --
-[cols=",",options="header",]
+[cols="m,",options="header",]
 |===============================================================
 |*Attribute* |*Setting*
 
@@ -468,7 +451,6 @@ URLs, email and Briefcase folders.
 ----
 zmprov modifyDomain <domain.com> zimbraPublicServiceHostname <hostname.domain.com>
 ----
-****
 
 *Set Up Proxy to use Clear Text for Upstream Connections*
 
@@ -524,8 +506,6 @@ localconfig `zimbra_http_originating_ip` header attribute. When a user logs
 in, this IP address and the user’s address are verified in the Zimbra
 mailbox log.
 
-.CLI
-****
 Set each proxy IP address in the attribute. For example, if you have two
 proxy servers:
 
@@ -550,8 +530,6 @@ zimbra_http originating_ip_header = X-Forwarded-For
 ----
 --
 
-****
-
 == Configuring Zimbra Proxy for Kerberos Authentication
 
 Use steps in this section if you use the Kerberos5 authenticating
@@ -559,10 +537,8 @@ mechanism, and want to configure it for the IMAP and POP proxy.
 
 [NOTE]
 Make sure that your Kerberos5 authentication mechanism is correctly
-configured. See <<zimbra_ldap_service, Zimbra LDAP Service>>
+configured. See <<zimbra_ldap_service,Zimbra LDAP Service>>
 
-.CLI
-****
 . On each proxy node, set the zimbraReverseProxyDefaultRealm server
 attribute to the realm name corresponding to the proxy server. For example:
 +
@@ -595,4 +571,3 @@ zmprov ms proxyl.isp.net zimbraReverseProxyPop3SaslGssapiEnabled TRUE
 ----
 zmproxyctl restart
 ----
-****

--- a/spnego.adoc
+++ b/spnego.adoc
@@ -112,48 +112,42 @@ The command to type follows:
 ktpass -out {keytab-file-to-produce} -princ {Service-Principal-Name}@\{the-kerberos-realm} -mapUser {AD-user} -mapOp set -pass {AD-user-password} -crypto RC4-HMAC-NT -pType KRB5_NT_PRINCIPAL
 ----
 +
-[cols=","]
+[cols="1m,4"]
 |=======================================================================
-|`Ktpass -out` |
-The key is written to this output file.
-
+|ktpass -out |
+The key is written to this output file. +
 Enter the directory location and keytab file name. The keytab file name is
-`jetty.keytab`.
-
+`jetty.keytab`. +
 For example, `C:\Temp\spengo\jetty.keytab`
 
-|`-princ` |
-This is the principal name.
-
+|-princ |
+This is the principal name. +
 Enter the service Principal Name as used in *Step 2* in Setting up the
-Microsoft Windows Active Directory Domain Controller section. For example,
-HTTP/mail1.example.com@COMPANY.COM
+Microsoft Windows Active Directory Domain Controller section. +
+For example, HTTP/mail1.example.com@COMPANY.COM
 
-|`-mapUser` |
-This maps `–princ` value to this user account.
-
+|-mapUser |
+This maps `–princ` value to this user account. +
 Enter the AD service account user name entered in the *User Logon Name
 (pre-Windows2000)* set in *Step 1.b* in Setting up the Microsoft Windows
 Active Directory Domain Controller section.
 
-|`-mapOp` |
+|-mapOp |
 This sets the mapping. The value for this parameter is *set*
 
-|`-pass` |
+|-pass |
 This is the password to use.
 
 Enter the password entered in the *User Logon Name (pre-Windows2000)* set
 in *Step 1.c* in Setting up the Microsoft Windows Active Directory Domain
 Controller section.
 
-|`-crypto` |
-This is the cryptosystem to use.
-
+|-crypto |
+This is the cryptosystem to use. +
 Enter *RC4-HMAC-NT*
 
-|`-pType` |
-Enter *KRB5_NT_PRINCIPAL*
-
+|-pType |
+Enter *KRB5_NT_PRINCIPAL* +
 To avoid warning messages from the toolkit enter this value.
 
 |=======================================================================
@@ -203,11 +197,11 @@ Only one Kerberos REALM is supported per {product-abbrev} installation.
 . Modify the following global config attributes, with the `zmprov mcf`
 command.
 +
-[cols=",",options=""]
+[cols="1m,2",options=""]
 |=======================================================================
-|`zimbraSpnegoAuthEnabled` |Set to TRUE.
+|zimbraSpnegoAuthEnabled |Set to TRUE.
 
-|`zimbraSpnegoAuthErrorURL` |
+|zimbraSpnegoAuthErrorURL |
 This is the URL users are redirected to when spnego auth fails. Setting it
 to `/zimbra/?ignoreLoginURL=1` will redirect user to the regular Zimbra
 login page, where user will be prompted for their zimbra user name and
@@ -230,12 +224,12 @@ To modify the global config attributes, type:
 . On each Zimbra server, modify the following global config attributes with
 the `zmprov ms` command.
 +
-[cols=",",options="",]
+[cols="1m,2",options="",]
 |=======================================================================
-|`zimbraSpnegoAuthTargetName` |
+|zimbraSpnegoAuthTargetName |
 This is the user logon name from Step 1 B, User Logon Name.
 
-|`zimbraSpnegoAuthPrincipal` |
+|zimbraSpnegoAuthPrincipal |
 Enter the user logon name set in `zimbraSpnegoAuthTargetName` and the
 address set in global config `zimbraSpnegoAuthRealm`
 

--- a/zimlets.adoc
+++ b/zimlets.adoc
@@ -59,10 +59,10 @@ immediately to everyone in the default COS. If a Zimlet is not deployed to
 another COS directly, the COS displays the Zimlets but they are not
 enabled.
 
-.Admin Console
-****
-*Configure > Zimlets*; go to *Gear* icon and select *Deploy*.
+Admin Console: ::
+*Home > Configure > Zimlets*, from the *Gear* icon select *Deploy*
 
+// divide definition above from list below
 . Browse to the Zimlet you want to deploy, then click *Deploy*.
 +
 The Zimlet deploys to the server. A dialog displays indicating the server
@@ -71,20 +71,18 @@ name where the Zimlet is deployed and the status of the deployment.
 . Click *Finish*.
 +
 Verify the Zimlet is enabled by viewing the Zimlets page.
-****
 
 === Enable, Disable, or Make Zimlets Mandatory
 
-You can enable or disable Zimlets, or make them mandatory. You can also use
-the toggle feature to enable or disable an installed Zimlet.
+You can enable, disable, or make Zimlets mandatory. You can also use
+the toggle feature to choose if an installed Zimlet will be made
+available for users to choose from.
 
-.Admin Console
-****
-On a class of service Zimlets page, select the default Zimlets you want
-to enable, disable, or make mandatory to users in the COS.
+Admin Console: ::
+*Home > Configure > Class of Service -> _COS_ -> Zimlets*
 
 .Zimlet Operational Status Settings.
-[cols=",",options="header",]
+[cols="1,4",options="header",]
 |=======================================================================
 |Setting |Description
 
@@ -104,20 +102,18 @@ All deployed Zimlets will be enabled.
 Users can enable or disable optional Zimlets from their account’s
 *Preferences > Zimlets* page. If you select a Zimlet as mandatory, it
 cannot be disabled by the user.
-****
 
 === Undeploying a Zimlet
 
 When a Zimlet is undeployed, it is removed from all COSs and then removed
 from the LDAP.
 
-.Admin Console
-****
-*Configure > Zimlets*; select the Zimlet to undeploy.
+Admin Console: ::
+*Home > Configure > Zimlets*
 
-. From the Gear icon menu select *Undeploy*.
+. Select a _Zimlet_ to undeploy.
+. From the *Gear* icon menu select *Undeploy*.
 . Click *Yes* to confirm.
-****
 
 === Adding Proxy-Allowed Domains to a Zimlet
 
@@ -126,9 +122,10 @@ accessed through a Zimlet. For the Zimlets that are included in {product-abbrev}
 allowed domains are already configured. If you download and deploy other
 Zimlets, you can add additional proxy domain names.
 
-.Admin Console
-****
-*Configure > Class of Service*; select the COS to edit.
+Admin Console: ::
+*Home > Configure > Class of Service*
+
+. Select the _COS_ to edit.
 
 . In the *Advanced* page, scroll down to the *Proxy Allowed Domains*
 section.
@@ -136,7 +133,6 @@ section.
 . Click *Add Domain* to add domains.
 
 . Click *Save*.
-****
 
 === Upgrading a Zimlet
 
@@ -144,14 +140,12 @@ Use the same steps as deploying a new Zimlet to upgrade a customized
 Zimlet. The new Zimlet zip file should have the same name as the existing
 Zimlet zip file.
 
-.Admin Console
-****
-*Configure > Zimlets;* from theGear icon menu select *Deploy*.
+Admin Console: ::
+*Home > Configure > Zimlets*, from the *Gear* icon select *Deploy*
 
 . Check *Flush Zimlet cache,* so that the upgraded zimlet will be used.
-. Browse to the Zimlet you want to upgrade, then click *Deploy*.
+. Browse to the _Zimlet_ you want to upgrade, then click *Deploy*.
 . Click *Finish*.
-****
 
 == Managing Zimlets from the Command Line Interface
 
@@ -185,23 +179,17 @@ When deploying a Zimlet, the COS attributes, `zimbraProxyAllowedDomains`,
 must be set for the domain address that the Zimlet might call to get
 information.
 
-.CLI
-****
 To set the `zimbraProxyAllowedDomains` attribute, type:
 [source,bash]
 ----
-zmprov mc <COSname> +zimbraProxyAllowedDomains <*.domain.com>
+zmprov mc <COSname> +zimbraProxyAllowedDomains '*.example.com'
 ----
 
-The `*` must be added before the `domain.com`.
+The `*` must be added before the `example.com`.
 
 This must be applied to all COSs that have your Zimlet enabled.
-****
 
 === Deploying a Zimlet and Granting Access to a COS
-
-.CLI
-****
 
 Use steps in this section to deploy a Zimlet to one or more COSs other than
 the default:
@@ -212,16 +200,8 @@ the default:
 +
 [source,bash]
 ----
-zmzimletctl deploy <path-to-zimlet.zip>
-----
-+
-.Deploy a Zimlet
-====
-[source,bash]
-----
 zmzimletctl deploy /tmp/<zimlet>.zip
 ----
-====
 
 . To deploy the zimlet to additional COSs, run:
 +
@@ -243,17 +223,13 @@ on each COS and add the allowed domains.
 +
 [source,bash]
 ----
-zmprov mc <COSname1> +zimbraProxyAllowedDomains <*.domain.com>
-
-zmprov mc <COSname2> +zimbraProxyAllowedDomains <*.domain.com>
+zmprov mc <COSname1> +zimbraProxyAllowedDomains '*.example.com'
+zmprov mc <COSname2> +zimbraProxyAllowedDomains '*.example.com'
 ----
-****
 
 === Viewing Installed Zimlets
 
-.CLI
-****
-Use the zmzimletctl command to view currently installed zimlets:
+Use the `zmzimletctl` command to view currently installed zimlets:
 
 [source,bash]
 ----
@@ -262,7 +238,6 @@ zmzimletctl listZimlets all
 
 The output from this command displays the Zimlets installed on the server,
 installed in LDAP, and those available by COS.
-****
 
 === Changing Zimlet Configurations
 
@@ -272,8 +247,6 @@ The Zimlet configuration template allows you to make changes on the
 configuration template and then install the new configuration file on the
 Zimbra server.
 
-.CLI
-****
 Use steps in this section to change a Zimlet configuration:
 
 . Extract the configuration template:
@@ -299,7 +272,6 @@ you changed the name of the configuration template, replace
 ----
 zmzimletctl configure config_template.xml
 ----
-****
 
 === Upgrading a Zimlet
 
@@ -310,8 +282,6 @@ used to deploy a new Zimlet.
 The new Zimlet zip file should be named identically to the existing Zimlet
 zip file.
 
-.CLI
-****
 Use steps in this section upgrade a zimlet:
 
 . Copy the Zimlet zip file to the `/opt/zimbra/zimlets-extra` directory,
@@ -334,7 +304,6 @@ your Zimlet includes a .jsp file, the .jsp file is also copied to the
 ----
 zmprov flushCache zimlet
 ----
-****
 
 === Using the Zimbra Gallery
 
@@ -345,4 +314,4 @@ the Extensions from the Zimbra Gallery section.
 === Developing Customized Zimlets
 
 To develop your own custom Zimlets, see the Zimlet Developers Guide on
-the Zimbra Wiki at https://wiki.zimbra.com/wiki/Main_Page.
+the Zimbra Wiki at https://wiki.zimbra.com.


### PR DESCRIPTION
- prefer https to http in URLs
- avoid smartquotes and emdashes
- fix typos and invalid examples
- fix some inconsistency of term usage (still more that could be done)
- fix some bogus data from format conversion
- attempt to improve some of the formatting conversion
- be more consistent with terms/verbiage
- take advantage of some table formatting/style capabilities
- MySQL to MariaDB in several places