### PR TITLE
https://github.com/Zimbra/adminguide/issues/135

### DIFF
--- a/ng-backup.adoc
+++ b/ng-backup.adoc
@@ -1,5 +1,5 @@
 [[backup-ng-guide]]
-= Backup Next Generation NG
+= Backup NG
 
 [[real-time-scan]]
 == Real-Time Scan


### PR DESCRIPTION
The title for the `ng-backup.adoc` section is currently Backup Next Generation NG. It should be just Backup NG.

PS: The "NG" actually stands for "New Generation", not "Next Generation".