### PR TITLE
New version of arch_overview image as vector graphic

### DIFF
--- a/images/arch_overview.svg
+++ b/images/arch_overview.svg
@@ -1,0 +1,1407 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 211.14724 179.26419"
+   height="179.26419mm"
+   width="211.14723mm">
+  <defs
+     id="defs2">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1376">
+      <stop
+         id="stop1374"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1458">
+      <stop
+         id="stop1456"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1452">
+      <stop
+         id="stop1450"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1395">
+      <stop
+         id="stop1393"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1389">
+      <stop
+         id="stop1387"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1383">
+      <stop
+         id="stop1381"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1367">
+      <stop
+         id="stop1365"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1359">
+      <stop
+         id="stop1357"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1351">
+      <stop
+         id="stop1349"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1343">
+      <stop
+         id="stop1341"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1337">
+      <stop
+         id="stop1335"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1329">
+      <stop
+         id="stop1327"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1289">
+      <stop
+         id="stop1287"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1283">
+      <stop
+         id="stop1281"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1277">
+      <stop
+         id="stop1275"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1269">
+      <stop
+         id="stop1267"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1255">
+      <stop
+         id="stop1253"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1249">
+      <stop
+         id="stop1247"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1238">
+      <stop
+         id="stop1236"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1219">
+      <stop
+         id="stop1217"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1211">
+      <stop
+         id="stop1209"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1656">
+      <stop
+         id="stop1654"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1198">
+      <stop
+         id="stop1196"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5511">
+      <stop
+         id="stop5509"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5505">
+      <stop
+         id="stop5503"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5450">
+      <stop
+         id="stop5448"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5437">
+      <stop
+         id="stop5435"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5429">
+      <stop
+         id="stop5427"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5423">
+      <stop
+         id="stop5421"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5356">
+      <stop
+         id="stop5354"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5350">
+      <stop
+         id="stop5348"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5342">
+      <stop
+         id="stop5340"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5310">
+      <stop
+         id="stop5308"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5304">
+      <stop
+         id="stop5302"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5291">
+      <stop
+         id="stop5289"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5283">
+      <stop
+         id="stop5281"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5277">
+      <stop
+         id="stop5275"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5265">
+      <stop
+         id="stop5263"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient4915">
+      <stop
+         id="stop4913"
+         offset="0"
+         style="stop-color:#a7a9ac;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient4907">
+      <stop
+         id="stop4905"
+         offset="0"
+         style="stop-color:#5f6062;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient4894">
+      <stop
+         id="stop4892"
+         offset="0"
+         style="stop-color:#f6861f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient4880">
+      <stop
+         id="stop4878"
+         offset="0"
+         style="stop-color:#f0471f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient4871">
+      <stop
+         id="stop4869"
+         offset="0"
+         style="stop-color:#3984e7;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="207.04166"
+       x2="395.36313"
+       y1="207.04166"
+       x1="130.77974"
+       id="linearGradient4873"
+       xlink:href="#linearGradient4871" />
+    <linearGradient
+       gradientTransform="matrix(2.216418,0,0,1,-128.4294,9.6994533)"
+       gradientUnits="userSpaceOnUse"
+       y2="232.64072"
+       x2="126.37513"
+       y1="232.64072"
+       x1="79.979881"
+       id="linearGradient4882"
+       xlink:href="#linearGradient4880" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="111.80531"
+       x2="124.99021"
+       y1="111.80531"
+       x1="88.635719"
+       id="linearGradient4896"
+       xlink:href="#linearGradient4894" />
+    <linearGradient
+       gradientTransform="translate(-0.52916667)"
+       gradientUnits="userSpaceOnUse"
+       y2="218.59026"
+       x2="108.10621"
+       y1="218.59026"
+       x1="84.457977"
+       id="linearGradient5267"
+       xlink:href="#linearGradient4894" />
+    <linearGradient
+       gradientTransform="matrix(0.66601186,0,0,3.1674432,6.9675406,-345.01621)"
+       gradientUnits="userSpaceOnUse"
+       y2="170.54305"
+       x2="135.50813"
+       y1="170.54305"
+       x1="103.22642"
+       id="linearGradient5285"
+       xlink:href="#linearGradient4894" />
+    <linearGradient
+       gradientTransform="matrix(0.97017709,0,0,0.82269794,1.2988143,30.459453)"
+       gradientUnits="userSpaceOnUse"
+       y2="170.13506"
+       x2="68.540939"
+       y1="170.13506"
+       x1="43.616959"
+       id="linearGradient5293"
+       xlink:href="#linearGradient4894" />
+    <linearGradient
+       gradientTransform="matrix(0.58613026,0,0,1,21.958304,18.777079)"
+       gradientUnits="userSpaceOnUse"
+       y2="158.3407"
+       x2="57.636696"
+       y1="158.3407"
+       x1="52.518379"
+       id="linearGradient5312"
+       xlink:href="#linearGradient4894" />
+    <linearGradient
+       gradientTransform="matrix(1.4179506,0,0,0.22179378,-100.93038,134.03581)"
+       gradientUnits="userSpaceOnUse"
+       y2="172.0509"
+       x2="138.19455"
+       y1="172.0509"
+       x1="116.36433"
+       id="linearGradient5344"
+       xlink:href="#linearGradient4894" />
+    <linearGradient
+       gradientTransform="matrix(1.0005882,0,0,0.8431325,-1.1387933,21.275598)"
+       gradientUnits="userSpaceOnUse"
+       y2="142.54065"
+       x2="62.887302"
+       y1="142.54065"
+       x1="25.904362"
+       id="linearGradient5352"
+       xlink:href="#linearGradient4915" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="127.65906"
+       x2="136.21555"
+       y1="127.65906"
+       x1="78.536385"
+       id="linearGradient5431"
+       xlink:href="#linearGradient5265" />
+    <linearGradient
+       y2="207.04166"
+       x2="395.36313"
+       y1="207.04166"
+       x1="130.77974"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5433"
+       xlink:href="#linearGradient4871" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="127.65906"
+       x2="136.21574"
+       y1="127.65906"
+       x1="78.536186"
+       id="linearGradient5439"
+       xlink:href="#linearGradient5342" />
+    <linearGradient
+       gradientTransform="matrix(0.9231378,0,0,0.9142273,-36.851386,7.3033344)"
+       gradientUnits="userSpaceOnUse"
+       y2="125.85047"
+       x2="145.32568"
+       y1="125.85047"
+       x1="142.07468"
+       id="linearGradient5452"
+       xlink:href="#linearGradient5265" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="219.25739"
+       x2="147.72577"
+       y1="219.25739"
+       x1="125.29467"
+       id="linearGradient5507"
+       xlink:href="#linearGradient5265" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="219.25739"
+       x2="147.72577"
+       y1="219.25739"
+       x1="125.29467"
+       id="linearGradient5513"
+       xlink:href="#linearGradient5423" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="160.70068"
+       x2="150.10568"
+       y1="160.70068"
+       x1="121.23243"
+       id="linearGradient1200"
+       xlink:href="#linearGradient5423" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="160.70068"
+       x2="149.97339"
+       y1="160.70068"
+       x1="121.36472"
+       id="linearGradient1658"
+       xlink:href="#linearGradient4871" />
+    <linearGradient
+       gradientTransform="matrix(0.77349397,0,0,1,22.01814,-0.08170193)"
+       gradientUnits="userSpaceOnUse"
+       y2="145.76564"
+       x2="149.22949"
+       y1="145.76564"
+       x1="118.27985"
+       id="linearGradient1213"
+       xlink:href="#linearGradient4871" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,4.3894823,-11.800125,-480.88358)"
+       gradientUnits="userSpaceOnUse"
+       y2="146.6147"
+       x2="149.24638"
+       y1="146.6147"
+       x1="146.24638"
+       id="linearGradient1221"
+       xlink:href="#linearGradient4871" />
+    <linearGradient
+       gradientTransform="translate(60.86487,-138.22616)"
+       gradientUnits="userSpaceOnUse"
+       y2="168.2829"
+       x2="166.31435"
+       y1="168.2829"
+       x1="156.31435"
+       id="linearGradient1240"
+       xlink:href="#linearGradient4871" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="207.34013"
+       x2="182.26729"
+       y1="207.34013"
+       x1="152.43631"
+       id="linearGradient1251"
+       xlink:href="#linearGradient5450" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="207.34013"
+       x2="182.39958"
+       y1="207.34013"
+       x1="152.30402"
+       id="linearGradient1257"
+       xlink:href="#linearGradient5423" />
+    <linearGradient
+       gradientTransform="matrix(3.1490546,0,0,1.3036409,-312.30298,-22.252534)"
+       gradientUnits="userSpaceOnUse"
+       y2="114.43466"
+       x2="156.01604"
+       y1="114.43466"
+       x1="146.17181"
+       id="linearGradient1271"
+       xlink:href="#linearGradient4880" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="157.06055"
+       x2="180.44423"
+       y1="157.06055"
+       x1="149.44423"
+       id="linearGradient1279"
+       xlink:href="#linearGradient5423" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="157.06055"
+       x2="180.44423"
+       y1="157.06055"
+       x1="149.44423"
+       id="linearGradient1285"
+       xlink:href="#linearGradient4915" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="194.67172"
+       x2="167.43188"
+       y1="194.67172"
+       x1="167.01373"
+       id="linearGradient1331"
+       xlink:href="#linearGradient4880" />
+    <linearGradient
+       gradientTransform="translate(0.97804265,0.03163438)"
+       gradientUnits="userSpaceOnUse"
+       y2="182.65572"
+       x2="208.58562"
+       y1="182.65572"
+       x1="176.23482"
+       id="linearGradient1339"
+       xlink:href="#linearGradient4907" />
+    <linearGradient
+       gradientTransform="translate(0.97804265,0.03163438)"
+       gradientUnits="userSpaceOnUse"
+       y2="182.65572"
+       x2="208.70367"
+       y1="182.65572"
+       x1="176.11674"
+       id="linearGradient1345"
+       xlink:href="#linearGradient5423" />
+    <linearGradient
+       gradientTransform="matrix(2.5011159,0,0,1,-288.89682,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="241.54385"
+       x2="195.64529"
+       y1="241.54385"
+       x1="187.94272"
+       id="linearGradient1353"
+       xlink:href="#linearGradient4907" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.87542846,5.1478327,30.888961)"
+       gradientUnits="userSpaceOnUse"
+       y2="188.06439"
+       x2="195.27344"
+       y1="188.06439"
+       x1="192.27344"
+       id="linearGradient1361"
+       xlink:href="#linearGradient4907" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="146.12271"
+       x2="187.27986"
+       y1="146.12271"
+       x1="182.49146"
+       id="linearGradient1369"
+       xlink:href="#linearGradient4880" />
+    <linearGradient
+       gradientTransform="matrix(0.92907886,0,0,1.0009449,72.56791,47.075904)"
+       gradientUnits="userSpaceOnUse"
+       y2="107.229"
+       x2="152.43089"
+       y1="107.229"
+       x1="133.80933"
+       id="linearGradient1385"
+       xlink:href="#linearGradient4915" />
+    <linearGradient
+       gradientTransform="matrix(0.92907886,0,0,1.0009449,72.56791,47.075904)"
+       gradientUnits="userSpaceOnUse"
+       y2="107.229"
+       x2="152.5634"
+       y1="107.229"
+       x1="133.67683"
+       id="linearGradient1391"
+       xlink:href="#linearGradient5423" />
+    <linearGradient
+       gradientTransform="translate(0,0.92430848)"
+       gradientUnits="userSpaceOnUse"
+       y2="110.15524"
+       x2="206.16747"
+       y1="110.15524"
+       x1="184.88567"
+       id="linearGradient1454"
+       xlink:href="#linearGradient5423" />
+    <linearGradient
+       gradientTransform="translate(0,0.92430848)"
+       gradientUnits="userSpaceOnUse"
+       y2="110.15524"
+       x2="206.16747"
+       y1="110.15524"
+       x1="184.88567"
+       id="linearGradient1460"
+       xlink:href="#linearGradient5310" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.8782087,2.6458334,15.100904)"
+       gradientUnits="userSpaceOnUse"
+       y2="121.18897"
+       x2="197.23708"
+       y1="121.18897"
+       x1="193.97249"
+       id="linearGradient1378"
+       xlink:href="#linearGradient5265" />
+    <linearGradient
+       y2="141.29263"
+       x2="57.180687"
+       y1="141.29263"
+       x1="28.929182"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1405"
+       xlink:href="#linearGradient4915" />
+    <linearGradient
+       y2="156.43214"
+       x2="171.13745"
+       y1="156.43214"
+       x1="158.13359"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1407"
+       xlink:href="#linearGradient4915" />
+    <linearGradient
+       y2="120.99824"
+       x2="159.47578"
+       y1="120.99824"
+       x1="146.09641"
+       gradientTransform="translate(53.239891,33.344056)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1409"
+       xlink:href="#linearGradient4915" />
+  </defs>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-4.2270979,-94.809317)"
+     id="layer1" />
+  <g
+     transform="translate(-4.2270979,-77.209317)"
+     style="display:inline"
+     id="layer6">
+    <g
+       id="g5084">
+      <g
+         id="g5006"
+         transform="translate(30.162505,-0.52916667)">
+        <rect
+           rx="7.5090251"
+           y="236.09018"
+           x="48.839455"
+           height="12.5"
+           width="102.83127"
+           id="rect1119"
+           style="opacity:1;fill:url(#linearGradient4882);fill-opacity:1;stroke:none;stroke-width:0.38394335;stroke-opacity:1" />
+        <text
+           id="text1088"
+           y="245.65701"
+           x="79.635544"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="245.65701"
+             x="79.635544"
+             id="tspan1086">Mailboxd</tspan></text>
+      </g>
+      <g
+         id="g4976"
+         transform="translate(49.897803,74.440148)">
+        <rect
+           rx="4.2320113"
+           y="172.03336"
+           x="33.866661"
+           height="10"
+           width="26.458338"
+           id="rect4968"
+           style="opacity:1;fill:#a7a9ac;fill-opacity:1;stroke:none;stroke-width:0.28754529;stroke-opacity:1" />
+        <text
+           id="text4926"
+           y="178.85834"
+           x="37.041668"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';stroke-width:0.26458332"
+             y="178.85834"
+             x="37.041668"
+             id="tspan4924">Store</tspan><tspan
+             id="tspan4928"
+             style="stroke-width:0.26458332"
+             y="186.79584"
+             x="37.041668" /></text>
+      </g>
+      <g
+         id="g4981"
+         transform="translate(39.843633,74.494316)">
+        <rect
+           rx="4.9756455"
+           y="171.97919"
+           x="70.379166"
+           height="10"
+           width="37.329002"
+           id="rect4970"
+           style="opacity:1;fill:#a7a9ac;fill-opacity:1;stroke:none;stroke-width:0.27887049;stroke-opacity:1" />
+        <text
+           id="text4932"
+           y="178.85834"
+           x="74.083336"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';stroke-width:0.26458332"
+             y="178.85834"
+             x="74.083336"
+             id="tspan4930">MariaDB</tspan></text>
+      </g>
+      <g
+         id="g4988"
+         transform="translate(40.58535,69.210793)">
+        <rect
+           rx="4.6929407"
+           y="177.26271"
+           x="106.96645"
+           height="10"
+           width="28.737358"
+           id="rect4983"
+           style="opacity:1;fill:#a7a9ac;fill-opacity:1;stroke:none;stroke-width:0.24039133;stroke-opacity:1" />
+        <text
+           id="text4936"
+           y="184.14999"
+           x="111.125"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';stroke-width:0.26458332"
+             y="184.14999"
+             x="111.125"
+             id="tspan4934">Index</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-12.392098,186.09549)"
+       id="g1128">
+      <rect
+         style="opacity:1;fill:#f0471f;fill-opacity:1;stroke:none;stroke-width:0.26871943;stroke-opacity:1"
+         id="rect1098"
+         width="28.737358"
+         height="12.5"
+         x="16.619196"
+         y="49.465523"
+         rx="3.3856082" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="19.04283"
+         y="58.849422"
+         id="text1080"><tspan
+           id="tspan1078"
+           x="19.04283"
+           y="58.849422"
+           style="stroke-width:0.26458332">SSDB</tspan></text>
+    </g>
+    <text
+       id="text4948"
+       y="240.33795"
+       x="56.807526"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+         y="240.33795"
+         x="56.807526"
+         id="tspan4946">Ephemeral</tspan><tspan
+         id="tspan4950"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+         y="248.27545"
+         x="56.807526">Data</tspan></text>
+    <g
+       transform="translate(0,5.8208336)"
+       id="g5257">
+      <g
+         id="g5190"
+         transform="matrix(0.29717737,0,0,0.26458333,32.759934,235.56101)">
+        <path
+           id="path5176"
+           d="M 14.877,4.067 H 79.398"
+           style="fill:none;stroke:#010101;stroke-width:1.36000001" />
+        <path
+           id="path5178"
+           d="M 0,4.067 16.773,8.133 C 15.572,7.124 14.877,5.635 14.877,4.067 14.877,2.499 15.572,1.008 16.773,0 Z"
+           style="fill:#010101" />
+      </g>
+      <g
+         id="g5249"
+         transform="matrix(0.29049174,0,0,0.26458333,56.355223,235.56127)">
+        <path
+           id="path5235"
+           d="M 64.521,4.066 H 0"
+           style="fill:none;stroke:#010101;stroke-width:1.36000001" />
+        <path
+           id="path5237"
+           d="M 79.397,4.066 62.625,0 c 1.2,1.009 1.896,2.496 1.896,4.066 0,1.57 -0.695,3.059 -1.896,4.066 z"
+           style="fill:#010101" />
+      </g>
+    </g>
+  </g>
+  <g
+     transform="translate(-4.2270979,-77.209317)"
+     style="display:inline"
+     id="layer9">
+    <g
+       transform="translate(29.292386,79.633646)"
+       id="g4901">
+      <rect
+         style="opacity:1;fill:url(#linearGradient4896);fill-opacity:1;stroke:none;stroke-width:0.27674267;stroke-opacity:1"
+         id="rect1107"
+         width="36.354488"
+         height="12.5"
+         x="88.635719"
+         y="105.55531"
+         rx="3.3856082" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="92.098045"
+         y="114.93921"
+         id="text1084"><tspan
+           id="tspan1082"
+           x="92.098045"
+           y="114.93921"
+           style="stroke-width:0.26458332">IMAPD</tspan></text>
+    </g>
+    <g
+       transform="matrix(6.4454433e-4,-0.48375054,0.26459457,-0.00343314,135.41283,235.94629)"
+       id="g5499">
+      <path
+         style="fill:none;stroke:#010101;stroke-width:1.36000001"
+         d="M 14.877,4.067 H 79.398"
+         id="path5485" />
+      <path
+         style="fill:#010101"
+         d="M 0,4.067 16.773,8.133 C 15.572,7.124 14.877,5.635 14.877,4.067 14.877,2.499 15.572,1.008 16.773,0 Z"
+         id="path5487" />
+    </g>
+    <rect
+       rx="3.382117"
+       y="214.39439"
+       x="125.43161"
+       height="9.7261286"
+       width="22.157225"
+       id="rect5501"
+       style="opacity:1;fill:url(#linearGradient5513);fill-opacity:1;stroke:url(#linearGradient5507);stroke-width:0.273871;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <text
+       id="text4962"
+       y="221.24869"
+       x="127.86926"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.26458332"
+         y="221.24869"
+         x="127.86926"
+         id="tspan4960">SOAP</tspan></text>
+    <rect
+       y="144.18394"
+       x="113.50689"
+       height="3"
+       width="23.939363"
+       id="rect1207"
+       style="opacity:1;fill:url(#linearGradient1213);fill-opacity:1;stroke:none;stroke-width:0.23269707;stroke-opacity:1" />
+    <rect
+       y="144.18394"
+       x="134.44626"
+       height="36.990166"
+       width="3"
+       id="rect1215"
+       style="opacity:1;fill:url(#linearGradient1221);fill-opacity:1;stroke:none;stroke-width:0.55433095;stroke-opacity:1" />
+    <g
+       id="g1226">
+      <rect
+         style="display:inline;opacity:1;fill:url(#linearGradient1200);fill-opacity:1;stroke:url(#linearGradient1658);stroke-width:0.26458332;stroke-opacity:1"
+         id="rect1193"
+         width="28.608665"
+         height="12.43855"
+         x="121.36472"
+         y="154.48141"
+         rx="3.3879101" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="125.92212"
+         y="162.78699"
+         id="text4958"><tspan
+           id="tspan4956"
+           x="125.92212"
+           y="162.78699"
+           style="stroke-width:0.26458332">IMAPS</tspan></text>
+    </g>
+    <path
+       id="rect1234"
+       d="m 223.6088,31.705101 3.35948,-6.279007 v 9.630511 h -9.42015 z"
+       style="opacity:1;fill:url(#linearGradient1240);fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+       transform="rotate(44.965652)" />
+  </g>
+  <g
+     transform="translate(-4.2270979,-77.209317)"
+     style="display:inline"
+     id="layer7">
+    <g
+       transform="translate(35.383146,12.705159)"
+       id="g5363">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient5352);stroke-width:0.2434005;stroke-miterlimit:4;stroke-dasharray:0.97360205, 0.24340051;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect5346"
+         width="36.739956"
+         height="9.7565994"
+         x="24.913177"
+         y="136.57796"
+         ry="3.7831037" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient1405);fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="28.446869"
+         y="143.13145"
+         id="text5047"><tspan
+           id="tspan5045"
+           x="28.446869"
+           y="143.13145"
+           style="fill:url(#linearGradient1405);fill-opacity:1;stroke-width:0.26458332">Memcached</tspan></text>
+    </g>
+    <g
+       transform="translate(16.619196,80.672345)"
+       id="g1168">
+      <rect
+         style="opacity:1;fill:#f0471f;fill-opacity:1;stroke:none;stroke-width:0.26135582;stroke-opacity:1"
+         id="rect1105"
+         width="57.474716"
+         height="12.5"
+         x="11.425697"
+         y="101.05427"
+         rx="3.3856082" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="14.195563"
+         y="109.7457"
+         id="text1076"><tspan
+           id="tspan1074"
+           x="14.195563"
+           y="109.7457"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';stroke-width:0.26458332">Mailboxd</tspan></text>
+      <g
+         id="g1159"
+         transform="translate(41.672021,79.940602)">
+        <rect
+           rx="3.4971976"
+           y="23.187399"
+           x="13.503096"
+           height="8.309598"
+           width="11.079463"
+           id="rect1154"
+           style="opacity:1;fill:#f0e34a;fill-opacity:1;stroke:none;stroke-width:0.24043716;stroke-opacity:1" />
+        <text
+           id="text1152"
+           y="29.419596"
+           x="15.417195"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="29.419596"
+             x="15.417195"
+             id="tspan1150">UI</tspan></text>
+      </g>
+    </g>
+    <rect
+       y="155.90366"
+       x="116.36433"
+       height="9.3842201"
+       width="0.75073761"
+       id="rect5269"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1" />
+    <rect
+       y="170.91841"
+       x="129.12686"
+       height="2.6275816"
+       width="4.1290565"
+       id="rect5271"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1" />
+    <rect
+       y="151.17766"
+       x="94.21756"
+       height="84.416092"
+       width="3"
+       id="rect5273"
+       style="opacity:1;fill:url(#linearGradient5285);fill-opacity:1;stroke:none;stroke-width:0.38428894;stroke-opacity:1" />
+    <rect
+       y="105.06621"
+       x="94.418968"
+       height="34.586136"
+       width="2.7694135"
+       id="rect5446"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient5452);stroke-width:0.23100001;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <g
+       transform="translate(-12.170834)"
+       id="g5444">
+      <rect
+         style="opacity:1;fill:url(#linearGradient5439);fill-opacity:1;stroke:url(#linearGradient5431);stroke-width:0.25099999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect5419"
+         width="57.428551"
+         height="9.7493944"
+         x="78.66169"
+         y="122.78436"
+         ry="3.3824322" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="81.686188"
+         y="129.5265"
+         id="text5043"><tspan
+           id="tspan5041"
+           x="81.686188"
+           y="129.5265"
+           style="stroke-width:0.26458332">HTTPS IMAPS POP3S</tspan></text>
+    </g>
+    <g
+       transform="translate(14.142895,71.128654)"
+       id="g1133">
+      <rect
+         style="opacity:1;fill:#f0471f;fill-opacity:1;stroke:#f0471f;stroke-width:0.14054161;stroke-opacity:1"
+         id="rect1021"
+         width="36.132298"
+         height="12.359458"
+         x="63.298656"
+         y="68.018448"
+         rx="3.3879087" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="68.554184"
+         y="76.507317"
+         id="text1065"><tspan
+           id="tspan1063"
+           x="68.554184"
+           y="76.507317"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';stroke-width:0.26458332">Proxy</tspan></text>
+    </g>
+    <g
+       id="g5333">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient5267);stroke-width:0.23222826;stroke-opacity:1"
+         id="rect5259"
+         width="23.648235"
+         height="20.269915"
+         x="83.92881"
+         y="208.45529"
+         rx="6.8560743" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="87.766533"
+         y="217.62679"
+         id="text5011"><tspan
+           id="tspan5009"
+           x="87.766533"
+           y="217.62679"
+           style="stroke-width:0.26458332">HTTPS</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="87.420296"
+         y="223.16652"
+         id="text5019"><tspan
+           id="tspan5017"
+           x="87.420296"
+           y="223.16652"
+           style="stroke-width:0.26458332">POP3S</tspan></text>
+    </g>
+    <rect
+       y="172.44452"
+       x="52.740913"
+       height="9.3464909"
+       width="3"
+       id="rect5300"
+       style="opacity:1;fill:url(#linearGradient5312);fill-opacity:1;stroke:none;stroke-width:0.20256272;stroke-opacity:1" />
+    <rect
+       y="170.69563"
+       x="64.068481"
+       height="3"
+       width="30.954182"
+       id="rect5338"
+       style="opacity:1;fill:url(#linearGradient5344);fill-opacity:1;stroke:none;stroke-width:0.14837737;stroke-opacity:1" />
+    <g
+       id="g5326">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient5293);stroke-width:0.2363786;stroke-opacity:1"
+         id="rect5287"
+         width="21.58989"
+         height="12.266322"
+         x="43.614986"
+         y="165.85223"
+         rx="6.6516008" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="46.741489"
+         y="173.5963"
+         id="text5015"><tspan
+           id="tspan5013"
+           x="46.741489"
+           y="173.5963"
+           style="stroke-width:0.26458332">HTTPS</tspan></text>
+    </g>
+  </g>
+  <g
+     transform="translate(-4.2270979,-77.209317)"
+     style="display:inline"
+     id="layer8">
+    <g
+       transform="translate(4.4746474,19.688449)"
+       id="g1315">
+      <g
+         id="g1296"
+         transform="translate(-1.1932393,-19.159281)">
+        <ellipse
+           ry="7"
+           rx="15.5"
+           cy="157.06055"
+           cx="164.94423"
+           id="path1273"
+           style="opacity:1;fill:url(#linearGradient1279);fill-opacity:1;stroke:url(#linearGradient1285);stroke-width:0.287;stroke-miterlimit:4;stroke-dasharray:1.148, 0.287;stroke-dashoffset:0;stroke-opacity:1" />
+        <text
+           id="text4966"
+           y="158.74054"
+           x="157.51347"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient1407);fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="fill:url(#linearGradient1407);fill-opacity:1;stroke-width:0.26458332"
+             y="158.74054"
+             x="157.51347"
+             id="tspan4964">DNS</tspan></text>
+      </g>
+      <g
+         id="g1305">
+        <ellipse
+           ry="7"
+           rx="15.5"
+           cy="126.92918"
+           cx="163.5"
+           id="path1265"
+           style="opacity:1;fill:url(#linearGradient1271);fill-opacity:1;stroke:none;stroke-width:0.53608239;stroke-opacity:1" />
+        <text
+           id="text1096"
+           y="130.17348"
+           x="152.34262"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="130.17348"
+             x="152.34262"
+             id="tspan1094">LDAP</tspan></text>
+      </g>
+    </g>
+    <path
+       id="path1325"
+       d="M 167.29983,235.80344 167.14578,153.54"
+       style="fill:none;stroke:url(#linearGradient1331);stroke-width:0.264;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.264, 0.79200001;stroke-dashoffset:0;stroke-opacity:1" />
+    <g
+       id="g1263">
+      <rect
+         style="display:inline;opacity:1;fill:url(#linearGradient1257);fill-opacity:1;stroke:url(#linearGradient1251);stroke-width:0.26458332;stroke-opacity:1"
+         id="rect1245"
+         width="29.83098"
+         height="10"
+         x="152.43631"
+         y="202.34013"
+         rx="3.3859999" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="155.45872"
+         y="209.11465"
+         id="text5023"><tspan
+           id="tspan5021"
+           x="155.45872"
+           y="209.11465"
+           style="stroke-width:0.26458332">LDAP-TLS</tspan></text>
+    </g>
+    <path
+       id="path1363"
+       d="m 182.49145,146.12271 h 4.78841"
+       style="fill:none;stroke:url(#linearGradient1369);stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.26499999, 0.52999997;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     transform="translate(-4.2270979,-77.209317)"
+     style="display:inline"
+     id="layer10">
+    <g
+       transform="translate(1.0583333,0.52916667)"
+       id="g1432">
+      <rect
+         style="opacity:1;fill:url(#linearGradient1391);fill-opacity:1;stroke:url(#linearGradient1385);stroke-width:0.2555508;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect1379"
+         width="17.300913"
+         height="10.009449"
+         x="196.88731"
+         y="149.40149"
+         rx="2.8364778" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient1409);fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="199.27359"
+         y="156.13771"
+         id="text5035"><tspan
+           id="tspan5033"
+           x="199.27359"
+           y="156.13771"
+           style="fill:url(#linearGradient1409);fill-opacity:1;stroke-width:0.26458332">ASAV</tspan></text>
+    </g>
+    <g
+       transform="translate(53.007865,16.350807)"
+       id="g1143">
+      <rect
+         style="opacity:1;fill:#f0471f;fill-opacity:1;stroke:none;stroke-width:0.2416683;stroke-opacity:1"
+         id="rect1121"
+         width="25.275024"
+         height="12.5"
+         x="132.95357"
+         y="122.86697"
+         rx="3.0533016" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="136.41589"
+         y="131.5584"
+         id="text1092"><tspan
+           id="tspan1090"
+           x="136.41589"
+           y="131.5584"
+           style="stroke-width:0.26458332">MTA</tspan></text>
+    </g>
+    <rect
+       y="150.99371"
+       x="197.42122"
+       height="89.064331"
+       width="3"
+       id="rect1355"
+       style="display:inline;opacity:1;fill:url(#linearGradient1361);fill-opacity:1;stroke:none;stroke-width:0.2208118;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <g
+       transform="translate(4.6203602,44.862984)"
+       id="g1377">
+      <rect
+         style="display:inline;opacity:1;fill:url(#linearGradient1345);fill-opacity:1;stroke:url(#linearGradient1339);stroke-width:0.236;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect1333"
+         width="32.350796"
+         height="16.021345"
+         x="177.21286"
+         y="174.67668"
+         rx="3.3860052" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="181.77245"
+         y="181.76222"
+         id="text5027"><tspan
+           id="tspan5025"
+           x="181.77245"
+           y="181.76222"
+           style="stroke-width:0.26458332">SMTP out</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="181.77246"
+         y="187.26271"
+         id="text5031"><tspan
+           id="tspan5029"
+           x="181.77246"
+           y="187.26271"
+           style="stroke-width:0.26458332">LMTP in</tspan></text>
+    </g>
+    <rect
+       y="240.04385"
+       x="181.16971"
+       height="3"
+       width="19.265022"
+       id="rect1347"
+       style="display:inline;opacity:1;fill:url(#linearGradient1353);fill-opacity:1;stroke:none;stroke-width:0.67240518;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <rect
+       y="103.80742"
+       x="196.75058"
+       height="35.445381"
+       width="3"
+       id="rect567"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient1378);stroke-width:0.21647654;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       transform="translate(2.4648226,18.003989)"
+       id="g565">
+      <rect
+         style="opacity:1;fill:url(#linearGradient1454);fill-opacity:1;stroke:url(#linearGradient1460);stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect1448"
+         width="21.281801"
+         height="10"
+         x="184.88567"
+         y="106.07955"
+         rx="2.836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="188.69711"
+         y="112.86182"
+         id="text5039"><tspan
+           id="tspan5037"
+           x="188.69711"
+           y="112.86182"
+           style="stroke-width:0.26458332">SMTP</tspan></text>
+    </g>
+  </g>
+  <g
+     transform="translate(-4.2270979,-77.209317)"
+     style="display:inline"
+     id="layer2">
+    <g
+       style="fill:#3984e7;fill-opacity:1;stroke:none"
+       transform="matrix(0.1398425,0,0,0.16475046,159.95466,57.628275)"
+       id="layer1-9">
+      <path
+         id="path3293"
+         d="m 284.00314,122.06466 a 57.911863,57.911863 0 0 0 -47.4077,24.703 43.709289,43.709289 0 0 0 -15.5907,-2.928 43.709289,43.709289 0 0 0 -43.70901,43.709 43.709289,43.709289 0 0 0 0.25,4.256 50.164606,50.164606 0 0 0 -46.76599,50.045 50.164606,50.164606 0 0 0 49.65719,50.139 l -0.022,0.03 h 0.5192 156.51701 a 57.911863,57.911863 0 0 0 57.91198,-57.912 57.911863,57.911863 0 0 0 -53.59559,-57.695 57.911863,57.911863 0 0 0 -57.7851,-54.342 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3984e7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00329208;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    </g>
+    <g
+       style="fill:url(#linearGradient4873);fill-opacity:1"
+       transform="matrix(0.1398425,0,0,0.16475046,58.635692,57.789532)"
+       id="layer1-3">
+      <path
+         id="path3293-8"
+         d="m 284.00314,122.06466 a 57.911863,57.911863 0 0 0 -47.4077,24.703 43.709289,43.709289 0 0 0 -15.5907,-2.928 43.709289,43.709289 0 0 0 -43.70901,43.709 43.709289,43.709289 0 0 0 0.25,4.256 50.164606,50.164606 0 0 0 -46.76599,50.045 50.164606,50.164606 0 0 0 49.65719,50.139 l -0.022,0.03 h 0.5192 156.51701 a 57.911863,57.911863 0 0 0 57.91198,-57.912 57.911863,57.911863 0 0 0 -53.59559,-57.695 57.911863,57.911863 0 0 0 -57.7851,-54.342 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient5433);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00329208;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    </g>
+  </g>
+</svg>

--- a/images/arch_overview_ink.svg
+++ b/images/arch_overview_ink.svg
@@ -1,0 +1,1538 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="211.14723mm"
+   height="179.26419mm"
+   viewBox="0 0 211.14724 179.26419"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="arch_overview_ink.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient1376"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop1374" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1458"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1456" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1452"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop1450" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1395"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1393" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1389"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop1387" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1383"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1381" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1367"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1365" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1359"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop1357" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1351"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop1349" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1343"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop1341" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1337"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1335" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1329"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1327" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1289"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1287" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1283"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1281" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1277"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop1275" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1269"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop1267" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1255"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1253" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1249"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1247" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1238"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop1236" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1219"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop1217" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1211"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop1209" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1656"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1654" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1198"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop1196" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5511"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5509" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5505"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop5503" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5450"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop5448" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5437"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5435" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5429"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop5427" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5423"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5421" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5356"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5354" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5350"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop5348" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5342"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5340" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5310"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5308" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5304"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5302" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5291"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5289" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5283"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5281" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5277"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop5275" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5265"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5263" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4915"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#a7a9ac;stop-opacity:1;"
+         offset="0"
+         id="stop4913" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#5f6062;stop-opacity:1;"
+         offset="0"
+         id="stop4905" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4894"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f6861f;stop-opacity:1;"
+         offset="0"
+         id="stop4892" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4880"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f0471f;stop-opacity:1;"
+         offset="0"
+         id="stop4878" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4871"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#3984e7;stop-opacity:1;"
+         offset="0"
+         id="stop4869" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871"
+       id="linearGradient4873"
+       x1="130.77974"
+       y1="207.04166"
+       x2="395.36313"
+       y2="207.04166"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4880"
+       id="linearGradient4882"
+       x1="79.979881"
+       y1="232.64072"
+       x2="126.37513"
+       y2="232.64072"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.216418,0,0,1,-128.4294,9.6994533)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient4896"
+       x1="88.635719"
+       y1="111.80531"
+       x2="124.99021"
+       y2="111.80531"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient5267"
+       x1="84.457977"
+       y1="218.59026"
+       x2="108.10621"
+       y2="218.59026"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.52916667)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient5285"
+       x1="103.22642"
+       y1="170.54305"
+       x2="135.50813"
+       y2="170.54305"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66601186,0,0,3.1674432,6.9675406,-345.01621)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient5293"
+       x1="43.616959"
+       y1="170.13506"
+       x2="68.540939"
+       y2="170.13506"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97017709,0,0,0.82269794,1.2988143,30.459453)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient5312"
+       x1="52.518379"
+       y1="158.3407"
+       x2="57.636696"
+       y2="158.3407"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.58613026,0,0,1,21.958304,18.777079)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient5344"
+       x1="116.36433"
+       y1="172.0509"
+       x2="138.19455"
+       y2="172.0509"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4179506,0,0,0.22179378,-100.93038,134.03581)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4915"
+       id="linearGradient5352"
+       x1="25.904362"
+       y1="142.54065"
+       x2="62.887302"
+       y2="142.54065"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0005882,0,0,0.8431325,-1.1387933,21.275598)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5265"
+       id="linearGradient5431"
+       x1="78.536385"
+       y1="127.65906"
+       x2="136.21555"
+       y2="127.65906"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871"
+       id="linearGradient5433"
+       gradientUnits="userSpaceOnUse"
+       x1="130.77974"
+       y1="207.04166"
+       x2="395.36313"
+       y2="207.04166" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5342"
+       id="linearGradient5439"
+       x1="78.536186"
+       y1="127.65906"
+       x2="136.21574"
+       y2="127.65906"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5265"
+       id="linearGradient5452"
+       x1="142.07468"
+       y1="125.85047"
+       x2="145.32568"
+       y2="125.85047"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9231378,0,0,0.9142273,-36.851386,7.3033344)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5265"
+       id="linearGradient5507"
+       x1="125.29467"
+       y1="219.25739"
+       x2="147.72577"
+       y2="219.25739"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5423"
+       id="linearGradient5513"
+       x1="125.29467"
+       y1="219.25739"
+       x2="147.72577"
+       y2="219.25739"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5423"
+       id="linearGradient1200"
+       x1="121.23243"
+       y1="160.70068"
+       x2="150.10568"
+       y2="160.70068"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871"
+       id="linearGradient1658"
+       x1="121.36472"
+       y1="160.70068"
+       x2="149.97339"
+       y2="160.70068"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871"
+       id="linearGradient1213"
+       x1="118.27985"
+       y1="145.76564"
+       x2="149.22949"
+       y2="145.76564"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.77349397,0,0,1,22.01814,-0.08170193)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871"
+       id="linearGradient1221"
+       x1="146.24638"
+       y1="146.6147"
+       x2="149.24638"
+       y2="146.6147"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,4.3894823,-11.800125,-480.88358)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871"
+       id="linearGradient1240"
+       x1="156.31435"
+       y1="168.2829"
+       x2="166.31435"
+       y2="168.2829"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(60.86487,-138.22616)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5450"
+       id="linearGradient1251"
+       x1="152.43631"
+       y1="207.34013"
+       x2="182.26729"
+       y2="207.34013"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5423"
+       id="linearGradient1257"
+       x1="152.30402"
+       y1="207.34013"
+       x2="182.39958"
+       y2="207.34013"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4880"
+       id="linearGradient1271"
+       x1="146.17181"
+       y1="114.43466"
+       x2="156.01604"
+       y2="114.43466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1490546,0,0,1.3036409,-312.30298,-22.252534)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5423"
+       id="linearGradient1279"
+       x1="149.44423"
+       y1="157.06055"
+       x2="180.44423"
+       y2="157.06055"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4915"
+       id="linearGradient1285"
+       x1="149.44423"
+       y1="157.06055"
+       x2="180.44423"
+       y2="157.06055"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4880"
+       id="linearGradient1331"
+       x1="167.01373"
+       y1="194.67172"
+       x2="167.43188"
+       y2="194.67172"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4907"
+       id="linearGradient1339"
+       x1="176.23482"
+       y1="182.65572"
+       x2="208.58562"
+       y2="182.65572"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.97804265,0.03163438)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5423"
+       id="linearGradient1345"
+       x1="176.11674"
+       y1="182.65572"
+       x2="208.70367"
+       y2="182.65572"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.97804265,0.03163438)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4907"
+       id="linearGradient1353"
+       x1="187.94272"
+       y1="241.54385"
+       x2="195.64529"
+       y2="241.54385"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.5011159,0,0,1,-288.89682,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4907"
+       id="linearGradient1361"
+       x1="192.27344"
+       y1="188.06439"
+       x2="195.27344"
+       y2="188.06439"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.87542846,5.1478327,30.888961)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4880"
+       id="linearGradient1369"
+       x1="182.49146"
+       y1="146.12271"
+       x2="187.27986"
+       y2="146.12271"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4915"
+       id="linearGradient1385"
+       x1="133.80933"
+       y1="107.229"
+       x2="152.43089"
+       y2="107.229"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92907886,0,0,1.0009449,72.56791,47.075904)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5423"
+       id="linearGradient1391"
+       x1="133.67683"
+       y1="107.229"
+       x2="152.5634"
+       y2="107.229"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92907886,0,0,1.0009449,72.56791,47.075904)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5423"
+       id="linearGradient1454"
+       x1="184.88567"
+       y1="110.15524"
+       x2="206.16747"
+       y2="110.15524"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.92430848)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5310"
+       id="linearGradient1460"
+       x1="184.88567"
+       y1="110.15524"
+       x2="206.16747"
+       y2="110.15524"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.92430848)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5265"
+       id="linearGradient1378"
+       x1="193.97249"
+       y1="121.18897"
+       x2="197.23708"
+       y2="121.18897"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.8782087,2.6458334,15.100904)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4915"
+       id="linearGradient1405"
+       gradientUnits="userSpaceOnUse"
+       x1="28.929182"
+       y1="141.29263"
+       x2="57.180687"
+       y2="141.29263" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4915"
+       id="linearGradient1407"
+       gradientUnits="userSpaceOnUse"
+       x1="158.13359"
+       y1="156.43214"
+       x2="171.13745"
+       y2="156.43214" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4915"
+       id="linearGradient1409"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(53.239891,33.344056)"
+       x1="146.09641"
+       y1="120.99824"
+       x2="159.47578"
+       y2="120.99824" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.8587501"
+     inkscape:cx="393.63328"
+     inkscape:cy="418.8991"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     units="mm"
+     showguides="true"
+     inkscape:window-width="1680"
+     inkscape:window-height="1005"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1178"
+       originx="-4.227098"
+       originy="-22.926491" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Background"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-4.2270979,-94.809317)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="Mailbox"
+     style="display:inline"
+     sodipodi:insensitive="true"
+     transform="translate(-4.2270979,-77.209317)">
+    <g
+       id="g5084">
+      <g
+         transform="translate(30.162505,-0.52916667)"
+         id="g5006">
+        <rect
+           style="opacity:1;fill:url(#linearGradient4882);fill-opacity:1;stroke:none;stroke-width:0.38394335;stroke-opacity:1"
+           id="rect1119"
+           width="102.83127"
+           height="12.5"
+           x="48.839455"
+           y="236.09018"
+           rx="7.5090251" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="79.635544"
+           y="245.65701"
+           id="text1088"><tspan
+             sodipodi:role="line"
+             id="tspan1086"
+             x="79.635544"
+             y="245.65701"
+             style="stroke-width:0.26458332">Mailboxd</tspan></text>
+      </g>
+      <g
+         transform="translate(49.897803,74.440148)"
+         id="g4976">
+        <rect
+           style="opacity:1;fill:#a7a9ac;fill-opacity:1;stroke:none;stroke-width:0.28754529;stroke-opacity:1"
+           id="rect4968"
+           width="26.458338"
+           height="10"
+           x="33.866661"
+           y="172.03336"
+           rx="4.2320113" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="37.041668"
+           y="178.85834"
+           id="text4926"><tspan
+             sodipodi:role="line"
+             id="tspan4924"
+             x="37.041668"
+             y="178.85834"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';stroke-width:0.26458332">Store</tspan><tspan
+             sodipodi:role="line"
+             x="37.041668"
+             y="186.79584"
+             style="stroke-width:0.26458332"
+             id="tspan4928" /></text>
+      </g>
+      <g
+         transform="translate(39.843633,74.494316)"
+         id="g4981">
+        <rect
+           style="opacity:1;fill:#a7a9ac;fill-opacity:1;stroke:none;stroke-width:0.27887049;stroke-opacity:1"
+           id="rect4970"
+           width="37.329002"
+           height="10"
+           x="70.379166"
+           y="171.97919"
+           rx="4.9756455" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="74.083336"
+           y="178.85834"
+           id="text4932"><tspan
+             sodipodi:role="line"
+             id="tspan4930"
+             x="74.083336"
+             y="178.85834"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';stroke-width:0.26458332">MariaDB</tspan></text>
+      </g>
+      <g
+         transform="translate(40.58535,69.210793)"
+         id="g4988">
+        <rect
+           style="opacity:1;fill:#a7a9ac;fill-opacity:1;stroke:none;stroke-width:0.24039133;stroke-opacity:1"
+           id="rect4983"
+           width="28.737358"
+           height="10"
+           x="106.96645"
+           y="177.26271"
+           rx="4.6929407" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="111.125"
+           y="184.14999"
+           id="text4936"><tspan
+             sodipodi:role="line"
+             id="tspan4934"
+             x="111.125"
+             y="184.14999"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';stroke-width:0.26458332">Index</tspan></text>
+      </g>
+    </g>
+    <g
+       id="g1128"
+       transform="translate(-12.392098,186.09549)">
+      <rect
+         rx="3.3856082"
+         y="49.465523"
+         x="16.619196"
+         height="12.5"
+         width="28.737358"
+         id="rect1098"
+         style="opacity:1;fill:#f0471f;fill-opacity:1;stroke:none;stroke-width:0.26871943;stroke-opacity:1" />
+      <text
+         id="text1080"
+         y="58.849422"
+         x="19.04283"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="58.849422"
+           x="19.04283"
+           id="tspan1078"
+           sodipodi:role="line">SSDB</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="56.807526"
+       y="240.33795"
+       id="text4948"><tspan
+         sodipodi:role="line"
+         id="tspan4946"
+         x="56.807526"
+         y="240.33795"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332">Ephemeral</tspan><tspan
+         sodipodi:role="line"
+         x="56.807526"
+         y="248.27545"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan4950">Data</tspan></text>
+    <g
+       id="g5257"
+       transform="translate(0,5.8208336)">
+      <g
+         transform="matrix(0.29717737,0,0,0.26458333,32.759934,235.56101)"
+         id="g5190">
+        <path
+           style="fill:none;stroke:#010101;stroke-width:1.36000001"
+           inkscape:connector-curvature="0"
+           d="M 14.877,4.067 H 79.398"
+           id="path5176" />
+        <path
+           style="fill:#010101"
+           inkscape:connector-curvature="0"
+           d="M 0,4.067 16.773,8.133 C 15.572,7.124 14.877,5.635 14.877,4.067 14.877,2.499 15.572,1.008 16.773,0 Z"
+           id="path5178" />
+      </g>
+      <g
+         transform="matrix(0.29049174,0,0,0.26458333,56.355223,235.56127)"
+         id="g5249">
+        <path
+           style="fill:none;stroke:#010101;stroke-width:1.36000001"
+           inkscape:connector-curvature="0"
+           d="M 64.521,4.066 H 0"
+           id="path5235" />
+        <path
+           style="fill:#010101"
+           inkscape:connector-curvature="0"
+           d="M 79.397,4.066 62.625,0 c 1.2,1.009 1.896,2.496 1.896,4.066 0,1.57 -0.695,3.059 -1.896,4.066 z"
+           id="path5237" />
+      </g>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer9"
+     inkscape:label="IMAP"
+     style="display:inline"
+     transform="translate(-4.2270979,-77.209317)">
+    <g
+       id="g4901"
+       transform="translate(29.292386,79.633646)">
+      <rect
+         rx="3.3856082"
+         y="105.55531"
+         x="88.635719"
+         height="12.5"
+         width="36.354488"
+         id="rect1107"
+         style="opacity:1;fill:url(#linearGradient4896);fill-opacity:1;stroke:none;stroke-width:0.27674267;stroke-opacity:1" />
+      <text
+         id="text1084"
+         y="114.93921"
+         x="92.098045"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="114.93921"
+           x="92.098045"
+           id="tspan1082"
+           sodipodi:role="line">IMAPD</tspan></text>
+    </g>
+    <g
+       id="g5499"
+       transform="matrix(6.4454433e-4,-0.48375054,0.26459457,-0.00343314,135.41283,235.94629)">
+      <path
+         id="path5485"
+         d="M 14.877,4.067 H 79.398"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#010101;stroke-width:1.36000001" />
+      <path
+         id="path5487"
+         d="M 0,4.067 16.773,8.133 C 15.572,7.124 14.877,5.635 14.877,4.067 14.877,2.499 15.572,1.008 16.773,0 Z"
+         inkscape:connector-curvature="0"
+         style="fill:#010101" />
+    </g>
+    <rect
+       style="opacity:1;fill:url(#linearGradient5513);fill-opacity:1;stroke:url(#linearGradient5507);stroke-width:0.273871;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect5501"
+       width="22.157225"
+       height="9.7261286"
+       x="125.43161"
+       y="214.39439"
+       rx="3.382117" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="127.86926"
+       y="221.24869"
+       id="text4962"><tspan
+         sodipodi:role="line"
+         id="tspan4960"
+         x="127.86926"
+         y="221.24869"
+         style="stroke-width:0.26458332">SOAP</tspan></text>
+    <rect
+       style="opacity:1;fill:url(#linearGradient1213);fill-opacity:1;stroke:none;stroke-width:0.23269707;stroke-opacity:1"
+       id="rect1207"
+       width="23.939363"
+       height="3"
+       x="113.50689"
+       y="144.18394" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient1221);fill-opacity:1;stroke:none;stroke-width:0.55433095;stroke-opacity:1"
+       id="rect1215"
+       width="3"
+       height="36.990166"
+       x="134.44626"
+       y="144.18394" />
+    <g
+       id="g1226">
+      <rect
+         rx="3.3879101"
+         y="154.48141"
+         x="121.36472"
+         height="12.43855"
+         width="28.608665"
+         id="rect1193"
+         style="display:inline;opacity:1;fill:url(#linearGradient1200);fill-opacity:1;stroke:url(#linearGradient1658);stroke-width:0.26458332;stroke-opacity:1" />
+      <text
+         id="text4958"
+         y="162.78699"
+         x="125.92212"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="162.78699"
+           x="125.92212"
+           id="tspan4956"
+           sodipodi:role="line">IMAPS</tspan></text>
+    </g>
+    <path
+       transform="rotate(44.965652)"
+       style="opacity:1;fill:url(#linearGradient1240);fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+       d="m 223.6088,31.705101 3.35948,-6.279007 v 9.630511 h -9.42015 z"
+       id="rect1234"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer7"
+     inkscape:label="Proxy"
+     style="display:inline"
+     transform="translate(-4.2270979,-77.209317)">
+    <g
+       id="g5363"
+       transform="translate(35.383146,12.705159)">
+      <rect
+         ry="3.7831037"
+         y="136.57796"
+         x="24.913177"
+         height="9.7565994"
+         width="36.739956"
+         id="rect5346"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient5352);stroke-width:0.2434005;stroke-miterlimit:4;stroke-dasharray:0.97360205, 0.24340051;stroke-dashoffset:0;stroke-opacity:1" />
+      <text
+         id="text5047"
+         y="143.13145"
+         x="28.446869"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient1405);fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="fill:url(#linearGradient1405);fill-opacity:1;stroke-width:0.26458332"
+           y="143.13145"
+           x="28.446869"
+           id="tspan5045"
+           sodipodi:role="line">Memcached</tspan></text>
+    </g>
+    <g
+       id="g1168"
+       transform="translate(16.619196,80.672345)">
+      <rect
+         rx="3.3856082"
+         y="101.05427"
+         x="11.425697"
+         height="12.5"
+         width="57.474716"
+         id="rect1105"
+         style="opacity:1;fill:#f0471f;fill-opacity:1;stroke:none;stroke-width:0.26135582;stroke-opacity:1" />
+      <text
+         id="text1076"
+         y="109.7457"
+         x="14.195563"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';stroke-width:0.26458332"
+           y="109.7457"
+           x="14.195563"
+           id="tspan1074"
+           sodipodi:role="line">Mailboxd</tspan></text>
+      <g
+         transform="translate(41.672021,79.940602)"
+         id="g1159">
+        <rect
+           style="opacity:1;fill:#f0e34a;fill-opacity:1;stroke:none;stroke-width:0.24043716;stroke-opacity:1"
+           id="rect1154"
+           width="11.079463"
+           height="8.309598"
+           x="13.503096"
+           y="23.187399"
+           rx="3.4971976" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="15.417195"
+           y="29.419596"
+           id="text1152"><tspan
+             sodipodi:role="line"
+             id="tspan1150"
+             x="15.417195"
+             y="29.419596"
+             style="stroke-width:0.26458332">UI</tspan></text>
+      </g>
+    </g>
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+       id="rect5269"
+       width="0.75073761"
+       height="9.3842201"
+       x="116.36433"
+       y="155.90366" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+       id="rect5271"
+       width="4.1290565"
+       height="2.6275816"
+       x="129.12686"
+       y="170.91841" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient5285);fill-opacity:1;stroke:none;stroke-width:0.38428894;stroke-opacity:1"
+       id="rect5273"
+       width="3"
+       height="84.416092"
+       x="94.21756"
+       y="151.17766" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient5452);stroke-width:0.23100001;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect5446"
+       width="2.7694135"
+       height="34.586136"
+       x="94.418968"
+       y="105.06621" />
+    <g
+       id="g5444"
+       transform="translate(-12.170834)">
+      <rect
+         ry="3.3824322"
+         y="122.78436"
+         x="78.66169"
+         height="9.7493944"
+         width="57.428551"
+         id="rect5419"
+         style="opacity:1;fill:url(#linearGradient5439);fill-opacity:1;stroke:url(#linearGradient5431);stroke-width:0.25099999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <text
+         id="text5043"
+         y="129.5265"
+         x="81.686188"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="129.5265"
+           x="81.686188"
+           id="tspan5041"
+           sodipodi:role="line">HTTPS IMAPS POP3S</tspan></text>
+    </g>
+    <g
+       id="g1133"
+       transform="translate(14.142895,71.128654)">
+      <rect
+         rx="3.3879087"
+         y="68.018448"
+         x="63.298656"
+         height="12.359458"
+         width="36.132298"
+         id="rect1021"
+         style="opacity:1;fill:#f0471f;fill-opacity:1;stroke:#f0471f;stroke-width:0.14054161;stroke-opacity:1" />
+      <text
+         id="text1065"
+         y="76.507317"
+         x="68.554184"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';stroke-width:0.26458332"
+           y="76.507317"
+           x="68.554184"
+           id="tspan1063"
+           sodipodi:role="line">Proxy</tspan></text>
+    </g>
+    <g
+       id="g5333">
+      <rect
+         rx="6.8560743"
+         y="208.45529"
+         x="83.92881"
+         height="20.269915"
+         width="23.648235"
+         id="rect5259"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient5267);stroke-width:0.23222826;stroke-opacity:1" />
+      <text
+         id="text5011"
+         y="217.62679"
+         x="87.766533"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="217.62679"
+           x="87.766533"
+           id="tspan5009"
+           sodipodi:role="line">HTTPS</tspan></text>
+      <text
+         id="text5019"
+         y="223.16652"
+         x="87.420296"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="223.16652"
+           x="87.420296"
+           id="tspan5017"
+           sodipodi:role="line">POP3S</tspan></text>
+    </g>
+    <rect
+       style="opacity:1;fill:url(#linearGradient5312);fill-opacity:1;stroke:none;stroke-width:0.20256272;stroke-opacity:1"
+       id="rect5300"
+       width="3"
+       height="9.3464909"
+       x="52.740913"
+       y="172.44452" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient5344);fill-opacity:1;stroke:none;stroke-width:0.14837737;stroke-opacity:1"
+       id="rect5338"
+       width="30.954182"
+       height="3"
+       x="64.068481"
+       y="170.69563" />
+    <g
+       id="g5326">
+      <rect
+         rx="6.6516008"
+         y="165.85223"
+         x="43.614986"
+         height="12.266322"
+         width="21.58989"
+         id="rect5287"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient5293);stroke-width:0.2363786;stroke-opacity:1" />
+      <text
+         id="text5015"
+         y="173.5963"
+         x="46.741489"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="173.5963"
+           x="46.741489"
+           id="tspan5013"
+           sodipodi:role="line">HTTPS</tspan></text>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer8"
+     inkscape:label="LDAP"
+     style="display:inline"
+     transform="translate(-4.2270979,-77.209317)">
+    <g
+       id="g1315"
+       transform="translate(4.4746474,19.688449)">
+      <g
+         transform="translate(-1.1932393,-19.159281)"
+         id="g1296">
+        <ellipse
+           style="opacity:1;fill:url(#linearGradient1279);fill-opacity:1;stroke:url(#linearGradient1285);stroke-width:0.287;stroke-miterlimit:4;stroke-dasharray:1.148, 0.287;stroke-dashoffset:0;stroke-opacity:1"
+           id="path1273"
+           cx="164.94423"
+           cy="157.06055"
+           rx="15.5"
+           ry="7" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient1407);fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="157.51347"
+           y="158.74054"
+           id="text4966"><tspan
+             sodipodi:role="line"
+             id="tspan4964"
+             x="157.51347"
+             y="158.74054"
+             style="fill:url(#linearGradient1407);fill-opacity:1;stroke-width:0.26458332">DNS</tspan></text>
+      </g>
+      <g
+         id="g1305">
+        <ellipse
+           style="opacity:1;fill:url(#linearGradient1271);fill-opacity:1;stroke:none;stroke-width:0.53608239;stroke-opacity:1"
+           id="path1265"
+           cx="163.5"
+           cy="126.92918"
+           rx="15.5"
+           ry="7" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="152.34262"
+           y="130.17348"
+           id="text1096"><tspan
+             sodipodi:role="line"
+             id="tspan1094"
+             x="152.34262"
+             y="130.17348"
+             style="stroke-width:0.26458332">LDAP</tspan></text>
+      </g>
+    </g>
+    <path
+       style="fill:none;stroke:url(#linearGradient1331);stroke-width:0.264;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.264, 0.79200001;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 167.29983,235.80344 167.14578,153.54"
+       id="path1325"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g1263">
+      <rect
+         rx="3.3859999"
+         y="202.34013"
+         x="152.43631"
+         height="10"
+         width="29.83098"
+         id="rect1245"
+         style="display:inline;opacity:1;fill:url(#linearGradient1257);fill-opacity:1;stroke:url(#linearGradient1251);stroke-width:0.26458332;stroke-opacity:1" />
+      <text
+         id="text5023"
+         y="209.11465"
+         x="155.45872"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="209.11465"
+           x="155.45872"
+           id="tspan5021"
+           sodipodi:role="line">LDAP-TLS</tspan></text>
+    </g>
+    <path
+       style="fill:none;stroke:url(#linearGradient1369);stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.26499999, 0.52999997;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 182.49145,146.12271 h 4.78841"
+       id="path1363"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer10"
+     inkscape:label="MTA"
+     style="display:inline"
+     transform="translate(-4.2270979,-77.209317)">
+    <g
+       id="g1432"
+       transform="translate(1.0583333,0.52916667)">
+      <rect
+         rx="2.8364778"
+         y="149.40149"
+         x="196.88731"
+         height="10.009449"
+         width="17.300913"
+         id="rect1379"
+         style="opacity:1;fill:url(#linearGradient1391);fill-opacity:1;stroke:url(#linearGradient1385);stroke-width:0.2555508;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <text
+         id="text5035"
+         y="156.13771"
+         x="199.27359"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient1409);fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="fill:url(#linearGradient1409);fill-opacity:1;stroke-width:0.26458332"
+           y="156.13771"
+           x="199.27359"
+           id="tspan5033"
+           sodipodi:role="line">ASAV</tspan></text>
+    </g>
+    <g
+       id="g1143"
+       transform="translate(53.007865,16.350807)">
+      <rect
+         rx="3.0533016"
+         y="122.86697"
+         x="132.95357"
+         height="12.5"
+         width="25.275024"
+         id="rect1121"
+         style="opacity:1;fill:#f0471f;fill-opacity:1;stroke:none;stroke-width:0.2416683;stroke-opacity:1" />
+      <text
+         id="text1092"
+         y="131.5584"
+         x="136.41589"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.76111126px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="131.5584"
+           x="136.41589"
+           id="tspan1090"
+           sodipodi:role="line">MTA</tspan></text>
+    </g>
+    <rect
+       style="display:inline;opacity:1;fill:url(#linearGradient1361);fill-opacity:1;stroke:none;stroke-width:0.2208118;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect1355"
+       width="3"
+       height="89.064331"
+       x="197.42122"
+       y="150.99371" />
+    <g
+       id="g1377"
+       transform="translate(4.6203602,44.862984)">
+      <rect
+         rx="3.3860052"
+         y="174.67668"
+         x="177.21286"
+         height="16.021345"
+         width="32.350796"
+         id="rect1333"
+         style="display:inline;opacity:1;fill:url(#linearGradient1345);fill-opacity:1;stroke:url(#linearGradient1339);stroke-width:0.236;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <text
+         id="text5027"
+         y="181.76222"
+         x="181.77245"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="181.76222"
+           x="181.77245"
+           id="tspan5025"
+           sodipodi:role="line">SMTP out</tspan></text>
+      <text
+         id="text5031"
+         y="187.26271"
+         x="181.77246"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="187.26271"
+           x="181.77246"
+           id="tspan5029"
+           sodipodi:role="line">LMTP in</tspan></text>
+    </g>
+    <rect
+       style="display:inline;opacity:1;fill:url(#linearGradient1353);fill-opacity:1;stroke:none;stroke-width:0.67240518;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect1347"
+       width="19.265022"
+       height="3"
+       x="181.16971"
+       y="240.04385" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient1378);stroke-width:0.21647654;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect567"
+       width="3"
+       height="35.445381"
+       x="196.75058"
+       y="103.80742" />
+    <g
+       id="g565"
+       transform="translate(2.4648226,18.003989)">
+      <rect
+         rx="2.836"
+         y="106.07955"
+         x="184.88567"
+         height="10"
+         width="21.281801"
+         id="rect1448"
+         style="opacity:1;fill:url(#linearGradient1454);fill-opacity:1;stroke:url(#linearGradient1460);stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <text
+         id="text5039"
+         y="112.86182"
+         x="188.69711"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="112.86182"
+           x="188.69711"
+           id="tspan5037"
+           sodipodi:role="line">SMTP</tspan></text>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Clouds"
+     style="display:inline"
+     transform="translate(-4.2270979,-77.209317)">
+    <g
+       id="layer1-9"
+       transform="matrix(0.1398425,0,0,0.16475046,159.95466,57.628275)"
+       style="fill:#3984e7;fill-opacity:1;stroke:none">
+      <path
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3984e7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00329208;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 284.00314,122.06466 a 57.911863,57.911863 0 0 0 -47.4077,24.703 43.709289,43.709289 0 0 0 -15.5907,-2.928 43.709289,43.709289 0 0 0 -43.70901,43.709 43.709289,43.709289 0 0 0 0.25,4.256 50.164606,50.164606 0 0 0 -46.76599,50.045 50.164606,50.164606 0 0 0 49.65719,50.139 l -0.022,0.03 h 0.5192 156.51701 a 57.911863,57.911863 0 0 0 57.91198,-57.912 57.911863,57.911863 0 0 0 -53.59559,-57.695 57.911863,57.911863 0 0 0 -57.7851,-54.342 z"
+         id="path3293"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="layer1-3"
+       transform="matrix(0.1398425,0,0,0.16475046,58.635692,57.789532)"
+       style="fill:url(#linearGradient4873);fill-opacity:1">
+      <path
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient5433);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00329208;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 284.00314,122.06466 a 57.911863,57.911863 0 0 0 -47.4077,24.703 43.709289,43.709289 0 0 0 -15.5907,-2.928 43.709289,43.709289 0 0 0 -43.70901,43.709 43.709289,43.709289 0 0 0 0.25,4.256 50.164606,50.164606 0 0 0 -46.76599,50.045 50.164606,50.164606 0 0 0 49.65719,50.139 l -0.022,0.03 h 0.5192 156.51701 a 57.911863,57.911863 0 0 0 57.91198,-57.912 57.911863,57.911863 0 0 0 -53.59559,-57.695 57.911863,57.911863 0 0 0 -57.7851,-54.342 z"
+         id="path3293-8"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/productoverview.adoc
+++ b/productoverview.adoc
@@ -12,7 +12,7 @@ client interfaces and server components that can run as a single node
 configuration or be deployed across multiple servers for high availability
 and increased scalability.
 
-image::images/arch_overview.png[Architectural Overview]
+image::images/arch_overview.svg[Architectural Overview,395]
 
 The architecture includes the following core advantages:
 


### PR DESCRIPTION
Updated the arch_overview image to a vector graphic utilizing the Zimbra "official" colors. 

Original source is available in arch_overview_ink.svg (layered Inkscape file), version for document is arch_overview.svg. Intended to replace arch_overview.png.

The productoverview.adoc file is updated to use this new image. In order to maintain the original formatting, a width is applied to the updated image which matches the original png image. 