### PR TITLE
PREAPPS-6887: Update for the Adminguide about "HAB" feature

### DIFF
--- a/HAB.adoc
+++ b/HAB.adoc
@@ -134,6 +134,8 @@ This example adds the users _Jane Doe_ and _John Smith_ to the group named _Corp
 
  zmprov addHABGroupMember accounts@example.com john.smith@example.com
 
+IMPORTANT: Before adding users, make sure that they are are already created.
+
 [#CreateSortOrder]
 === Set Sort Order
 Configure the sort order for groups in the HAB. Groups with higher seniority index appear above groups with lower seniority index.
@@ -196,7 +198,7 @@ There can be multiple organizational units in a domain. This command lists all t
  zmprov listHABOrgUnit <domain name of OU>
 
 ==== Example
- zmprov listHABOrgUnit example.com ZimbraOU
+ zmprov listHABOrgUnit example.com
 
 ==== Explanation
 All OUs in _example.com_ listed.

--- a/ja_jp/HAB.adoc
+++ b/ja_jp/HAB.adoc
@@ -143,6 +143,8 @@ organizational unitとして_{product-family}OU_を作成します。
 
  zmprov addHABGroupMember accounts@example.com john.smith@example.com
 
+IMPORTANT: ユーザーが存在していることを確認してから、グループへの追加操作を行ってください。
+
 [#CreateSortOrder]
 === 年功序列を設定する
 HAB でグループが表示する順番を指定します。年功序列が高いグループが他のグループより先表示されます。
@@ -207,7 +209,7 @@ image::HABStructure-zimbra.png[]
 ==== 使用例
 _example.com_ のドメインにあるすべての OU リストを表示します。
 
- zmprov listHABOrgUnit example.com ZimbraOU
+ zmprov listHABOrgUnit example.com
 
 [#rename-OU]
 === 部門名 (OU) の名前を更新する


### PR DESCRIPTION
(1) One example of the Hierarchical Address Book (HAB) feature in the
Admin guide is not correctly described.
(2) Add a "IMPORTANT" note in adding a member user to the HAB group.