### PR TITLE
Replace "subject" to "body"

### DIFF
--- a/imapd.adoc
+++ b/imapd.adoc
@@ -7,9 +7,21 @@ When installed on the same node as a *mailbox server* the mailbox's internal IMA
 
 In installations which have very heavy IMAP usage it is the recommended practice to install IMAPD on separate nodes from the *mailbox* processes to allow for horizontal scaling of IMAPD resources independently from the mailbox nodes.
 
+[IMPORTANT]
+===============================
 Whenever a new IMAPD node is installed in a ZCS cluster that is not a mailboxd it MUST BE added to the '''zimbraHttpThrottleSafeIPs''' configuration item or the DosFilter will
 throttle the new server.  Failure to do so will cause SOAP traffic from the Remote IMAPD node to be throttled leading to unexpected communication errors.
 
 Alternatively the DoSFilter can be effectively disabled by adding the ip address subnet that the new machine lives on to the '''zimbraHttpThrottleSafeIPs''' configuration item.
+===============================
 
-Lastly, when an IMAPD node is added to a ZCS cluster, the globalconfig LDAP cache must be flushed on all ZCS servers listed in '''zimbraReverseProxyAvailableLookupTargets'''. This is necessary to ensure that the new node is added to '''zimbraReverseProxyUpstreamImapServers''' attribute; without this step, the lookup extension on these servers will not be aware of the newly-provisioned IMAP node. To do this, run the command `zmprov flushCache -a config`. To verify that this has taken effect, make sure that the new IMAPD node is listed in the output of `zmprov gacf zimbraReverseProxyUpstreamImapServers`, when run from a lookup target server.
+[IMPORTANT]
+When an IMAPD node is added to a ZCS cluster, the globalconfig LDAP cache must be flushed on all ZCS servers listed in '''zimbraReverseProxyAvailableLookupTargets'''. This is necessary to ensure that the new node is added to '''zimbraReverseProxyUpstreamImapServers''' attribute; without this step, the lookup extension on these servers will not be aware of the newly-provisioned IMAP node. To do this, run the command `zmprov flushCache -a config`. To verify that this has taken effect, make sure that the new IMAPD node is listed in the output of `zmprov gacf zimbraReverseProxyUpstreamImapServers`, when run from a lookup target server.
+
+[IMPORTANT]
+Do NOT configure a load balancer between the Zimbra HTTP Proxy node and any remote IMAPD servers as this will interfere
+with correct operation.
+
+[IMPORTANT]
+The zmlocalconfig setting *nio_imap_enabled* MUST have value *true* when using the Zimbra IMAPD server.  The legacy
+Imap server which does not use NIO is not supported.


### PR DESCRIPTION
In the section of "Auto-Provisioning Attributes",  zimbraAutoProvNotificationBody is incorrectly described as follows:
Template used to construct the subject of the notification message sent to the user when the user’s account is auto provisioned.

I think the "subject" should be replaced to "body" in this context.