### PR TITLE
ZCS-3317: fixed 13 bugs among 38.

### DIFF
--- a/imap_upstream.adoc
+++ b/imap_upstream.adoc
@@ -126,7 +126,7 @@ connections of existing IMAP clients.
 Prior to changing any configuration, it should be decided how existing
 routes in `memcached` will be handled. By default, routes are cached in
 `memcached` for 1 day, as specified by the
-`zimbraMemcachedClientExpirySeconds` LDAP attribute. If untouched, it
+`zimbraReverseProxyCacheEntryTTL` LDAP attribute. If untouched, it
 will take this long for the cached routes to expire and for the lookup
 extension to send IMAP traffic to the newly provisioned imapd
 servers. There are two things that can be done to change this
@@ -136,7 +136,7 @@ behavior:
 complete. This will cause all existing IMAP sessions to be restarted
 on the new servers.
 2. One day prior to switching to the imapd pool, modify the value
-`zimbraMemcachedClientExpirySeconds` of to a shorter interval, such as
+`zimbraReverseProxyCacheEntryTTL` of to a shorter interval, such as
 30 minutes, and reload the `memcached` configuration with the command
 `zmprov rmcc all`. Doing so will allow embedded IMAP to be turned off
 within a shorter timeframe without risking service interruptions.
@@ -163,7 +163,7 @@ zmprov mcf +zimbraReverseProxyUpstreamImapServers <server1> \
 ----
 +
 4. Flush the config cache on lookup servers: `zmprov -a fc config`
-5. If `zimbraMemcachedClientExpirySeconds` was decreased prior to this
+5. If `zimbraReverseProxyCacheEntryTTL` was decreased prior to this
 change, wait the corresponding amount of time for the existing routes
 to expire. This will allow routes in memcached to switch over to the
 new routes. Otherwise, flush memcached manually. It is recommended
@@ -178,7 +178,7 @@ zmprov mcf zimbraImapSSLServerEnabled FALSE
 [NOTE] If these settings were overridden at the at the server level,
 you will need to modify them on the mailbox servers via `zmprov ms <server>..`
 +
-7. Reset `zimbraMemcachedClientExpirySeconds` to the original value if
+7. Reset `zimbraReverseProxyCacheEntryTTL` to the original value if
 necessary.
 
 

--- a/imap_upstream.adoc
+++ b/imap_upstream.adoc
@@ -135,11 +135,9 @@ behavior:
 1. Flush `memcached` after the imapd pool configuration is
 complete. This will cause all existing IMAP sessions to be restarted
 on the new servers.
-2. One day prior to switching to the imapd pool, modify the value
-`zimbraReverseProxyCacheEntryTTL` of to a shorter interval, such as
-30 minutes, and reload the `memcached` configuration with the command
-`zmprov rmcc all`. Doing so will allow embedded IMAP to be turned off
-within a shorter timeframe without risking service interruptions.
+2. One day prior to switching to the imapd pool, modify the value of
+`zimbraReverseProxyCacheEntryTTL` to a shorter interval, such as
+30 minutes.
 
 == Migration steps
 

--- a/ng-admin.adoc
+++ b/ng-admin.adoc
@@ -480,7 +480,7 @@ operations or failed operations.
 ** `Start` and `End`: Limits the logs shown to a specific timespan
 (default: the current day).
 
-Clicking the `View` button will apply the selected filters and show the
+Clicking the `Details` button will apply the selected filters and show the
 log browser.
 
 [[the-action-filter]]

--- a/ng-cli.adoc
+++ b/ng-cli.adoc
@@ -547,17 +547,17 @@ Admin NG Commands
 `zxsuite admin getDelegationSettings [attr1 value1 [attr2 value2...`
 
 ::
-  *doEditDelegationSettings* -
+  *doEditDelegationSettings*
 
 `zxsuite admin doEditDelegationSettings {account} {domain} [attr1 value1 [attr2 value2...`
 
 ::
-  *doAddDelegationSettings* -
+  *doAddDelegationSettings*
 
 `zxsuite admin doAddDelegationSettings {account} {domain} [attr1 value1 [attr2 value2...`
 
 ::
-  *doRemoveDelegationSettings -
+  *doRemoveDelegationSettings
 
 `zxsuite admin doRemoveDelegationSettings {account} {domain}`
 

--- a/ng-hsm.adoc
+++ b/ng-hsm.adoc
@@ -216,10 +216,8 @@ To schedule a daily execution of the `doMoveBlobs` operation:
 
 * Log into the Zimbra Administration Console.
 * Click the `HSM NG` entry in the Administration Zimlet.
-* Enable scheduling by selecting the `Enable Policy Application
-scheduling` button.
-* Select the hour to run the operation under `Policy Application
-scheduled for:`.
+* Enable scheduling by selecting the `Enable HSM Session scheduling:` button.
+* Select the hour to run the operation under `HSM Session scheduled for:`.
 
 [[domoveblobs-stats-and-info]]
 doMoveBlobs Stats and Info
@@ -988,7 +986,7 @@ its content (as BLOBs are named after their file's SHA hash).
 whether the BLOB file's size is coherent with the expected size (stored
 in the DB).
 
-IMPORTANT: The old `zmblobchk` command is deprecated and replaced by `zxsuite hsm doCheckBlobs` on all infrastructures using HSM NG module. 
+IMPORTANT: The old `zmblobchk` command is deprecated and replaced by `zxsuite hsm doCheckBlobs` on all infrastructures using HSM NG module.
 
 [[dodeduplicate]]
 doDeduplicate
@@ -1210,7 +1208,7 @@ like mailbox id.
     ** reindex: Start a mailbox reindex.
     ** delete:  All blobs and db entries are deleted from the source server,
     backup items are also marked as deleted.
-    
+
 * All of the stages are executed sequentially. If a single stage is specified,
 the mailbox is parked in maintenance mode throughout the entire operation. On
 success, the mailbox will be placed into its original state.

--- a/ng-mobile.adoc
+++ b/ng-mobile.adoc
@@ -80,7 +80,7 @@ To enable Mobile NG for a single user from the Administration Console:
 
 * Open the Zimbra Administration Console.
 * Double-click the user you want to edit (on the left, under
-Addresses -> Accounts).
+Manage -> Accounts).
 * Click the Mobile tab.
 
 * Check `Enable mobile synchronization`.
@@ -106,7 +106,7 @@ To disable Mobile NG for a single user from the CLI:
 
 * Open the Zimbra Administration Console.
 * Double-click the user you want to edit (on the left, under
-Addresses -> Accounts).
+Manage -> Accounts).
 * Click the Mobile NG tab and uncheck `Enable mobile
 synchronization`.
 
@@ -325,7 +325,7 @@ SyncStates of synchronized mobile devices:
 forcing a full re-synchronization the next time the device connects to
 the server.
 
-* Remove Device: Removes all the device's SyncState and history from the
+* Wipe Device: Removes all the device's SyncState and history from the
 server. Useful when a mobile device is not used anymore or is assigned
 to a different employee in the same company.
 

--- a/zimbra-drive-guide.adoc
+++ b/zimbra-drive-guide.adoc
@@ -424,7 +424,7 @@ Build from Sources
 
 This section describes the steps to build the Zimbra Drive components. The
 official Zimbra Drive source repository is hosted on
-https://github.com/ZeXtras/ZimbraDrive[GitHub.com/ZeXtras/ZimbraDrive].
+https://github.com/ZeXtras/zimbra-drive[GitHub.com/ZeXtras/zimbra-drive].
 
 The build system uses a relative path. The following example assumes that
 the working path is `/tmp/`, but it can be changed at will.
@@ -591,19 +591,20 @@ information:
 * A detailed description of the issue: What you are expecting and what
 is really happening.
 * A detailed description of the steps to reproduce the issue.
-* A detailed description of the installation and the environment: (see )
+* A detailed description of the installation and the environment: (see
+"Gathering System Information" section of this guide)
 ** Cloud information:
 ** Server information: CPU, RAM, number of servers and for each
 server:
-*** Zimbra version (see )
+*** Zimbra version
 *** Zimbra Drive version
-*** List of the installed Zimlets (see )
+*** List of the installed Zimlets
 ** Client information:
 *** Browser name and version
 *** Connectivity used between the servers and the client
 *** Client skin (theme)
 *** Client language
-*** List of the Zimlets enabled for the user (see )
+*** List of the Zimlets enabled for the user
 * Any log involved in the issue:
 ** `mailbox.log`
 


### PR DESCRIPTION
6 related files are modified. Please review. Thank you!

#[ng-cli.adoc]
# There is no description following to the command and the hyphen, "doEditDelegationSettings -".
# -> Removed hyphen
# There is no description following to the command and the hyphen, "doAddDelegationSettings -".
# -> Removed hyphen
#
# There is no description following to the command and the hyphen, "*doRemoveDelegationSettings -".
# -> Removed hyphen
#
#
#[zimbra-drive-guide.adoc]
#
#The following sentence lacks reference after the word, see". 
#  A detailed description of the installation and the environment: (see )
# -> Added "Gathering System Information" section of this guide) after the "(see)", according to the same portion in "zimbra-chat-guide.adoc". 
#
#The following sentence lacks reference after the word, "see". 
#  Zimbra version (see )
# -> Removed "(see)", according to the same portion in "zimbra-chat-guide.adoc". 
#
#The following sentence lacks reference after the word, "see".  
#  List of the installed Zimlets (see )
# -> Removed "(see)", according to the same portion in "zimbra-chat-guide.adoc". 
#
#The following sentence lacks reference after the word, "see". 
#  List of the Zimlets enabled for the user (see )
# -> Removed "(see)", according to the same portion in "zimbra-chat-guide.adoc". 
#
#
#[ng-mobile.adoc]
#
#A wrong  name, "Addresses", is used in the following sentence. 
#  Double-click the user you want to edit (on the left, under Addresses → Accounts).
# -> Changed from "Addresses -> Accounts" to "Manage -> Accounts" for the corresponding 2 portions.
#
#A wrong  name, "Remove Device", is used. It should be replaced to "Wipe Device" according to the actual screen UI.
# -> Changed from "Remove Device" to "Wipe Device", according to the actual screen UI.
#
#
#[ng-hsm.adoc]
#Wrong names, "Enable Policy Application scheduling" and "Policy Application scheduled for:" are used. 
# -> Changed from "Enable Policy Application scheduling" and "Policy Application scheduled for:" to "Enable HSM Session scheduling:" and "HSM Session scheduled for :", based on  the actual screen UI.
#
#
#[ng-admin.adoc]
#A wrong  name, "View",  is used in the following sentence although the actual button name is "Details" on screen.
#  Clicking the View button will apply the selected filters and show the log browser.
# -> Changed from "View" to "Details", based on the actual UI.
#
#[imap_upstream.adoc]
#The description "zimbraMemcachedClientExpirySeconds LDAP attribute" could be wrong. 
#I wonder if It is "zimbraReverseProxyCacheEntryTTL LDAP attribute". 
# -> Changed the description "zimbraMemcachedClientExpirySeconds LDAP attribute" to "zimbraReverseProxyCacheEntryTTL LDAP attribute" in all the 4 portions.
