### PR TITLE
add a comment about non-HTTP protocols

### DIFF
--- a/cos.adoc
+++ b/cos.adoc
@@ -256,7 +256,7 @@ zmprov md example.com zimbraChangePasswordURL https://auth.example.com
 ----
 
 === Configuring a Password Policy
-
+[[passwordpolicy]]
 If internal authentication is configured for the domain, you can require
 users to create strong passwords to guard against simple password
 harvest attacks. Users can be locked out of their accounts if they fail

--- a/monitoring.adoc
+++ b/monitoring.adoc
@@ -240,10 +240,10 @@ with `iostat -x`).
 == Configuring Denial of Service Filter Parameters
 
 The denial-of-service filter (DoSFilter) limits exposure to requests
-flooding.  The DoSFilter throttles clients sending a large number of
+flooding over HTTP/HTTPS.  The DoSFilter throttles clients sending a large number of
 requests over a short period of time.
 
-The DoSFilter is enabled by default on {product-abbrev} and is applied to all requests.
+The DoSFilter is enabled by default on {product-abbrev} and is applied to all HTTP and HTTPS requests. DosFilter dis not applied to POP3, IMAP or SMTP requests.
 You can modify the configuration to accommodate your specific environmental
 needs.  Disabling the DoSFilter is not recommended.
 

--- a/monitoring.adoc
+++ b/monitoring.adoc
@@ -243,9 +243,7 @@ The denial-of-service filter (DoSFilter) limits exposure to requests
 flooding over HTTP/HTTPS.  The DoSFilter throttles clients sending a large number of
 requests over a short period of time.
 
-The DoSFilter is enabled by default on {product-abbrev} and is applied to all HTTP and HTTPS requests. DosFilter dis not applied to POP3, IMAP or SMTP requests.
-You can modify the configuration to accommodate your specific environmental
-needs.  Disabling the DoSFilter is not recommended. For information on preventing multiple failed login attempts see  <<cos.adoc#passwordpolicy,Password Policy>>
+DosFilter is only applied to HTTP and HTTPS requests, in other words, it does not affect requests for any other protocols like POP3, IMAP or SMTP. You can modify the configuration to accommodate your specific environmental needs. DoSFilter is enabled by default on {product-abbrev}. Disabling the DoSFilter is not recommended. For information on preventing multiple failed login attempts see <<cos.adoc#passwordpolicy,Password Policy>>
 
 === Identifying False Positives
 

--- a/monitoring.adoc
+++ b/monitoring.adoc
@@ -245,7 +245,7 @@ requests over a short period of time.
 
 The DoSFilter is enabled by default on {product-abbrev} and is applied to all HTTP and HTTPS requests. DosFilter dis not applied to POP3, IMAP or SMTP requests.
 You can modify the configuration to accommodate your specific environmental
-needs.  Disabling the DoSFilter is not recommended.
+needs.  Disabling the DoSFilter is not recommended. For information on preventing multiple failed login attempts see  <<cos.adoc#passwordpolicy,Password Policy>>
 
 === Identifying False Positives
 


### PR DESCRIPTION
to address the concern raised on BZ : https://bugzilla.zimbra.com/show_bug.cgi?id=108217, add text to clarify that Jetty DosFilter applies only to HTTP/HTTPS