### PR TITLE
ZMS-436 Updated ephemeral data storage configuration information

### DIFF
--- a/ephemeraldata.adoc
+++ b/ephemeraldata.adoc
@@ -31,6 +31,7 @@ Mail systems with large numbers of active users have been found to overload LDAP
 Configuring an already running {product-name} installation
 to utilize `SSDB` instead of `LDAP` for short lived data storage
 through the following process:
+
 1. Install `SSDB` and note the ip address and port configured since you will
    need this data for the next steps.
 2. Configure the {product-name} to utilize `SSDB`.

--- a/ephemeraldata.adoc
+++ b/ephemeraldata.adoc
@@ -1,0 +1,59 @@
+= Ephemeral Data
+
+There are 3 main types of ephemeral data stored in LDAP during normal operation of the {product-name}.
+
+      - Last Logon Time Stamps
+      - Auth Tokens
+      - CSRF Tokens
+
+Historically the only option for storage of these types of ephemeral data was in LDAP.
+Starting with version 8.8.0 the ability to save these types of ephemeral data using an external server has been implemented.  Note: This document does not cover how to install and maintain the ephemeral storage server.
+
+Configuring the storage location of ephemeral data is done through the following LDAP attribute:
+
+|====================
+| Attribute | Format | Description
+| zimbraEphemeralBackendURL | [backend name]:[params] | Ephemeral Backend URL Configuration
+|====================
+
+The two currently supported Ephemeral Data backends are:
+
+|====================
+| Backend | Format | Description
+| LDAP    | ldap://default |  Default configuration
+| SSDB    | ssdb:127.0.0.1:8888 | SSDB server and port
+|====================
+
+Mail systems with large numbers of active users have been found to overload LDAP as noted in  https://bugzilla.zimbra.com/show_bug.cgi?id=104858[Bugzilla 104858].
+
+== Post {product-name} Install Configuration
+
+Configuring an already running {product-name} installation
+to utilize `SSDB` instead of `LDAP` for short lived data storage
+through the following process:
+1. Install `SSDB` and note the ip address and port configured since you will
+   need this data for the next steps.
+2. Configure the {product-name} to utilize `SSDB`.
+3. Migrate any existing short-lived data to `SSDB` using the `/opt/zimbra/bin/zmmigrateattrs` command.
+
+==== Migration Procedure
+
+1. Access the command prompt on one of the machines in the installation.
+2. Configure the {product-name} to use `SSDB`:
+
+You may use either an ip address or a hostname for the host portion of the
+configuration item.  In this case you will need to ensure it resolves to the
+proper ip address on all machines in the cluster.
+
+----
+sudo su - zimbra
+zmprov mcf zimbraEphemeralDataURL ssdb:<ip address|hostname>:port # substituting your server values
+----
+
+[start=3]
+. Migrate any existing attributes from LDAP -> SSDB
+
+----
+sudo su - zimbra
+# Specify -r for a dry run
+/opt/zimbra/bin/zmmigrateattrs zimbraAuthTokens zimbraCsrfTokenData zimbraLastLogonTimestamp -n 4

--- a/glossary.adoc
+++ b/glossary.adoc
@@ -84,6 +84,9 @@ Edge MTA::
 Entry::
     An item in the directory server, such as an account or mail host.
 
+Ephemeral Data::
+    Data which is short lived or fast changing in nature. Login timestamps, authentication tokens, etc.
+
 Failover::
     Takeover process where a spare server machine detects that a main
     server is unavailable, and the spare takes over processing for that

--- a/index.adoc
+++ b/index.adoc
@@ -53,6 +53,10 @@ include::configuration.adoc[]
 
 <<<
 
+include::ephemeraldata.adoc[]
+
+<<<
+
 include::cos.adoc[]
 
 <<<


### PR DESCRIPTION
The other request was inadvertently closed and I couldn't see how to reopen it.
This commit was rebased to the end of the 'zms-dev' branch.

Additions:
========
- zmprov command to enable / change the ephemeral storage method
- zmmigrateattrs command detailing how to transition fully to ssdb