### PR TITLE
HAB images not shown, wrong case in directory name

### DIFF
--- a/HAB.adoc
+++ b/HAB.adoc
@@ -14,7 +14,7 @@ In a Hierarchical Address Book (HAB), your root organization (e.g., {product-fam
 
 .Example Hierarchy
 [#ExampleHierarchy]
-image::Images/HABHierarchy.png[]
+image::images/HABHierarchy.png[]
 
 [#SeniorityIndex]
 == Seniority Index
@@ -183,7 +183,7 @@ A group needs to be specified as root so that other groups can be added as child
 . Choose *Organizational Address Book*.
 . The address book in a hierarchical format appears in the left pane.
 +
-image::Images/HABStructure-zimbra.png[]
+image::images/HABStructure-zimbra.png[]
 +
 . Click any group to view and select users of that group.
 


### PR DESCRIPTION
This change should fix the problem, so the images are included correctly.