### PR TITLE
ZCS-7794:Admin Guide (English) typos

### DIFF
--- a/introduction.adoc
+++ b/introduction.adoc
@@ -32,7 +32,7 @@ We appreciate your feedback and suggestions.
 For additional product information, the following resources are available:
 
 * https://wiki.zimbra.com[Zimbra Wiki]
-* https://wiki.zimbra.com/wiki/SecurityCenter[Security Center]
+* https://wiki.zimbra.com/wiki/Security_Center[Security Center]
 
 Let us know what you like about the product and what you would like to see in the product.
 Post your ideas to the Zimbra Forum.

--- a/ng-admin.adoc
+++ b/ng-admin.adoc
@@ -229,8 +229,7 @@ Quota
 Let's examine these scenario one by one.
 
 [[a-global-admin-grants-a-user-a-higher-quota-than-the-allowed-domain-quota]]
-A Global Admin grants a user a higher quota than the allowed Domain
-Quota
+A Global Admin grants a user a higher quota than the allowed Domain Quota
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Since the Domain Quota applies to a given domain, not to a given Admin,
@@ -238,8 +237,7 @@ the effective quota for the user will be the maximum quota allowed by
 the `Domain Quota` setting.
 
 [[a-delegated-admin-grants-a-user-a-higher-quota-than-the-allowed-domain-quota]]
-A Delegated Admin grants a user a higher quota than the allowed Domain
-Quota
+A Delegated Admin grants a user a higher quota than the allowed Domain Quota
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In this case, the effective quota for the user will be the maximum quota

--- a/ng-hsm.adoc
+++ b/ng-hsm.adoc
@@ -293,7 +293,7 @@ Remember that only *empty* volumes can be deleted.
 
 IMPORTANT: Beginning with release 8.8.9, all volume creation and update commands have been updated, as the `storeType` argument is now required.
 
-The `storeType` argument is *mandatory*, it is always the on the first position and accepts any one value corresponding to the <<S3-compatible-services, S3-Compatible Services>> listed previously.
+The `storeType` argument is *mandatory*, it is always the on the first position and accepts any one value corresponding to the <<s3-compatible-services, S3-Compatible Services>> listed previously.
 The arguments that follow in the command now depend on the selected `storeType`.
 
 ===== FileBlob (Local)

--- a/ng-migration.adoc
+++ b/ng-migration.adoc
@@ -157,7 +157,7 @@ Running a reindex of all mailboxes is also suggested.
 
 [[MIG-88-step-2-network-ng-modules-setup]]
 Step 2: Network NG Setup
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Disable the Real Time Scanner on both servers:
 

--- a/ng-mobile.adoc
+++ b/ng-mobile.adoc
@@ -192,9 +192,7 @@ breaches to a minimum.
 Provisioning Features Available on Your Client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Not all provisioning features are available on all clients. A good
-comparison of Exchange ActiveSync clients can be found on
-http://en.wikipedia.org/wiki/Comparison_of_Exchange_ActiveSync_clients[Wikipedia]
+Not all provisioning features are available on all clients.
 
 [[network-ng-modules-and-mdm]]
 Network NG and MDM

--- a/productlifecycle.adoc
+++ b/productlifecycle.adoc
@@ -16,7 +16,7 @@ This chapter provides information about the Product Life Cycle stages of Zimbra 
 
 |ZCS Migration Wizard for Exchange
 |This tool is supported only for PST file import, with End of Technical Guidance set for 31 December 2020.
-We recommend [https://zimbra.audriga.com Audriga's self-service migration solution] as a preferred alternative for all account migrations.
+We recommend https://zimbra.audriga.com[Audriga's self-service migration solution] as a preferred alternative for all account migrations.
 
 |ZCS Migration Wizard for Domino
 |Deprecated

--- a/zimbra-drive-open-guide.adoc
+++ b/zimbra-drive-open-guide.adoc
@@ -115,7 +115,7 @@ Requirements
 
 * Root-level access to the underlying operating system.
 * Administrative access to an external cloud supported service (see
-[==subsec:supportedClouds==]). +
+<<supportedClouds>>). +
 Supported versions:
 ** Nextcloud 9, 10, 11
 ** ownCloud 9.0, 9.1, 10
@@ -201,7 +201,7 @@ correctly configured. Refer to these instructions for _Apache Web Server
 Configuration_ in the Nextcloud manual:
 https://docs.nextcloud.com/server/11/admin_manual/installation/source_installation.html#apache-web-server-configuration[Nextcloud
 installation] or in the ownCloud manual:
-https://doc.owncloud.org/server/10.0/admin_manual/installation/source_installation.html#apache-web-server-configuration[ownCloud
+https://doc.owncloud.org/server/10.0/admin_manual/installation/manual_installation.html#configure-the-web-server[ownCloud
 installation].
 
 [[configuration]]
@@ -325,7 +325,7 @@ manually upgraded on every version change.
 
 The upgrade of Zimbra Open Drive App in Nextcloud/ownCloud requires that
 files are replaced. Perform these steps at
-installation([==subsec:NextcloudownCloudInstallation==]):
+installation(<<subsec:NextcloudownCloudInstallation>>):
 
 1.  Copy `zimbradrive.tar.gz` in Nextcloud/ownCloud drive +
 `scp zimbradrive.tar.gz root@cloud:/tmp`
@@ -350,7 +350,7 @@ uninstallation of Zimbra Open Drive and cleanup of the system.
 
 [[disablePackages]]
 Disable Zimbra Open Drive Packages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Since the Zimbra Open Drive Extension and the Zimbra Open Drive Zimlet are installed as
 Zimbra packages, their uninstallation is unexpected. To disable Zimbra Open Drive,
@@ -554,7 +554,7 @@ Manual Uninstall
 Manual uninstallation is not supported.
 
 Please consider disabling Zimbra Open Drive (see:
-[==sec:disablePackages==]) instead of uninstalling it. Any modification
+<<disablePackages>>) instead of uninstalling it. Any modification
 to the installed Zimbra packages may lead to a fail during the Zimbra
 upgrade.
 


### PR DESCRIPTION
a couple of typos and broken links in the original English version.
 => Fixed broken links, removed garbage charactors

Article of "Comparison_of_Exchange_ActiveSync_clients" in Wikipedia
does no longer exist.
 => Removed the whole line.

The file name of the "ownCloud installation" page has been changed.
 => Re-linked the correct URL.