### PR TITLE
ZCS-1451: notes on flushing cache after adding imap node

### DIFF
--- a/backuprestore.adoc
+++ b/backuprestore.adoc
@@ -1537,7 +1537,7 @@ auth tokens generated prior to the backup will no longer work.
 The Jira ticket ZMS-614 has been opened to track the potential future development
 of ephemeral data backups.
 
-==== Backups with SSDB Backend
+=== Backups with SSDB Backend
 
 If SSDB is used as the ephemeral backend, a backup will not include any ephemeral
 attributes. All authentication data is lost, including the last logon timestamp.
@@ -1546,7 +1546,7 @@ will display "Never logged in" for restored accounts. If a specific need for thi
 data arises, all authentication events are logged in the audit.log file. Customers
 considering migrating to an SSDB backend should be aware of this limitation.
 
-==== Backups with LDAP backend
+=== Backups with LDAP backend
 
 If the ephemeral backend is LDAP, a backup will not include auth tokens or CSRF
 tokens, but it will include the last logon timestamp. Upon account restore,

--- a/imapd.adoc
+++ b/imapd.adoc
@@ -11,3 +11,5 @@ Whenever a new IMAPD node is installed in a ZCS cluster that is not a mailboxd i
 throttle the new server.  Failure to do so will cause SOAP traffic from the Remote IMAPD node to be throttled leading to unexpected communication errors.
 
 Alternatively the DoSFilter can be effectively disabled by adding the ip address subnet that the new machine lives on to the '''zimbraHttpThrottleSafeIPs''' configuration item.
+
+Lastly, when an IMAPD node is added to a ZCS cluster, the globalconfig LDAP cache must be flushed on all ZCS servers listed in '''zimbraReverseProxyAvailableLookupTargets'''. This is necessary to ensure that the new node is added to '''zimbraReverseProxyUpstreamImapServers''' attribute; without this step, the lookup extension on these servers will not be aware of the newly-provisioned IMAP node. To do this, run the command `zmprov flushCache -a config`. To verify that this has taken effect, make sure that the new IMAPD node is listed in the output of `zmprov gacf zimbraReverseProxyUpstreamImapServers`, when run from a lookup target server.

--- a/remote_imap.adoc
+++ b/remote_imap.adoc
@@ -15,7 +15,7 @@ Example multi-node environment:
 <<<
 
 
-=== IMAPD Server selection
+== IMAPD Server selection
 
 The {product-name} Proxy selects the IMAPD server to send IMAP(S) requests to based
 on the configured IMAP load balancing strategy.
@@ -28,7 +28,7 @@ Currently the following load balancing strategies exist:
 NOTE: When the custom load balancing class CAN NOT be found the load balancing algorithm
       falls back to the *ClientIPHash* algorithm.
 
-=== Client Request Flow
+== Client Request Flow
 
 image:images/zimbra-client-request-flow.png[Client Request Flow,400,400,float="right"]
 


### PR DESCRIPTION
Added a paragraph about flushing the LDAP cache after adding an imapd node.