### PR TITLE
ZCS-2402 document upgrade scenario requirement

### DIFF
--- a/imap_upstream.adoc
+++ b/imap_upstream.adoc
@@ -161,6 +161,8 @@ zmprov mcf +zimbraReverseProxyUpstreamImapServers <server1> \
   +zimbraReverseProxyUpstreamImapServers <server2> \
  ...
 ----
+[NOTE]
+In an upgrade scenario values MUST BE assigned to `zimbraReverseProxyUpstreamImapServers` at the server level until all mailbox servers have been updated.
 +
 4. Flush the config cache on lookup servers: `zmprov -a fc config`
 5. If `zimbraMemcachedClientExpirySeconds` was decreased prior to this
@@ -180,7 +182,3 @@ you will need to modify them on the mailbox servers via `zmprov ms <server>..`
 +
 7. Reset `zimbraMemcachedClientExpirySeconds` to the original value if
 necessary.
-
-
-
-


### PR DESCRIPTION
Unsure if this is the best place to call out the requirement to assign server level `zimbraReverseProxyUpstreamImapServers` in respect to upgrades.
