### PR TITLE
ZMS-634: updated admin docs

### DIFF
--- a/backuprestore.adoc
+++ b/backuprestore.adoc
@@ -1525,3 +1525,29 @@ zmplayredo --fromTime "2008/10/17 08:00:00:000"
 All data is brought forward to the current time and the standby site is
 set up and running. Data from 8:30:00 to 8:35:00 is lost but that is
 expected when the restore process is being carried out.
+
+
+== Notes on Ephemeral Data
+
+As of ZCS 8.8, ephemeral data is not backed up as part of the backup process.
+Since auth tokens are ephemeral attributes, the implication is that clients
+accessing accounts restored after deletion will need to re-authenticate;
+auth tokens generated prior to the backup will no longer work.
+
+The Jira ticket ZMS-614 has been opened to track the potential future development
+of ephemeral data backups.
+
+==== Backups with SSDB Backend
+
+If SSDB is used as the ephemeral backend, a backup will not include any ephemeral
+attributes. All authentication data is lost, including the last logon timestamp.
+As a result, the "Last Login" column in Accounts section of the admin console
+will display "Never logged in" for restored accounts. If a specific need for this
+data arises, all authentication events are logged in the audit.log file. Customers
+considering migrating to an SSDB backend should be aware of this limitation.
+
+==== Backups with LDAP backend
+
+If the ephemeral backend is LDAP, a backup will not include auth tokens or CSRF
+tokens, but it will include the last logon timestamp. Upon account restore,
+the appropriate "Last Login" value in the admin console will be restored.

--- a/ephemeraldata.adoc
+++ b/ephemeraldata.adoc
@@ -82,7 +82,9 @@ Ephemeral data migration is a one-way process. The `zmmigrateattrs` script does 
 
 === Changes to zmprov
 
-Due to changes in the way multi-valued ephemeral data is stored, the attributes `zimbraAuthTokens` and `zimbraCsrfTokenData` are no longer returned as part of the `zmprov ga <account>` response. The value of `zimbraLastLogonTimestamp` is returned as before.
+Due to changes in the way multi-valued ephemeral data is stored, the attributes `zimbraAuthTokens` and `zimbraCsrfTokenData` are no longer returned as part of the `zmprov ga <account>` response. The value of `zimbraLastLogonTimestamp` is returned as before, although
+only if the -l flag is not used, as adding the -l flag will restrict the server to accessing attributes in LDAP only.
+It is still possible to modify these attributes using the `zmprov ma <account>` command, regardless of the ephemeral backend. In order to do this, the provided attribute value must match its LDAP format: `tokenId|expiration|serverVersion` for auth tokens; `data:crumb:expiration` for CSRF tokens.
 
 === Migration In-Progress Flag
 
@@ -91,3 +93,9 @@ The `zmmigrateattrs` script sets a flag in `SSDB` at the beginning of the migrat
 === Migration CSV Output
 
 Each run of `zmmigrateattrs` generates a CSV file in `/opt/zimbra/data/tmp/` directory. The file contains migration info for every migrated account. If any migrations fail, a cutdown CSV file report detailing only the errors is also created in the same directory. The name(s) of the file(s) are logged at the end of the run.
+
+=== Account Deletion Behavior
+
+Ephemeral data deletion behavior differs slightly between SSDB and LDAP backends. With SSDB as the backend, account deletion results in
+the `zimbraLastLogonTimestamp` attribute being explicitly deleted from SSDB. `zimbraAuthTokens` and `zimbraCsrfTokenData`, however, are
+left to be expired by SSDB when the token lifetimes are reached (default of 2 days). Conversely, ephemeral data in LDAP is wiped immediately as part of the account deletion process.


### PR DESCRIPTION
- Updated backuprestore.adoc with information about backup/restore behavior with respect to ephemeral data.
- Updated ephemeraldata.adoc with notes on account deletion behavior, as well as improved documentation on modifying ephemeral data with `zmprov` 